### PR TITLE
Adapt removeExcessiveDestrArgs to also handle type arguments

### DIFF
--- a/src/Pirouette/Term/ConstraintTree.hs
+++ b/src/Pirouette/Term/ConstraintTree.hs
@@ -117,7 +117,8 @@ execute t = do
   mdest <- runMaybeT $ unDest t
   case mdest of
     Nothing -> return (Result t)
-    Just (dName, tyName, tyArgs, x, tyRet, cases) -> do
+    Just (dName, tyName, tyArgs, x, tyRet, cases, excess) -> do
+      unless (null excess) $ throwError' (PEOther "ConstraintTree.execute'ing a term with excessive destr args. Please use removeExcessiveDestrArgs before execute")
       cons <- constructors <$> typeDefOf tyName
       -- Since excessive arguments to a destructor are suppressed by the transformation
       -- `removeExcessiveDest`, this error should never be triggered.

--- a/src/Pirouette/Term/Transformations.hs
+++ b/src/Pirouette/Term/Transformations.hs
@@ -167,12 +167,12 @@ removeExcessiveDestArgs = pushCtx "removeExcessiveDestArgs" . rewriteM (runMaybe
   where
     go :: (MonadPirouette m) => PrtTerm -> MaybeT m PrtTerm
     go t = do
-      (n, tyN, tyArgs, x, tyReturn@(R.TyFun tyA tyB), cases, excess) <- unDest t
-      Datatype _ _ _ cons <- lift (typeDefOf tyN)
+      (n, tyN, tyArgs, x, tyReturn, cases, excess) <- unDest t
       if null excess
-      then fail "Destruction to a function type without excessive arguments"
+      then fail "No excessive destr arguments"
       else do
         logTrace $ show n
+        Datatype _ _ _ cons <- lift (typeDefOf tyN)
         return $
           R.App (R.F $ FreeName n) $
             map R.TyArg tyArgs

--- a/src/Pirouette/Term/Transformations.hs
+++ b/src/Pirouette/Term/Transformations.hs
@@ -167,10 +167,8 @@ removeExcessiveDestArgs = pushCtx "removeExcessiveDestArgs" . rewriteM (runMaybe
   where
     go :: (MonadPirouette m) => PrtTerm -> MaybeT m PrtTerm
     go t = do
-      (n, tyN, tyArgs, x, tyReturn@(R.TyFun tyA tyB), cases) <- unDest t
-      Datatype _ _ _ cons <- lift $ typeDefOf tyN
-      let nbCons = length cons
-      let (cases', excess) = splitAt nbCons cases
+      (n, tyN, tyArgs, x, tyReturn@(R.TyFun tyA tyB), cases, excess) <- unDest t
+      Datatype _ _ _ cons <- lift (typeDefOf tyN)
       if null excess
       then fail "Destruction to a function type without excessive arguments"
       else do
@@ -179,43 +177,23 @@ removeExcessiveDestArgs = pushCtx "removeExcessiveDestArgs" . rewriteM (runMaybe
           R.App (R.F $ FreeName n) $
             map R.TyArg tyArgs
               ++ [R.Arg x, R.TyArg $ tyDrop (length excess) tyReturn]
-              ++ zipWith (\(_,cty) t -> R.Arg $ appExcessive excess cty t) cons cases'
+              ++ zipWith (\(_,cty) t -> R.Arg $ appExcessive excess cty t) cons cases
 
-    appExcessive :: [PrtTerm] -> Type Name -> PrtTerm -> PrtTerm
+    -- Receives the excessive arguments, the type of the constructor whose case we're on and
+    -- the term defining the value at this constructor's case.
+    appExcessive :: [R.Arg PrtType PrtTerm] -> Type Name -> PrtTerm -> PrtTerm
     appExcessive l (R.TyFun a b) (R.Lam n ty t) =
-      R.Lam n ty (appExcessive (map (shift 1) l) b t) -- `a` and `ty` are equal, up to substitution of variables in the type of the constructors.
+      R.Lam n ty (appExcessive (map (R.argMap id (shift 1)) l) b t) -- `a` and `ty` are equal, up to substitution of variables in the type of the constructors.
     appExcessive l (R.TyFun a b) _              =
-       undefined -- When matching, the number of lambdas should be bigger than the number of arguments of a constructor.
+       error "Ill-typed program! Number of lambdas in case-branch must be bigger than constructor arity"
     appExcessive l _             t              =
-       R.appN t $ map R.Arg l
+       R.appN t l
 
     tyDrop :: Int -> PrtType -> PrtType
-    tyDrop 0 t             = t
-    tyDrop n (R.TyFun a b) = tyDrop (n-1) b
-    tyDrop n t             = undefined -- If `n` is not 0, then the type must be an arrow.
-
--- |Simpler version of 'removeExcessiveArgs' that removes arguments of type Unit only.
-removeThunks :: (MonadPirouette m) => PrtTerm -> m PrtTerm
-removeThunks = pushCtx "removeThunks" . rewriteM (runMaybeT . go)
-  where
-    go :: (MonadPirouette m) => PrtTerm -> MaybeT m PrtTerm
-    go t = do
-      (n, tyN, tyArgs, x, R.TyFun tyA tyB, cases) <- unDest t
-      isUnit <- lift $ typeIsUnit tyA
-      if not isUnit then fail "Can't rewrite; not Unit"
-      else do
-        let (cases', [unit]) = splitAt (length cases - 1) cases
-        logTrace $ show n
-        return $ R.App (R.F $ FreeName n)
-               $ map R.TyArg tyArgs
-              ++ [R.Arg x, R.TyArg tyB]
-              ++ map (R.Arg . (`appLast` unit)) cases'
-
-    appLast :: (HasSubst ty, IsVar f)
-            => R.AnnTerm ty ann f -> R.AnnTerm ty ann f -> R.AnnTerm ty ann f
-    appLast t@(R.Lam _ _ (R.App _ _)) arg = R.termApp t (R.Arg arg)
-    appLast (R.Lam ann ty t)          arg = R.Lam ann ty (appLast t arg)
-    appLast t                         arg = R.termApp t (R.Arg arg)
+    tyDrop 0 t               = t
+    tyDrop n (R.TyFun a b)   = tyDrop (n-1) b
+    tyDrop n (R.TyAll _ _ t) = tyDrop (n-1) t
+    tyDrop n t               = error "Ill-typed program: not enough type parameters to drop"
 
 -- |Because TLA+ really doesn't allow for shadowed bound names, we need to rename them
 -- after performing any sort of inlining.
@@ -287,14 +265,12 @@ constrDestrId = pushCtx "constrDestrId" . rewriteM (runMaybeT . go)
   where
     go :: (MonadPirouette m) => PrtTerm -> MaybeT m PrtTerm
     go t = do
-      (_, tyN, tyArgs, x, ret, cases) <- unDest t
+      (_, tyN, tyArgs, x, ret, cases, excess) <- unDest t
       (tyN', xTyArgs, xIdx, xArgs) <- unCons x
       guard (tyN == tyN')
-      ar <- length . constructors <$> lift (typeDefOf tyN)
-      let (cases0, rest) = splitAt ar cases
-      let xCase          = cases0 !! xIdx
+      let xCase          = cases !! xIdx
       logTrace $ show tyN
-      return $ R.appN (R.appN xCase (map R.Arg xArgs)) (map R.Arg rest)
+      return $ R.appN (R.appN xCase (map R.Arg xArgs)) excess
 
 -- `chooseHeadCase f tyf [st,INPUT,param] INPUT` creates a term which contains the body of `f`
 -- but with a matching on the `INPUT` at the head of it.

--- a/src/Pirouette/Term/Transformations.hs
+++ b/src/Pirouette/Term/Transformations.hs
@@ -35,8 +35,6 @@ import           Data.Text.Prettyprint.Doc hiding (pretty)
 import qualified Data.Text as T
 import qualified Data.Map as M
 
-import Debug.Trace
-
 -- * Monomorphic Transformations
 
 -- |Removes superfluous Bool-match. For example,
@@ -189,8 +187,7 @@ removeExcessiveDestArgs = pushCtx "removeExcessiveDestArgs" . rewriteM (runMaybe
     appExcessive l (R.TyFun a b) _              =
        error "Ill-typed program! Number of lambdas in case-branch must be bigger than constructor arity"
     appExcessive l _             t              =
-       trace ("Applying: " ++ renderSingleLineStr (pretty t) ++ "\n to: " ++ renderSingleLineStr (pretty l))
-           $ R.appN t l
+       R.appN t l
 
     tyDrop :: Int -> PrtType -> PrtType
     tyDrop 0 t               = t

--- a/src/Pirouette/Term/Transformations.hs
+++ b/src/Pirouette/Term/Transformations.hs
@@ -35,6 +35,8 @@ import           Data.Text.Prettyprint.Doc hiding (pretty)
 import qualified Data.Text as T
 import qualified Data.Map as M
 
+import Debug.Trace
+
 -- * Monomorphic Transformations
 
 -- |Removes superfluous Bool-match. For example,
@@ -187,7 +189,8 @@ removeExcessiveDestArgs = pushCtx "removeExcessiveDestArgs" . rewriteM (runMaybe
     appExcessive l (R.TyFun a b) _              =
        error "Ill-typed program! Number of lambdas in case-branch must be bigger than constructor arity"
     appExcessive l _             t              =
-       R.appN t l
+       trace ("Applying: " ++ renderSingleLineStr (pretty t) ++ "\n to: " ++ renderSingleLineStr (pretty l))
+           $ R.appN t l
 
     tyDrop :: Int -> PrtType -> PrtType
     tyDrop 0 t               = t

--- a/tests/integration/Manual/README.md
+++ b/tests/integration/Manual/README.md
@@ -25,11 +25,12 @@ by the plutus compiler.
 
 ## [HO Constructor, Simple Transition](ho-constr-simple-transi.pir)
 
-Defines a simple contract that uses values of type `Maybe (State -> State)` but,
+Defines a simple contract that uses values of type `forall s . Maybe (s -> s)` but,
 upon normalization reduzes to a first order program. The main objective here
 is testing the `removeExcessiveDestrArgs` function ([here](https://github.com/tweag/pirouette/blob/88d38d34b52184957e89d9183db1fbd45e0055ea/src/Pirouette/Term/Transformations.hs#L165)), 
 which ensures that the over-saturated `Input_match` on `ho-constr-simple-transi.pir:45`
 gets its last parameter distributed, then gets all its branches normalized.
+Note that this tests `removeExcessiveDestrArgs` with distributing both term and type arguments.
 
 ## [HO Constructor, HO transition](ho-constr-ho-transi.pir)
 _PENDING:_ Waiting for issue #3

--- a/tests/integration/Manual/ho-constr-simple-transi.pir
+++ b/tests/integration/Manual/ho-constr-simple-transi.pir
@@ -30,23 +30,24 @@
       )
       (termbind
         (strict)
-        (vardecl defaultId (fun [Maybe (fun State State)] (fun State State)))
-        (lam f [Maybe (fun State State)] (lam st State
-          [[ { [ { Maybe_match (fun State State) } f ] State }
-            (lam x (fun State State) [x st]) ]
+        (vardecl defaultId (all s (type) (fun [Maybe (fun s s)] (fun s s))))
+        (abs s (type) (lam f [Maybe (fun s s)] (lam st s
+          [[ { [ { Maybe_match (fun s s) } f ] s }
+            (lam x (fun s s) [x st]) ]
             st ]
-        ))
+        )))
       )
       (termbind
         (strict)
         (vardecl transition (fun State (fun Input State)))
         (lam s State
           (lam i Input
-            [[[[{[Input_match i] (fun State State)}
-              [defaultId Nothing]]
-              [defaultId [Just Inc]]]
-              [defaultId [Just Dec]]]
-              s
+            [{[[[{[Input_match i] (all s (type) (fun s s))}
+               (abs s (type) [{ defaultId s } Nothing])]
+               (abs s (type) [{ defaultId s } [Just Inc]])]
+               (abs s (type) [{ defaultId s } [Just Dec]])]
+               State }
+               s
             ]
           )
         )


### PR DESCRIPTION
After updating Plutus, we have realized that we need to remove excessive type arguments from destructors in addition to term arguments. This PR adapts `unDest` and `removeExcessiceDestArgs` to do precisely that.