### PR TITLE
Enabling profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ to avoid building GHC when you start the nix shell.
 You might want to consider `direnv` and [`nix-direnv`](https://github.com/nix-community/nix-direnv)
 instead of running `nix-shell` directly.
 
+### Profling Pirouette
+
+To build with profiling enabled, open a nix shell with `nix-shell --arg enableHaskellProfiling true` (
+_WARNING:_ This will take a long time to complete). Once inside the nix shell, you can 
+`cabal build --enable-profiling` and pass `+RTS` options to the executable normally.
+
 ## Usage
 
 Run `cabal run pirouette -- --help` to see an updated list of options.

--- a/cabal.project
+++ b/cabal.project
@@ -10,7 +10,6 @@ tests: true
 benchmarks: false
 
 -- Profiling related options
-profiling: true
 package plutus-core
   ghc-options: -fexternal-interpreter
 

--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,11 @@ write-ghc-environment-files: never
 tests: true
 benchmarks: false
 
+-- Profiling related options
+profiling: true
+package plutus-core
+  ghc-options: -fexternal-interpreter
+
 -- Plutus revision from 2021/06/11
 source-repository-package
   type: git

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,9 @@
 # developing plutus-starter.
 #
 ########################################################################
-
+{ packages ? import ./nix { inherit enableHaskellProfiling; }
+, enableHaskellProfiling ? false
+}:
 let
   # Here a some of the various attributes for the variable 'packages':
   #
@@ -22,7 +24,6 @@ let
   #     haskell-language-server
   #   }
   # }
-  packages = import ./nix;
 
   inherit (packages) pkgs pirouette;
   project = pirouette.haskell.project;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,3 +1,5 @@
+{ enableHaskellProfiling ? false
+}:
 let
   # Pratically, the only needed dependency is the plutus repository.
   sources = import ./sources.nix { inherit pkgs; };
@@ -15,7 +17,7 @@ let
   haskell-nix = pkgs.haskell-nix;
 
   pirouette = import ./pkgs {
-    inherit pkgs haskell-nix sources plutus;
+    inherit pkgs haskell-nix sources plutus enableHaskellProfiling;
   };
 
 in

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -2,6 +2,7 @@
 , sources
 , plutus
 , haskell-nix
+, enableHaskellProfiling
 }:
 let
   gitignore-nix = pkgs.callPackage plutus."gitignore.nix" { };
@@ -11,6 +12,7 @@ let
   haskell = pkgs.callPackage ./haskell {
     inherit gitignore-nix sources haskell-nix;
     inherit compiler-nix-name; # Use the same GHC version as plutus
+    inherit enableHaskellProfiling;
     inherit (pkgs) libsodium-vrf;
   };
 

--- a/nix/pkgs/haskell/default.nix
+++ b/nix/pkgs/haskell/default.nix
@@ -4,6 +4,7 @@
 , sources
 , compiler-nix-name
 , libsodium-vrf
+, enableHaskellProfiling
 }:
 let
   # The Hackage index-state from cabal.project
@@ -22,7 +23,7 @@ let
 
   # The haskell project created by haskell-nix.cabalProject'
   project = import ./haskell.nix {
-    inherit lib haskell-nix compiler-nix-name gitignore-nix libsodium-vrf;
+    inherit lib haskell-nix compiler-nix-name gitignore-nix libsodium-vrf enableHaskellProfiling;
   };
 
   # All the packages defined by our project, including dependencies

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -6,6 +6,7 @@
 , compiler-nix-name
 , lib
 , libsodium-vrf
+, enableHaskellProfiling
 }:
 
 let
@@ -49,13 +50,16 @@ let
           # Broken due to haddock errors. Refer to https://github.com/input-output-hk/plutus/blob/master/nix/pkgs/haskell/haskell.nix
           plutus-ledger.doHaddock = false;
           plutus-use-cases.doHaddock = false;
-          
+
           # See https://github.com/input-output-hk/iohk-nix/pull/488
           cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [ [ libsodium-vrf ] ];
           cardano-crypto-class.components.library.pkgconfig = lib.mkForce [ [ libsodium-vrf ] ];
         };
       }
-    ];
+    ] ++ lib.optional enableHaskellProfiling {
+      enableLibraryProfiling = true;
+      enableExecutableProfiling = true;
+    };
   };
 in
   project

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -13,6 +13,11 @@ extra-source-files:
     LICENSE
     README.md
 
+common lang
+    ghc-options:
+      -fprof-auto
+      "-with-rtsopts=-N -p -s -h -i0.1"
+
 library
   exposed-modules:
       Pirouette.Monad

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,8 @@
-{ nixpkgs ? import <nixpkgs> {} }:
+{ nixpkgs ? import <nixpkgs> {}
+, enableHaskellProfiling ? false
+, packages ? import ./. { inherit enableHaskellProfiling; }
+}:
 let
-  packages = import ./.;
   inherit (packages) pkgs pirouette;
   inherit (pirouette) haskell;
 


### PR DESCRIPTION
To enable profiling, one simply has to open a nix shell with `nix-shell --arg enableHaskellProfiling true` and then to run pirouette with RTS, like in `cabal run pirouette --enable-profiling -- --term-only tests/integration/GameStateMachine/GameStateMachine.flat +RTS -h`