### PR TITLE
Fix inner-let-bug

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -81,6 +81,7 @@ data CliOpts = CliOpts
   , skeleton      :: Maybe FilePath
   , pruneMaybe    :: Bool
   , tySpecializer :: [String]
+  , checkSanity   :: Bool
   } deriving Show
 
 data Stage = ToTerm | ToTLA | ToCTree
@@ -179,7 +180,12 @@ mainOpts opts uDefs = do
 
 processDecls :: (MonadIO m) => CliOpts -> PrtUnorderedDefs -> PrtT m PrtOrderedDefs
 processDecls opts uDefs = do
-  runReaderT checkDeBruijn uDefs
+  -- If the user wishes, we can perform checks on the sanity of the translation
+  -- from PlutusIR to PrtDefs
+  when (checkSanity opts) $ do
+    runReaderT checkDeBruijnIndices uDefs
+
+  -- Otherwise, we proceed normally
   oDefs  <- expandAllNonRec (contains (funNamePrefix opts)) <$> elimEvenOddMutRec uDefs
   postDs <- runReaderT (sequence $ M.map processOne $ prtDecls oDefs) oDefs
   return $ oDefs { prtDecls = postDs }
@@ -289,6 +295,13 @@ parseCliOpts = CliOpts <$> parseStage
                        <*> parseSkeletonFile
                        <*> parsePruneMaybe
                        <*> parseTySpecializer
+                       <*> parseTrSanity
+
+parseTrSanity :: Opt.Parser Bool
+parseTrSanity = Opt.switch
+                  (  Opt.long "sanity-check"
+                  <> Opt.help "Perform a series of extra checks, can help with debugging"
+                  )
 
 parseWithArgs :: Opt.Parser [String]
 parseWithArgs = Opt.option (Opt.maybeReader (Just . r))

--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -205,7 +205,7 @@ pirouette :: (MonadIO m) => FilePath -> PrtOpts
 pirouette pir opts f =
   withParsedPIR pir $ \pirProg ->
   withDecls pirProg $ \toplvl decls0 -> do
-    let decls = decls0 -- declsUniqueNames decls0
+    let decls = declsUniqueNames decls0
     let defs  = PrtUnorderedDefs decls toplvl
     (eres, msgs) <- runPrtT opts (f defs)
     mapM_ printLogMessage msgs

--- a/src/Pirouette/Monad/Logger.hs
+++ b/src/Pirouette/Monad/Logger.hs
@@ -68,6 +68,9 @@ class (Monad m) => MonadLogger m where
   logWarn  :: String -> m ()
   logWarn  = logMsg WARN
 
+  logError  :: String -> m ()
+  logError  = logMsg ERROR
+
 newtype LoggerT m a = LoggerT { unLogger :: WriterT LogMessages (ReaderT [String] m) a }
   deriving newtype (Functor, Applicative, Monad, MonadIO)
 

--- a/src/Pirouette/TLA/Type.hs
+++ b/src/Pirouette/TLA/Type.hs
@@ -94,7 +94,7 @@ pirTyUnit :: PrtType
 pirTyUnit = R.tyPure $ R.F $ TyBuiltin PIRTypeUnit
 
 pirTyList :: PIRType -> PrtType
-pirTyList a = R.tyPure $ R.F $ TyBuiltin (PIRTypeList a)
+pirTyList a = R.tyPure $ R.F $ TyBuiltin (PIRTypeList $ Just a)
 
 tlaAll :: [(Name, R.Kind)] -> TlaType -> TlaType
 tlaAll = flip (foldr (\(n, k) t -> TlaAll (R.Ann n) k t))

--- a/src/Pirouette/Term/FromPlutusIR.hs
+++ b/src/Pirouette/Term/FromPlutusIR.hs
@@ -52,7 +52,6 @@ type PIRConstraint tyname name fun
 data Err loc
   = NotYetImplemented loc String
   | NoTermBindAllowed loc
-  | DependencyComputationOverflow
   deriving (Eq, Show)
 
 -- |Translating to De Bruijn requires us to keep the stack of bound variables, whereas
@@ -142,7 +141,7 @@ bindingCtxDeps termBinds = do
       vs <- asks termStack
       let currDeps = M.unionWith S.union origDeps delta
       let newDelta = M.fromList $ map (second $ termCtxDeps vs currDeps) xs
-      if M.null newDelta
+      if delta == newDelta
       then return currDeps
       else go xs origDeps newDelta
 

--- a/src/Pirouette/Term/FromPlutusIR.hs
+++ b/src/Pirouette/Term/FromPlutusIR.hs
@@ -54,7 +54,7 @@ type PIRConstraint tyname name fun
 data Err loc
   = NotYetImplemented loc String
   | NoTermBindAllowed loc
-  | ApplicationError
+  | DependencyComputationOverflow
   deriving (Eq, Show)
 
 -- |Translating to De Bruijn requires us to keep the stack of bound variables, whereas
@@ -131,22 +131,26 @@ bindingCtxDeps :: forall tyname name fun loc
                -> TrM loc ()
 bindingCtxDeps termBinds = do
   deps  <- get
-  deps' <- go termBinds deps M.empty
+  deps' <- go 32 termBinds deps M.empty
   put deps'
   where
     -- The go function below runs a fixpoint computation on a delta over the original dependencies;
-    -- We keep computing a new delta until we find nothing different to add.
-    go :: [(Name, PIR.Term tyname name DefaultUni fun loc)]
+    -- We keep computing a new delta until we find nothing different to add; just to be sure we
+    -- wont loop here, we decrease a gas-counter on every recursive call.
+    go :: Int
+       -> [(Name, PIR.Term tyname name DefaultUni fun loc)]
        -> DepsOf Name
        -> DepsOf Name
        -> TrM loc (DepsOf Name)
-    go xs origDeps delta = do
+    go i xs origDeps delta = do
       vs <- asks termStack
       let currDeps = M.unionWith S.union origDeps delta
       let newDelta = M.fromList $ map (second $ termCtxDeps vs currDeps) xs
+      when (i <= 0) $
+        throwError DependencyComputationOverflow
       if newDelta == delta
       then return currDeps
-      else go xs origDeps newDelta
+      else go (i-1) xs origDeps newDelta
 
 -- |Given a stack of bound variables and a dependency map, compute one step
 -- of the transitive dependencies of a term. For example, let @t@ be

--- a/src/Pirouette/Term/Syntax.hs
+++ b/src/Pirouette/Term/Syntax.hs
@@ -6,6 +6,8 @@ module Pirouette.Term.Syntax
   , Name(..), ToName(..), TyName
   , separateBoundFrom
   , declsUniqueNames
+  , safeIdx
+  , unsafeIdx
   ) where
 
 import           Pirouette.Term.Syntax.Base    as EXPORT
@@ -23,6 +25,7 @@ import qualified Data.Map.Strict           as M
 import qualified Data.Set                  as S
 import           Data.Data
 import           Data.String
+import           Data.Maybe (fromMaybe)
 
 -- * Top Level Terms and Types
 --
@@ -222,3 +225,15 @@ typeUNSubst = R.tyBimapM return subst
   where
     subst (R.F (TyFree n))  = R.F . TyFree <$> unNameSubst n
     subst x                 = return x
+
+-- ** Utility Functions
+
+safeIdx :: (Integral i) => [a] -> i -> Maybe a
+safeIdx l = go l . fromIntegral
+  where
+    go []     _ = Nothing
+    go (x:_)  0 = Just x
+    go (_:xs) n = go xs (n-1)
+
+unsafeIdx :: (Integral i) => String -> [a] -> i -> a
+unsafeIdx lbl l = fromMaybe (error $ "unsafeIdx: out-of-bounds; " ++ lbl) . safeIdx l

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -43,8 +43,8 @@ data PIRType
   | PIRTypeBool
   | PIRTypeString
   | PIRTypeData
-  | PIRTypeList PIRType
-  | PIRTypePair PIRType PIRType
+  | PIRTypeList (Maybe PIRType)
+  | PIRTypePair (Maybe PIRType) (Maybe PIRType)
   deriving (Eq, Ord, Show, Data, Typeable)
 
 defUniToType :: forall k (a :: k) . DefaultUni (P.Esc a) -> PIRType
@@ -54,8 +54,12 @@ defUniToType DefaultUniUnit        = PIRTypeUnit
 defUniToType DefaultUniBool        = PIRTypeBool
 defUniToType DefaultUniString      = PIRTypeString
 defUniToType DefaultUniData        = PIRTypeData
-defUniToType (DefaultUniList a)    = PIRTypeList (defUniToType a)
-defUniToType (DefaultUniPair a b)  = PIRTypePair (defUniToType a) (defUniToType b)
+defUniToType (DefaultUniList a)    = PIRTypeList (Just (defUniToType a))
+defUniToType (DefaultUniPair a b)  = PIRTypePair (Just $ defUniToType a) (Just $ defUniToType b)
+defUniToType DefaultUniProtoList   = PIRTypeList Nothing
+defUniToType DefaultUniProtoPair   = PIRTypePair Nothing Nothing
+defUniToType (DefaultUniApply DefaultUniProtoPair a) = PIRTypePair (Just $ defUniToType a) Nothing
+
 
 -- |The language of types will consits of the standard polymorphic type-level lambda calculus
 -- where the free variables will be of type 'TypeBase', that is, they are either a builtin type or

--- a/src/Pirouette/Term/Syntax/Pretty.hs
+++ b/src/Pirouette/Term/Syntax/Pretty.hs
@@ -157,6 +157,10 @@ instance Pretty PIRType where
   pretty (PIRTypeList a)   = brackets (sep ["List", pretty a])
   pretty (PIRTypePair a b) = brackets (sep ["Pair", pretty a, pretty b])
 
+instance Pretty (Maybe PIRType) where
+  pretty Nothing  = "-"
+  pretty (Just t) = pretty t
+
 instance (Pretty tyname) => Pretty (TypeBase tyname) where
   pretty (TyBuiltin x)   = pretty x
   pretty (TyFree n)      = pretty n

--- a/src/Pirouette/Term/ToTla.hs
+++ b/src/Pirouette/Term/ToTla.hs
@@ -811,7 +811,7 @@ trFreeName n args = do
     DDestructor ty    -> trDestrApp n ty args
     DFunction r df ty -> do
       tlaAppName n args
-    DTypeDef _        -> throwError' $ PEOther "trFreeName: Found TypeDef where a term was expected"
+    DTypeDef _        -> throwError' $ PEOther $ "trFreeName: Found TypeDef where a term was expected: " ++ show n
 
 -- |Constructs a value of a datatype as a TLA expression.
 trConstrApp :: (PirouetteReadDefs m) => Name -> [TLA.AS_Expression] -> TlaT m TLA.AS_Expression

--- a/src/Pirouette/Term/ToTla.hs
+++ b/src/Pirouette/Term/ToTla.hs
@@ -411,7 +411,7 @@ trBoundedSetDef tyName tyVars cons = do
       | tn == tyName = tlaOpApp (tlaIdentPrefixed "BoundedSetOf" tn) . (nMinus1:) $ map (trSimpleType env) args
       | otherwise    = tlaOpApp (tlaIdentPrefixed "SetOf" tn) $ map (trSimpleType env) args
     trSimpleType env (R.TyApp (R.F (TyBuiltin n)) args) = tlaOpApp (trBuiltinType n) (map (trSimpleType env) args)
-    trSimpleType env (R.TyApp (R.B _ i) args) = tlaOpApp (tlaIdent $ env L.!! fromInteger i) $ map (trSimpleType env) args
+    trSimpleType env (R.TyApp (R.B _ i) args) = tlaOpApp (tlaIdent $ unsafeIdx "trSimpleType" env (fromInteger i)) $ map (trSimpleType env) args
 
 trType :: (PirouetteReadDefs m) => PrtType -> TlaT m TLA.AS_Expression
 trType (R.TyApp n args)  = tlaOpApp <$> trTypeVar n <*> mapM trType args
@@ -503,9 +503,9 @@ trBuiltinType PIRTypeUnit       = tlaIdentPrefixed "Plutus" "Unit"
 trBuiltinType PIRTypeBool       = tlaIdentPrefixed "Plutus" "Bool"
 trBuiltinType PIRTypeString     = tlaIdentPrefixed "Plutus" "String"
 trBuiltinType PIRTypeData       = tlaIdentPrefixed "Plutus" "Data"
-trBuiltinType (PIRTypeList t) =
+trBuiltinType (PIRTypeList (Just t)) =
   TLA.AS_OpApp di (tlaIdentPrefixed "Plutus" "List") [trBuiltinType t]
-trBuiltinType (PIRTypePair t u) =
+trBuiltinType (PIRTypePair (Just t) (Just u)) =
   TLA.AS_OpApp di (tlaIdentPrefixed "Plutus" "Pair") [trBuiltinType t, trBuiltinType u]
 
 -- |Returns a TLA quantifier bound. It is used in, for example,

--- a/src/Pirouette/Transformations.hs
+++ b/src/Pirouette/Transformations.hs
@@ -24,30 +24,6 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import           Data.Generics.Uniplate.Operations
 
-checkDeBruijn :: (PirouetteReadDefs m) => m ()
-checkDeBruijn = pushCtx "checkDeBruijn" $ do
-  allDefs <- prtAllDefs
-  flip mapM_ (M.toList allDefs) $ \(n, def) -> do
-    case defTermMapM (\t -> go 0 0 t >> return t) def of
-      Left err -> logError ("Invalid de Bruijn index for " ++ show n ++ "; " ++ show err)
-               >> logError (renderSingleLineStr (pretty def))
-               >> throwError' (PEOther "Invalid de Bruijn index")
-      Right _  -> return ()
-  where
-    go :: Integer -> Integer -> PrtTerm -> Either String ()
-    go ty term (R.Lam (R.Ann ann) _ t)
-        = go ty (term + 1) t
-    go ty term (R.Abs (R.Ann ann) _ t)
-        = go (ty + 1) term t
-    go ty term (R.App n args) = do
-      mapM_ (R.argElim (const $ return ()) (go ty term)) args
-      case n of
-        R.B _ i -> if i >= term
-                   then Left $ "Referencing var " ++ show i ++ " with only " ++ show term ++ " lams"
-                   else return ()
-        _       -> return ()
-
-
 -- |Removes all Even-Odd mutually recursive functions from the program.
 -- When successfull, sets the 'tord' state field with a list of names indicating the order in which
 -- they should be defined so that the dependencies of a term @T@ are defined before @T@.
@@ -162,3 +138,29 @@ expandDefsIn inlinables decls k =
      nDef <- M.lookup n inlinables
      return . deshadowBoundNames $ R.appN nDef args
    inlineAll _ _ = Nothing
+
+-- ** Sanity Checks
+
+-- |Checks that all deBruijn indices make sense, this gets run whenever pirouette
+-- is ran with the @--sanity-check@ flag.
+checkDeBruijnIndices :: (PirouetteReadDefs m) => m ()
+checkDeBruijnIndices = pushCtx "checkDeBruijn" $ do
+  allDefs <- prtAllDefs
+  forM_ (M.toList allDefs) $ \(n, def) -> do
+    case defTermMapM (\t -> go 0 0 t >> return t) def of
+      Left err -> logError ("Invalid de Bruijn index for " ++ show n ++ "; " ++ show err)
+               >> logError (renderSingleLineStr (pretty def))
+               >> throwError' (PEOther "Invalid de Bruijn index")
+      Right _  -> return ()
+  where
+    go :: Integer -> Integer -> PrtTerm -> Either String ()
+    go ty term (R.Lam (R.Ann ann) _ t)
+        = go ty (term + 1) t
+    go ty term (R.Abs (R.Ann ann) _ t)
+        = go (ty + 1) term t
+    go ty term (R.App n args) = do
+      mapM_ (R.argElim (const $ return ()) (go ty term)) args
+      case n of
+        R.B _ i -> when (i >= term) $
+                     Left $ "Referencing var " ++ show i ++ " with only " ++ show term ++ " lams"
+        _       -> return ()

--- a/src/Pirouette/Transformations.hs
+++ b/src/Pirouette/Transformations.hs
@@ -24,6 +24,29 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import           Data.Generics.Uniplate.Operations
 
+checkDeBruijn :: (PirouetteReadDefs m) => m ()
+checkDeBruijn = pushCtx "checkDeBruijn" $ do
+  allDefs <- prtAllDefs
+  flip mapM_ (M.toList allDefs) $ \(n, def) -> do
+    case defTermMapM (\t -> go 0 0 t >> return t) def of
+      Left err -> logError ("Invalid de Bruijn index for " ++ show n ++ "; " ++ show err)
+               >> logError (renderSingleLineStr (pretty def))
+               >> throwError' (PEOther "Invalid de Bruijn index")
+      Right _  -> return ()
+  where
+    go :: Integer -> Integer -> PrtTerm -> Either String ()
+    go ty term (R.Lam (R.Ann ann) _ t)
+        = go ty (term + 1) t
+    go ty term (R.Abs (R.Ann ann) _ t)
+        = go (ty + 1) term t
+    go ty term (R.App n args) = do
+      mapM_ (R.argElim (const $ return ()) (go ty term)) args
+      case n of
+        R.B _ i -> if i >= term
+                   then Left $ "Referencing var " ++ show i ++ " with only " ++ show term ++ " lams"
+                   else return ()
+        _       -> return ()
+
 
 -- |Removes all Even-Odd mutually recursive functions from the program.
 -- When successfull, sets the 'tord' state field with a list of names indicating the order in which

--- a/tests/integration/Manual/README.md
+++ b/tests/integration/Manual/README.md
@@ -51,6 +51,15 @@ _PENDING:_ needs to be added to `all.json`
 Tests let-expansion. Our representation of System F has no let-bindings, hence we lift all
 definitions within a let-binding to the outer scope transforming its free variables
 into bound variables, then passing all the necessary arguments on all call sites.
+In this particular example, this is the dependency relation we're encoding:
+
+```haskell
+\ x -> let ds = ... x ...
+           m  = ... r ...
+           r  = ... ds ...
+        in \ n -> let j = ... n ... m ...
+                   in j
+```
 
 ## [Mutual Recursion](mutual-recursion.pir)
 _PENDING:_ Pirouette cannot output valid TLA+ for mutually recursive datatypes; nevertheless, we need to add this to `all.json`

--- a/tests/integration/Manual/inner-let.pir
+++ b/tests/integration/Manual/inner-let.pir
@@ -8,47 +8,50 @@
             (vardecl True Bool) (vardecl False Bool)
           )
       )
-      (datatypebind
-          (datatype
-            (tyvardecl FirstSecond (type))
-            FS_match
-            (vardecl First FirstSecond) (vardecl Second FirstSecond)
-          )
-      )
-      (termbind
+      (termbind 
         (strict)
-        (vardecl
-          problem
-          (fun FirstSecond (fun FirstSecond Bool))
-        )
-        (lam
-          arg_721
-          FirstSecond
-          (lam
-            arg_722
-            FirstSecond
-            (let
-              (nonrec)
-              (termbind
-                (strict)
-                (vardecl b_723 (con bool))
-                [
-                  [ (builtin greaterThanEqualsInteger) arg_721 ]
-                  arg_722
-                ]
-              )
-              [
-                [ [ { (builtin ifThenElse) Bool } b_723 ] True ]
-                False
-              ]
-            )
-          )
-        )
-      )
-      (termbind (strict)
-        (vardecl main Bool)
-        [problem First Second])
-      main
-  )
+        (vardecl not (fun Bool Bool))
+        (lam a Bool
+          [[ { [ Bool_match a ] Bool }
+             False ]
+             True  ]
+      ))
+      (termbind 
+        (strict)
+        (vardecl or (fun Bool (fun Bool Bool)))
+        (lam a Bool (lam b Bool
+          [[ { [ Bool_match a ] Bool }
+             True ]
+             b    ]
+      )))
+      (termbind
+        (strict) 
+        (vardecl top (fun Bool (fun Bool Bool)))
+        (lam xxx Bool
+          (let
+            (nonrec)
+            (termbind
+              (strict)
+              (vardecl dsdsds Bool)
+              [not xxx])
+            (termbind
+              (strict)
+              (vardecl mmm Bool)
+              [not rrr])
+            (termbind
+              (strict)
+              (vardecl rrr Bool)
+              [not dsdsds])
+            (lam nnn Bool
+              (let
+                (nonrec)
+                (termbind 
+                  (strict)
+                  (vardecl jjj Bool)
+                  [[or nnn] mmm])
+                jjj
+            )))
+      ))
+      top)
 )
 


### PR DESCRIPTION
Our code was crashing with the `StableCoin.flat` contract; I was able to produce a minimal example that reproduces the bug.
The bug was actually simple, the `bindingCtxDeps` was erasing dependencies on recursive calls.