### PR TITLE
Modified constraint trees to avoid duplication

### DIFF
--- a/src/Pirouette/Term/ConstraintTree.hs
+++ b/src/Pirouette/Term/ConstraintTree.hs
@@ -57,18 +57,19 @@ import           Data.Text.Prettyprint.Doc hiding (Pretty(..))
 --
 -- The constraint tree we would obtain from symbolically executing it should be something like:
 --
--- > Choose
--- >   [ (Match i#0 with Dec m)
--- >     :&: Choose [ Match [d/State st#2 (λds λds. ds#1)] with Counter n
--- >              :&: Choose [ Fact "b/greaterThanEqualsInteger m n"   :&: Result "M1"
--- >                         , Fact "! b/greaterThanEqualsInteber m n" :&: Result "M2"
--- >                         ]
--- >                ]
--- >  , (Match i#0 with Inc m)
--- >     :&: Choose [ Match [d/State st#2 (λds λds. ds#1)] wih Counter n
--- >              :&: Result "Just M3"
--- >                ]
--- >  ]
+-- > Choose i#0 of type Input
+-- >   [ Match with Dec m ->
+-- >     Choose [d/State st#2 (λds λds. ds#1)] of type Counter
+-- >       [ Match with Counter n ->
+-- >         Choose "b/greaterThanEqualsInteger m n" of type Bool
+-- >           [ Match with True -> Result "M1"
+-- >           , Match with False -> Result "M2"
+-- >           ]
+-- >       ]
+-- >   , Match with Inc m ->
+-- >     Choose [d/State st#2 (λds λds. ds#1)] of type Counter
+-- >       [ Match with Counter n -> Result "Just M3" ]
+-- >   ]
 
 data CTreeOpts = CTreeOpts
   { coPruneMaybe    :: Bool

--- a/src/Pirouette/Term/ConstraintTree.hs
+++ b/src/Pirouette/Term/ConstraintTree.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 
 module Pirouette.Term.ConstraintTree where
 
@@ -18,7 +18,7 @@ import           Pirouette.PlutusIR.Utils
 
 import qualified PlutusCore as P (DefaultFun)
 
-import           Control.Applicative
+import           Control.Arrow ( second )
 import           Control.Monad
 import           Control.Monad.Except
 import qualified Data.Map as M
@@ -78,68 +78,63 @@ data CTreeOpts = CTreeOpts
 type CTreeTerm name = Term name P.DefaultFun
 
 data CTree name
-  = Choose [CTree name]
-  | (Constraint name) :&: (CTree name)
+  = Choose (CTreeTerm name) (Type name) [(Constraint name, CTree name)]
   | Result (CTreeTerm name)
   deriving (Eq, Show)
 
 data Constraint name
-  = Match (CTreeTerm name) (Type name) name [(name, Type name)]
-  | Fact  Bool (CTreeTerm name)
+  = Match name [(name, Type name)]
   deriving (Eq, Show)
 
 ctreeFirstMatches :: CTree name -> [name]
-ctreeFirstMatches (Choose t) = concatMap ctreeFirstMatches t
-ctreeFirstMatches (Match _ _ x _ :&: _) = [x]
+ctreeFirstMatches (Choose _ _ t) =
+  map (constraintFirstMatches . fst) t
 ctreeFirstMatches _ = []
 
+constraintFirstMatches :: Constraint name -> name
+constraintFirstMatches (Match x _) = x
+
 instance (Pretty name) => Pretty (Constraint name) where
-  pretty (Match t ty c vs) = "Match" <+> pretty t <+> "with"
-                               <+> pretty ty <> dot <> pretty c
-                               <> parens (hsep . punctuate "," $ map pretty vs)
-  pretty (Fact neg t)      = "Fact" <+> (if neg then ("~" <+>) . parens else id) (pretty t)
+  pretty (Match c vs) =
+    "Match with" <+> pretty c
+      <> parens (hsep . punctuate "," $ map pretty vs)
 
 instance (Pretty name) => Pretty (CTree name) where
-  pretty (Choose l)   = vsep ("Choose":map (indent 2 . pretty) l)
-  pretty (cst :&: tr) = vsep [pretty cst <+> ":&:", indent 2 (pretty tr)]
-  pretty (Result tr)  = "Result" <+> pretty tr
+  pretty (Choose t ty l) =
+    vsep
+      ( "Choose" <+> pretty t <+> "of type" <+> pretty ty
+      : map (\(cst,tr) -> indent 2 $ vsep [pretty cst <+> "->", indent 2 (pretty tr)]) l
+      )
+  pretty (Result tr)     = "Result" <+> pretty tr
 
 -- |Symbolicaly execute's a term into a /constraint tree/. Assumes that
 -- the term in question is of the form @\ a b ... zz -> case i of ... @,
 -- or, in words, its a closed WHNF abstraction whose body starts by pattern
 -- matching on whatever value is supposed to be the user's input.
 execute :: forall m . (MonadPirouette m) => PrtTerm -> m (CTree Name)
-execute (R.App (R.F (nameIsITE -> True)) [R.Arg x, R.Arg t, R.Arg f])
-  = Choose <$> sequence [ (Fact False x :&:) <$> execute t
-                        , (Fact True  x :&:) <$> execute f
-                        ]
 execute t = do
   mdest <- runMaybeT $ unDest t
   case mdest of
     Nothing -> return (Result t)
     Just (dName, tyName, tyArgs, x, tyRet, cases) -> do
       cons <- constructors <$> typeDefOf tyName
+      -- Since excessive arguments to a destructor are suppressed by the transformation
+      -- `removeExcessiveDest`, this error should never be triggered.
       when (length cons /= length cases) $ throwError' (PEOther $ "Different number of cases for " ++ show dName)
       let ty = R.TyApp (R.F $ TyFree tyName) tyArgs
-      Choose <$> zipWithM (constructMatching x ty) cases cons
+      Choose x ty <$> zipWithM constructMatching cases cons
      where
-      constructMatching :: PrtTerm -> PrtType -> PrtTerm -> (Name, PrtType)
-                        -> m (CTree Name)
-      constructMatching v ty t (conName, conTy) =
-        -- do
-        -- isBool <- typeIsBool ty
-        -- if isBool
-        -- then (\ isFalse -> (Fact isFalse v :&:)) <$> consIsBoolVal False conName <*> execute t
-        -- else
+      constructMatching :: PrtTerm -> (Name, PrtType)
+                        -> m (Constraint Name,CTree Name)
+      constructMatching t (conName, conTy) =
         let arity      = R.tyArity conTy
             (args, tl) = R.getNHeadLams arity t
-        in (Match v ty conName args :&:) <$> execute tl
+        in (Match conName args, ) <$> execute tl
 
 -- |Prune all the paths leading to @Result t@ such that @f t == Nothing@
 pruneMaybe :: forall m . (MonadPirouette m)
            => CTree Name
            -> MaybeT m (CTree Name)
-pruneMaybe (c :&: t)   = (c :&:) <$> pruneMaybe t
 pruneMaybe (Result t)  = Result <$> MaybeT (go t)
   where go :: CTreeTerm Name -> m (Maybe (CTreeTerm Name))
         go t@(R.App (R.F (FreeName n)) args) = do
@@ -149,9 +144,10 @@ pruneMaybe (Result t)  = Result <$> MaybeT (go t)
             Just (Just _)  -> Just $ head (mapMaybe R.fromArg args)
             Just Nothing   -> Nothing
         go t = return (Just t)
-pruneMaybe (Choose ts) = lift (mapMaybeM pruneMaybe ts) >>= choose
+pruneMaybe (Choose x ty ts) =
+  lift (mapMaybeM ((\(a,b) -> (a,) <$> b) . second pruneMaybe) ts) >>= choose
   where choose [] = fail "empty tree"
-        choose ts = return (Choose ts)
+        choose ts = return (Choose x ty ts)
 
 termToCTree :: (MonadPirouette m) => CTreeOpts -> Name -> PrtTerm -> m (CTree Name)
 termToCTree opts name t = do

--- a/src/Pirouette/Term/ToTla.hs
+++ b/src/Pirouette/Term/ToTla.hs
@@ -232,8 +232,9 @@ termToSpec opts sortedNames mainFun t = flip evalStateT tlaState0 $ flip runRead
   mctree <- tlaPure $ termToCTree (toSymbExecOpts opts) mainFun t
   tlaPure $ logDebug $ "Translating Action Definitions for " ++ show mainFun
   defs   <- case mctree of
-    Choose branches -> concatMap p2l <$> mapM matchToAction branches
-    ctree           -> p2l           <$> matchToAction ctree
+    Choose x ty br -> concatMap p2l <$> mapM (uncurry $ matchToAction x ty) br
+    Result t       -> tlaPure (logDebug ("tree: " ++ show (pretty t)))
+                        >> throwError' (PEOther "CTreeIsNotAMatch")
   let next = tlaOpDef (tlaIdent "Next") [] $ tlaOr $ map (tlaIdentPrefixed "Wrapped") $ ctreeFirstMatches mctree
 
   tlaPure $ logDebug "Assembling the spec"
@@ -376,8 +377,9 @@ declareTermNameMutRec n = do
 -- > Dec(m)     == trTree (rest [ i := Dec m ])
 -- > WrappedDec == \E m \in TypeM : Dec(m)
 matchToAction :: (MonadPirouette m)
-              => CTree Name -> TlaT m (TLA.AS_UnitDef, TLA.AS_UnitDef)
-matchToAction (Match val ty cons args :&: rest) =
+              => PrtTerm -> PrtType -> Constraint Name -> CTree Name
+              -> TlaT m (TLA.AS_UnitDef, TLA.AS_UnitDef)
+matchToAction val ty (Match cons args) rest =
   case val of
     R.App (R.B (R.Ann valN) _) [] -> do
       let argIds = map (tlaIdent . fst) args
@@ -392,8 +394,6 @@ matchToAction (Match val ty cons args :&: rest) =
       qboundNs <- mapM (uncurry trQBoundN) args
       return (op, opWrap (opWrapBody qboundNs))
     _                     -> throwError' $ PEOther "MatchIsNotAVariable"
-matchToAction t            = tlaPure (logDebug ("tree: " ++ show (pretty t)))
-                          >> throwError' (PEOther "CTreeIsNotAMatch")
 
 -- *** Translating Types
 
@@ -590,37 +590,23 @@ trQBoundN n ty = TLA.AS_QBoundN [tlaIdent n] <$> trType ty
 -- >                                 /\ TxConstraints' = res.arg1
 --
 trTree :: (MonadPirouette m) => CTree Name -> PrtType -> TlaT m TLA.AS_Expression
-trTree (Choose cases) ty = tlaOr <$> mapM (flip trTree ty) cases
-trTree (cstr :&: tr)  ty = trConstrainedExp cstr (trTree tr ty)
-trTree (Result t)     ty = asks (wrapExp . toActionWrapper) <*> trTerm t (TlaVal ty)
-
--- |Constructs a tla expression constrained by a 'Constraint'. This will take care of our "pattern-matching",
--- translating equivalences and registering facts alongside the main execution path.
-trConstrainedExp :: (MonadPirouette m) => Constraint Name -> TlaT m TLA.AS_Expression -> TlaT m TLA.AS_Expression
-trConstrainedExp (Match x ty c args) mexp = do
-  spz <- asks ((=<<) . toSpecialize) <*> return (nameOf ty)
+trTree (Result t)             ty =
+  asks (wrapExp . toActionWrapper) <*> trTerm t (TlaVal ty)
+trTree (Choose x pirTy cases) tyRes = do
+  spz <- asks ((=<<) . toSpecialize) <*> return (nameOf pirTy)
   case spz of
-    Just tySpz -> do
-      x' <- trTerm x (TlaVal ty)
-      fresh <- tlaFreshName
-      let ctx = spzMatch tySpz x' c (map fst args) fresh
-      ctx <$> mexp
+    Just tySpz ->
+      tlaOr <$> mapM (uncurry $ trSpecializedConstrainedExp tySpz x pirTy tyRes) cases
     Nothing -> do
-      (nx, ctx) <- case x of
-                    R.App (R.B (R.Ann n) _) [] -> return (tlaIdent n, id)
-                    _ -> do
-                      nx <- tlaFreshName
-                      tx <- trTerm x (TlaVal ty)
-                      return (nx, tlaLet [tlaAssign nx tx])
-      exp <- tlaWithDeclTypeOf ((nx, TlaVal ty) : map (tlaIdent *** TlaVal) args) mexp
-      return $ ctx $ tlaAnd
-        [ tlaEq (tlaProj nx onCons) (tlaString c)
-        -- , tlaEq (tlaProj nx typeField) (tlaIdent ty) -- this is harder because ty is not a name, but a Type!
-        , (\l -> if null l then exp else tlaLet l exp) $
-            L.zipWith
-              (\(n, ty) i -> tlaAssign (tlaIdent n) (tlaProj nx (onArg i)))
-              args [0..]
-        ]
+      (nx, ctx) <-
+        case x of
+          R.App (R.B (R.Ann n) _) [] -> return (tlaIdent n, id)
+          _ -> do
+            nx <- tlaFreshName
+            tx <- trTerm x (TlaVal pirTy)
+            return (nx, tlaLet [tlaAssign nx tx])
+      ctx . tlaOr <$>
+        mapM (\(cstr,tr) -> trConstrainedExp nx pirTy cstr (trTree tr tyRes)) cases
   where
     nameOf :: PrtType -> Maybe String
     nameOf (R.TyApp (R.B (R.Ann x) _) []) =
@@ -629,10 +615,29 @@ trConstrainedExp (Match x ty c args) mexp = do
       Just $ T.unpack (nameString x)
     nameOf _ = Nothing
 
-trConstrainedExp (Fact b t) mexp = do
-  t'  <- trTerm t tlaTyBool
-  exp <- mexp
-  return $ tlaAnd [ (if b then tlaNeg else id) t', exp]
+trSpecializedConstrainedExp :: (MonadPirouette m)
+                            => TypeSpecializer -> PrtTerm -> PrtType -> PrtType
+                            -> Constraint Name -> CTree Name
+                            -> TlaT m TLA.AS_Expression
+trSpecializedConstrainedExp tySpz x pirTy tyRes (Match c args) tr = do
+  x' <- trTerm x (TlaVal pirTy)
+  fresh <- tlaFreshName
+  spzMatch tySpz x' c (map fst args) fresh <$> trTree tr tyRes
+
+-- |Constructs a tla expression constrained by a 'Constraint'. This will take care of our "pattern-matching",
+-- translating equivalences and registering facts alongside the main execution path.
+trConstrainedExp :: (MonadPirouette m)
+                 => TLA.AS_Expression -> PrtType -> Constraint Name -> TlaT m TLA.AS_Expression
+                 -> TlaT m TLA.AS_Expression
+trConstrainedExp nx ty (Match c args) mexp = do
+  exp <- tlaWithDeclTypeOf ((nx, TlaVal ty) : map (tlaIdent *** TlaVal) args) mexp
+  return $ tlaAnd
+    [ tlaEq (tlaProj nx onCons) (tlaString c)
+    , (\l -> if null l then exp else tlaLet l exp) $
+        L.zipWith
+          (\(n, ty) i -> tlaAssign (tlaIdent n) (tlaProj nx (onArg i)))
+          args [0..]
+    ]
 
 -- |When translating the body of a PrtTerm, we also receive the 'TlaType' that we expect
 -- from the translation. For example, the Just constructor is declared with


### PR DESCRIPTION
Currently the `ConstraintTree` has a node `Choose` which takes only a list of `Match x ty c args :&: tr` which means "If `x` of type `ty` is the constructor `c`, then let `args` be the name of its arguments and output `tr`".
This implies that the `x` and `ty` are declared once for each constructors, whereas they should be common to all branches of the `Choose`.
In particular, if `x` is a complex term, a new free name `fn` and a new binding `LET fn == x` is generated in each branch.
This PR redesigns `ConstraintTree` to eliminate this duplication of code.