### PR TITLE
Corrections of the --spz-ty option

### DIFF
--- a/src/Pirouette/Specializer.hs
+++ b/src/Pirouette/Specializer.hs
@@ -11,5 +11,4 @@ allSpz "Bool"   = Just boolSpz
 allSpz "List"   = Just listSpz
 allSpz "Unit"   = Just unitSpz
 allSpz "Tuple2" = Just tuple2Spz
-allSpz "Maybe"  = Just maybeSpz
 allSpz _        = Nothing

--- a/src/Pirouette/Specializer/Basics.hs
+++ b/src/Pirouette/Specializer/Basics.hs
@@ -70,17 +70,3 @@ tuple2Spz = TypeSpecializer {
   spzDestructor = [tla_u|Tuple2_match(t,cT(_,_)) == cT(t[1],t[2])|],
   spzMatch = tuple2SpzMatch
 }
-
-maybeSpzMatch t n []  _ exp
-  | nameString n == T.pack "Nothing" = exp
-maybeSpzMatch t n [x] _ exp
-  | nameString n == T.pack "Just" =
-    tlaLet [tlaAssign (tlaIdent x) t] exp
-
-maybeSpz :: TypeSpecializer
-maybeSpz = TypeSpecializer {
-  spzSet = [tla_u|SetOfMaybe(a) == {{}} \union a|],
-  spzConstructors = [[tla_u|Nothing == {}|], [tla_u|Just(x) == x|]],
-  spzDestructor = [tla_u|Maybe_match(m,cN,cJ(_)) == IF m = {} THEN cN ELSE cJ(m)|],
-  spzMatch = maybeSpzMatch
-}

--- a/src/Pirouette/Term/ToTla.hs
+++ b/src/Pirouette/Term/ToTla.hs
@@ -554,9 +554,7 @@ trTree (Choose x pirTy cases) tyRes = do
         mapM (\(cstr,tr) -> trConstrainedExp nx pirTy cstr (trTree tr tyRes)) cases
   where
     nameOf :: PrtType -> Maybe String
-    nameOf (R.TyApp (R.B (R.Ann x) _) []) =
-      Just $ T.unpack (nameString x)
-    nameOf (R.TyApp (R.F (TyFree x)) []) =
+    nameOf (R.TyApp (R.F (TyFree x)) _) =
       Just $ T.unpack (nameString x)
     nameOf _ = Nothing
 


### PR DESCRIPTION
Specializing the `Maybe` type was a bad idea (at least with the chosen encoding with `Nothing == {}`, since it is impossible to compare a record and a non-record value, meaning that one cannot use the proposed `Maybe_match(m,cJ(_),cN)` which started by `IF m = {} THEN ...`.
Furthermore, when wondering if a type was to specialize, I do not know why we considered that the type name could be a bound variable, and in the case of lists (or maybes if it has not been suppressed), it is supposed to be applied to some arguments, so no reason to check if the list of arguments is empty.