### PR TITLE
Confusion tlaNeg, tlaNot

### DIFF
--- a/src/Pirouette/Specializer/Basics.hs
+++ b/src/Pirouette/Specializer/Basics.hs
@@ -13,7 +13,7 @@ import qualified Data.Text as T
 
 boolSpzMatch t n [] _ exp
   | nameString n == T.pack "True"  = tlaAnd [t, exp]
-  | nameString n == T.pack "False" = tlaAnd [tlaNeg t, exp]
+  | nameString n == T.pack "False" = tlaAnd [tlaNot t, exp]
 
 boolSpz :: TypeSpecializer
 boolSpz = TypeSpecializer {

--- a/src/Pirouette/TLA/Syntax.hs
+++ b/src/Pirouette/TLA/Syntax.hs
@@ -102,8 +102,8 @@ tlaEq = tlaInfix TLA.AS_EQ
 tlaGreater :: TLA.AS_Expression -> TLA.AS_Expression -> TLA.AS_Expression
 tlaGreater = tlaInfix TLA.AS_GT
 
-tlaNeg :: TLA.AS_Expression -> TLA.AS_Expression
-tlaNeg = tlaPrefix TLA.AS_Neg
+tlaNot :: TLA.AS_Expression -> TLA.AS_Expression
+tlaNot = tlaPrefix TLA.AS_Not
 
 -- * Declaring Operators
 

--- a/src/Pirouette/Term/ToTla.hs
+++ b/src/Pirouette/Term/ToTla.hs
@@ -632,7 +632,7 @@ trConstrainedExp (Match x ty c args) mexp = do
 trConstrainedExp (Fact b t) mexp = do
   t'  <- trTerm t tlaTyBool
   exp <- mexp
-  return $ tlaAnd [ (if b then tlaNeg else id) t', exp]
+  return $ tlaAnd [ (if b then tlaNot else id) t', exp]
 
 -- |When translating the body of a PrtTerm, we also receive the 'TlaType' that we expect
 -- from the translation. For example, the Just constructor is declared with


### PR DESCRIPTION
`TLA.AS_Neg` was incorrectly used for negation whereas it stands for prefix `-` symbol. The symbol we were really looking for was `TLA.AS_Not`.