### PR TITLE
Fixing eta-expansion

### DIFF
--- a/src/Language/Pirouette/Example/Syntax.hs
+++ b/src/Language/Pirouette/Example/Syntax.hs
@@ -85,7 +85,6 @@ instance Pretty ExConstant where
   prettyPrec _ (ConstInt n) = pretty n
   prettyPrec _ (ConstBool b) = pretty b
 
-
 -- | The language builtins definition
 data Ex deriving (Data)
 

--- a/src/Pirouette/Term/Syntax.hs
+++ b/src/Pirouette/Term/Syntax.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 module Pirouette.Term.Syntax
   ( module EXPORT,
@@ -78,7 +78,7 @@ separateBoundFrom u t =
 -- https://github.com/input-output-hk/plutus/issues/3445
 
 -- | Exported interface function to uniquely naming declarations.
-declsUniqueNames :: forall lang . Decls lang -> Term lang -> (Decls lang, Term lang)
+declsUniqueNames :: forall lang. Decls lang -> Term lang -> (Decls lang, Term lang)
 declsUniqueNames decls mainFun = first Map.fromList (go (Map.toList decls))
   where
     onPairM f g (x, y) = (,) <$> f x <*> g y

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -7,11 +7,11 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- |Provides the base syntactical elements for the languages supported by Pirouette.
--- This module /does not/ expose the underlying System F implementation. In case
--- you're interested in manipulating terms at the Systm F level make sure
--- to bring in "Pirouette.Term.Syntax.SystemF", which is meant to be
--- imported qualified.
+-- | Provides the base syntactical elements for the languages supported by Pirouette.
+--  This module /does not/ expose the underlying System F implementation. In case
+--  you're interested in manipulating terms at the Systm F level make sure
+--  to bring in "Pirouette.Term.Syntax.SystemF", which is meant to be
+--  imported qualified.
 module Pirouette.Term.Syntax.Base where
 
 import Control.Arrow ((&&&))

--- a/src/Pirouette/Term/Syntax/SystemF.hs
+++ b/src/Pirouette/Term/Syntax/SystemF.hs
@@ -118,10 +118,11 @@ tyApp (TyLam _ _ t) u = subst (singleSub u) t
 tyApp TyAll {} _ = error "Can't apply TyAll"
 tyApp TyFun {} _ = error "Can't apply TyFun"
 
-tyAfterTermApp :: (IsVar v) => AnnType ann v -> AnnType ann v -> AnnType ann v
+tyAfterTermApp :: (IsVar v, IsVar vTerm) => AnnType ann v -> Arg (AnnType ann v) (AnnTerm ty ann vTerm) -> AnnType ann v
 tyAfterTermApp (TyApp n args) u = error "Terms of type TyApp are not supposed to be applied."
 tyAfterTermApp (TyLam _ _ t) u = error "Terms of type TyLam cannot be applied."
-tyAfterTermApp (TyAll _ _ t) u = subst (singleSub u) t
+tyAfterTermApp (TyAll _ _ t) (TyArg u) = subst (singleSub u) t
+tyAfterTermApp (TyAll _ _ t) (TermArg u) = error "A type application was expected."
 tyAfterTermApp (TyFun _ t) _ = t -- Here we do not check that the term of the provided argument is the one expected by the function.
 
 -- TODO: write an efficient appN that substitutes multiple variables in one go

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -1,18 +1,19 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MonoLocalBinds #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
-module Pirouette.Transformations.Defunctionalization(defunctionalize) where
+module Pirouette.Transformations.Defunctionalization (defunctionalize) where
 
 import Control.Arrow ((***))
 import Control.Monad.RWS.Strict
+import Control.Monad.Writer.Strict
 import Data.Generics.Uniplate.Data
 import Data.List (nub, sortOn)
 import qualified Data.Map as M
@@ -21,20 +22,18 @@ import qualified Data.Set as S
 import Data.String.Interpolate.IsString
 import qualified Data.Text as T
 import Data.Traversable
-
 import Pirouette.Monad
 import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.Base as B
 import qualified Pirouette.Term.Syntax.SystemF as SystF
-
 import Pirouette.Transformations.EtaExpand
 import Pirouette.Transformations.Utils
-import Control.Monad.Writer.Strict
 
-defunctionalize :: (LanguagePretty lang, LanguageBuiltins lang)
-                => PrtUnorderedDefs lang
-                -> PrtUnorderedDefs lang
-defunctionalize defs = traceDefsId defs' { prtUODecls = prtUODecls defs' <> typeDecls <> applyFunDecls }
+defunctionalize ::
+  (LanguagePretty lang, LanguageBuiltins lang) =>
+  PrtUnorderedDefs lang ->
+  PrtUnorderedDefs lang
+defunctionalize defs = traceDefsId defs' {prtUODecls = prtUODecls defs' <> typeDecls <> applyFunDecls}
   where
     (defs', closureCtorInfos) = evalRWS (defunFuns >=> defunTypes $ etaExpandAll defs) mempty (DefunState mempty)
 
@@ -43,36 +42,43 @@ defunctionalize defs = traceDefsId defs' { prtUODecls = prtUODecls defs' <> type
 
 -- * Defunctionalization of types
 
-defunTypes :: (LanguagePretty lang, LanguageBuiltins lang)
-           => PrtUnorderedDefs lang
-           -> DefunCallsCtx lang (PrtUnorderedDefs lang)
+defunTypes ::
+  (LanguagePretty lang, LanguageBuiltins lang) =>
+  PrtUnorderedDefs lang ->
+  DefunCallsCtx lang (PrtUnorderedDefs lang)
 defunTypes defs = defunCalls toDefun $ defunDtors defs'
   where
     (defs', toDefun) = runWriter $ traverseDefs defunTypeDef defs
 
-    defunTypeDef _ (DTypeDef Datatype{..}) = do
-      forM_ allMaybeHofs $ \case (ctorName, Just hof) -> tell $ M.singleton ctorName hof
-                                 _ -> pure ()
-      pure $ DTypeDef Datatype{constructors = ctors', ..}
+    defunTypeDef _ (DTypeDef Datatype {..}) = do
+      forM_ allMaybeHofs $ \case
+        (ctorName, Just hof) -> tell $ M.singleton ctorName hof
+        _ -> pure ()
+      pure $ DTypeDef Datatype {constructors = ctors', ..}
       where
-        (ctors', allMaybeHofs) = unzip [ ((ctorName, ctorTy'), (ctorName, maybeHofs))
-                                       | (ctorName, ctorTy) <- constructors
-                                       , let (ctorTy', hofs) = rewriteHofType ctorTy
-                                             maybeHofs | ctorTy' == ctorTy = Nothing
-                                                       | otherwise = Just hofs
-                                       ]
+        (ctors', allMaybeHofs) =
+          unzip
+            [ ((ctorName, ctorTy'), (ctorName, maybeHofs))
+              | (ctorName, ctorTy) <- constructors,
+                let (ctorTy', hofs) = rewriteHofType ctorTy
+                    maybeHofs
+                      | ctorTy' == ctorTy = Nothing
+                      | otherwise = Just hofs
+            ]
     defunTypeDef _ x = pure x
 
 -- Destructors have a well-known structure: they are η-expanded,
 -- they accept a bunch of funargs that needn't be defunctionalized, etc,
 -- so we can have a few shortcuts
-defunDtors :: forall lang. (LanguagePretty lang, LanguageBuiltins lang)
-           => PrtUnorderedDefs lang
-           -> PrtUnorderedDefs lang
+defunDtors ::
+  forall lang.
+  (LanguagePretty lang, LanguageBuiltins lang) =>
+  PrtUnorderedDefs lang ->
+  PrtUnorderedDefs lang
 defunDtors defs = transformBi f defs
   where
     dtorsNames = S.fromList $ mapMaybe getDtorName (M.elems $ prtUODecls defs)
-    getDtorName (DTypeDef Datatype{..}) = Just destructor
+    getDtorName (DTypeDef Datatype {..}) = Just destructor
     getDtorName _ = Nothing
 
     f :: Term lang -> Term lang
@@ -86,21 +92,23 @@ defunDtors defs = transformBi f defs
 
 -- * Defunctionalization of functions
 
-defunFuns :: (LanguagePretty lang, Pretty (FunDef lang), LanguageBuiltins lang)
-          => PrtUnorderedDefs lang
-          -> DefunCallsCtx lang (PrtUnorderedDefs lang)
+defunFuns ::
+  (LanguagePretty lang, Pretty (FunDef lang), LanguageBuiltins lang) =>
+  PrtUnorderedDefs lang ->
+  DefunCallsCtx lang (PrtUnorderedDefs lang)
 defunFuns defs = defunCalls toDefun defs'
   where
     (defs', toDefun) = runWriter $ traverseDefs defunFunDef defs
 
-    defunFunDef name (DFunDef FunDef{..}) =  do
+    defunFunDef name (DFunDef FunDef {..}) = do
       when changed $ tell $ M.singleton name hofs
       pure $ DFunDef $ FunDef funIsRec funBody' funTy'
       where
         (funTy', hofs) = rewriteHofType funTy
         changed = funTy' /= funTy
-        funBody' | changed = rewriteHofBody funBody
-                 | otherwise = funBody
+        funBody'
+          | changed = rewriteHofBody funBody
+          | otherwise = funBody
     defunFunDef _ x = pure x
 
 -- * Closure type generation
@@ -108,16 +116,18 @@ defunFuns defs = defunCalls toDefun defs'
 mkClosureTypes :: (Language lang) => [ClosureCtorInfo lang] -> Decls lang
 mkClosureTypes infos = M.fromList $ typeDecls <> ctorDecls <> dtorDecls
   where
-    types = M.toList $ M.fromListWith (<>) [ (closureTypeName $ hofType $ hofArgInfo info, [info]) | info <- infos ]
-    typeDecls = [ (tyName, typeDecl)
-                | (tyName, infos') <- types
-                , let info2ctor ClosureCtorInfo{..} = (ctorName, foldr SystF.TyFun (SystF.Free (TySig tyName) `SystF.TyApp` []) ctorArgs)
-                , let typeDecl = DTypeDef $ Datatype SystF.KStar [] (dtorName tyName) (info2ctor <$> sortOn ctorIdx infos')
-                ]
-    ctorDecls = [ (ctorName, DConstructor ctorIdx $ closureTypeName hofType)
-                | ClosureCtorInfo { hofArgInfo = DefunHofArgInfo{..}, ..} <- infos
-                ]
-    dtorDecls = [ (dtorName tyName, DDestructor tyName) | tyName <- fst <$> types ]
+    types = M.toList $ M.fromListWith (<>) [(closureTypeName $ hofType $ hofArgInfo info, [info]) | info <- infos]
+    typeDecls =
+      [ (tyName, typeDecl)
+        | (tyName, infos') <- types,
+          let info2ctor ClosureCtorInfo {..} = (ctorName, foldr SystF.TyFun (SystF.Free (TySig tyName) `SystF.TyApp` []) ctorArgs),
+          let typeDecl = DTypeDef $ Datatype SystF.KStar [] (dtorName tyName) (info2ctor <$> sortOn ctorIdx infos')
+      ]
+    ctorDecls =
+      [ (ctorName, DConstructor ctorIdx $ closureTypeName hofType)
+        | ClosureCtorInfo {hofArgInfo = DefunHofArgInfo {..}, ..} <- infos
+      ]
+    dtorDecls = [(dtorName tyName, DDestructor tyName) | tyName <- fst <$> types]
 
 dtorName :: Name -> Name
 dtorName tyName = [i|#{tyName}_match|]
@@ -127,20 +137,22 @@ dtorName tyName = [i|#{tyName}_match|]
 mkApplyFuns :: (Language lang) => [ClosureCtorInfo lang] -> Decls lang
 mkApplyFuns infos = M.fromList funDecls
   where
-    funs = M.toList $ M.fromListWith (<>) [ (applyFunName $ hofType $ hofArgInfo info, [info]) | info <- infos ]
+    funs = M.toList $ M.fromListWith (<>) [(applyFunName $ hofType $ hofArgInfo info, [info]) | info <- infos]
 
-    funDecls = [ (funName, DFunDef $ FunDef NonRec funBody funTy)
-               | (funName, infos') <- funs
-               , let DefunHofArgInfo{..} = hofArgInfo $ head infos'
-               , let closTy = closureType hofType
-               , let funTy = closTy `SystF.TyFun` hofType
-               , let (_, resTy) = flattenType hofType
-               , let funBody = let closArgIdx = SystF.TermArg $ SystF.Bound (SystF.Ann "cls") 0 `SystF.App` []
-                                   dtorResTy = SystF.TyArg resTy
-                                   dtor = SystF.Free (TermSig $ dtorName $ closureTypeName hofType)
-                                in SystF.Lam (SystF.Ann "cls") closTy $ dtor `SystF.App` (closArgIdx : dtorResTy : (SystF.TermArg . mkDtorBranch <$> infos'))
-               ]
-    mkDtorBranch ClosureCtorInfo{..} = foldr (SystF.Lam (SystF.Ann "ctx")) hofTerm ctorArgs
+    funDecls =
+      [ (funName, DFunDef $ FunDef NonRec funBody funTy)
+        | (funName, infos') <- funs,
+          let DefunHofArgInfo {..} = hofArgInfo $ head infos',
+          let closTy = closureType hofType,
+          let funTy = closTy `SystF.TyFun` hofType,
+          let (_, resTy) = flattenType hofType,
+          let funBody =
+                let closArgIdx = SystF.TermArg $ SystF.Bound (SystF.Ann "cls") 0 `SystF.App` []
+                    dtorResTy = SystF.TyArg resTy
+                    dtor = SystF.Free (TermSig $ dtorName $ closureTypeName hofType)
+                 in SystF.Lam (SystF.Ann "cls") closTy $ dtor `SystF.App` (closArgIdx : dtorResTy : (SystF.TermArg . mkDtorBranch <$> infos'))
+      ]
+    mkDtorBranch ClosureCtorInfo {..} = foldr (SystF.Lam (SystF.Ann "ctx")) hofTerm ctorArgs
 
 -- * Defunctionalization of function call sites
 
@@ -150,23 +162,26 @@ newtype DefunState lang = DefunState
   deriving (Show)
 
 data ClosureCtorInfo lang = ClosureCtorInfo
-  { hofArgInfo :: DefunHofArgInfo lang
-  , ctorIdx :: Int
-  , ctorName :: Name
-  , ctorArgs :: [Type lang]
-  , hofTerm :: Term lang
+  { hofArgInfo :: DefunHofArgInfo lang,
+    ctorIdx :: Int,
+    ctorName :: Name,
+    ctorArgs :: [Type lang],
+    hofTerm :: Term lang
   }
 
 type DefunCallsCtx lang = RWS () [ClosureCtorInfo lang] (DefunState lang)
 
-defunCalls :: forall lang. (Language lang)
-           => M.Map Name (HofsList lang)
-           -> PrtUnorderedDefs lang
-           -> DefunCallsCtx lang (PrtUnorderedDefs lang)
-defunCalls toDefun PrtUnorderedDefs{..} = do
+defunCalls ::
+  forall lang.
+  (Language lang) =>
+  M.Map Name (HofsList lang) ->
+  PrtUnorderedDefs lang ->
+  DefunCallsCtx lang (PrtUnorderedDefs lang)
+defunCalls toDefun PrtUnorderedDefs {..} = do
   mainTerm' <- defunCallsInTerm prtUOMainTerm
-  decls' <- for prtUODecls $ \case DFunction r body ty -> (\body' -> DFunction r body' ty) <$> defunCallsInTerm body
-                                   def -> pure def
+  decls' <- for prtUODecls $ \case
+    DFunction r body ty -> (\body' -> DFunction r body' ty) <$> defunCallsInTerm body
+    def -> pure def
   pure $ PrtUnorderedDefs decls' mainTerm'
   where
     defunCallsInTerm :: Term lang -> DefunCallsCtx lang (Term lang)
@@ -177,40 +192,45 @@ defunCalls toDefun PrtUnorderedDefs{..} = do
           args' <- mapM (SystF.argElim (pure . SystF.TyArg) (fmap SystF.TermArg . go ctx)) args
           goApp ctx term args'
         go ctx (SystF.Lam ann ty term) = SystF.Lam ann ty <$> go ((FlatTermArg ty, ann) : ctx) term
-        go ctx (SystF.Abs ann k  term) = SystF.Abs ann k  <$> go ((FlatTyArg k, ann) : ctx) term
+        go ctx (SystF.Abs ann k term) = SystF.Abs ann k <$> go ((FlatTyArg k, ann) : ctx) term
 
         goApp ctx (SystF.Free (TermSig name)) args
           | Just hofsList <- M.lookup name toDefun = do
-            args' <- forM (zip3 [0..] hofsList args) (replaceArg ctx)
+            args' <- forM (zip3 [0 ..] hofsList args) (replaceArg ctx)
             pure $ SystF.Free (TermSig name) `SystF.App` args'
         goApp _ term args = pure $ term `SystF.App` args
 
-    replaceArg :: [(FlatArgType lang, SystF.Ann Name)]
-               -> (Integer, Maybe (DefunHofArgInfo lang), Arg lang)
-               -> DefunCallsCtx lang (Arg lang)
+    replaceArg ::
+      [(FlatArgType lang, SystF.Ann Name)] ->
+      (Integer, Maybe (DefunHofArgInfo lang), Arg lang) ->
+      DefunCallsCtx lang (Arg lang)
     replaceArg ctx (_, Just hofArgInfo, SystF.TermArg lam@SystF.Lam {}) = mkClosureArg ctx hofArgInfo lam
-    replaceArg _   (_, _, arg) = pure arg
+    replaceArg _ (_, _, arg) = pure arg
 
-mkClosureArg :: (LanguagePretty lang, LanguageBuiltins lang)
-             => [(FlatArgType lang, SystF.Ann Name)]
-             -> DefunHofArgInfo lang
-             -> Term lang
-             -> DefunCallsCtx lang (Arg lang)
-mkClosureArg ctx hofArgInfo@DefunHofArgInfo{..} lam = do
+mkClosureArg ::
+  (LanguagePretty lang, LanguageBuiltins lang) =>
+  [(FlatArgType lang, SystF.Ann Name)] ->
+  DefunHofArgInfo lang ->
+  Term lang ->
+  DefunCallsCtx lang (Arg lang)
+mkClosureArg ctx hofArgInfo@DefunHofArgInfo {..} lam = do
   ctorIdx <- newCtorIdx $ closureType hofType
   let ctorName = [i|#{closureTypeName hofType}_ctor_#{ctorIdx}|]
-  tell [ClosureCtorInfo{hofTerm = remapFreeDeBruijns free2closurePos lam, ..}]
-  pure $ SystF.TermArg $ SystF.Free (TermSig ctorName) `SystF.App` [ SystF.TermArg $ SystF.Bound (snd $ ctx !! fromIntegral idx) idx `SystF.App` [] | idx <- frees ]
+  tell [ClosureCtorInfo {hofTerm = remapFreeDeBruijns free2closurePos lam, ..}]
+  pure $ SystF.TermArg $ SystF.Free (TermSig ctorName) `SystF.App` [SystF.TermArg $ SystF.Bound (snd $ ctx !! fromIntegral idx) idx `SystF.App` [] | idx <- frees]
   where
     frees = collectFreeDeBruijns lam
-    free2closurePos = M.fromList [ (freeIdx, closurePos)
-                                 | freeIdx <- frees
-                                 | closurePos <- reverse [0 .. fromIntegral $ length frees - 1]
-                                 ]
+    free2closurePos =
+      M.fromList
+        [ (freeIdx, closurePos)
+          | freeIdx <- frees
+          | closurePos <- reverse [0 .. fromIntegral $ length frees - 1]
+        ]
     ctorArgs = (\(FlatTermArg ty) -> ty) . fst . (ctx !!) . fromIntegral <$> frees
 
-collectFreeDeBruijns :: Term lang
-                     -> [Integer]
+collectFreeDeBruijns ::
+  Term lang ->
+  [Integer]
 collectFreeDeBruijns = nub . go 0
   where
     go cutoff (SystF.App var args) = checkVar cutoff var <> foldMap (SystF.argElim (const mempty) (go cutoff)) args
@@ -220,14 +240,15 @@ collectFreeDeBruijns = nub . go 0
     checkVar cutoff (SystF.Bound _ n) | n >= cutoff = [n - cutoff]
     checkVar _ _ = mempty
 
-remapFreeDeBruijns :: M.Map Integer Integer
-                   -> Term lang
-                   -> Term lang
+remapFreeDeBruijns ::
+  M.Map Integer Integer ->
+  Term lang ->
+  Term lang
 remapFreeDeBruijns mapping = go 0
   where
     go cutoff (SystF.App var args) = remapVar cutoff var `SystF.App` (SystF.argElim SystF.TyArg (SystF.TermArg . go cutoff) <$> args)
     go cutoff (SystF.Lam ann ty term) = SystF.Lam ann ty $ go (cutoff + 1) term
-    go cutoff (SystF.Abs ann k  term) = SystF.Abs ann k  $ go (cutoff + 1) term
+    go cutoff (SystF.Abs ann k term) = SystF.Abs ann k $ go (cutoff + 1) term
 
     remapVar cutoff (SystF.Bound _ n) | n >= cutoff = SystF.Bound (SystF.Ann "ctx") $ cutoff + mapping M.! (n - cutoff)
     remapVar _ v = v
@@ -235,30 +256,33 @@ remapFreeDeBruijns mapping = go 0
 newCtorIdx :: LanguageBuiltins lang => B.Type lang -> DefunCallsCtx lang Int
 newCtorIdx ty = do
   idx <- gets $ M.findWithDefault 0 ty . closureType2Idx
-  modify' $ \st -> st { closureType2Idx = M.insert ty (idx + 1) $ closureType2Idx st }
+  modify' $ \st -> st {closureType2Idx = M.insert ty (idx + 1) $ closureType2Idx st}
   pure idx
 
 -- * Defunctionalization of function definitions
 
 type HofsList lang = [Maybe (DefunHofArgInfo lang)]
 
-traverseDefs :: Monad m
-             => (Name -> Definition lang -> m (Definition lang))
-             -> PrtUnorderedDefs lang
-             -> m (PrtUnorderedDefs lang)
+traverseDefs ::
+  Monad m =>
+  (Name -> Definition lang -> m (Definition lang)) ->
+  PrtUnorderedDefs lang ->
+  m (PrtUnorderedDefs lang)
 traverseDefs f defs = do
   decls' <- forM defsList $ \(name, def) -> (name,) <$> f name def
-  pure $ defs { prtUODecls = M.fromList decls' }
+  pure $ defs {prtUODecls = M.fromList decls'}
   where
     defsList = M.toList $ prtUODecls defs
 
-newtype DefunHofArgInfo lang = DefunHofArgInfo { hofType :: B.Type lang } deriving (Show, Eq, Ord)
+newtype DefunHofArgInfo lang = DefunHofArgInfo {hofType :: B.Type lang} deriving (Show, Eq, Ord)
 
 -- Changes the type of the form @Ty1 -> (Ty2 -> Ty3) -> Ty4@ to @Ty1 -> Closure[Ty2->Ty3] -> Ty4@
 -- where the @Closure[Ty2->Ty3]@ is the ADT with the labels and environments for the funargs of type @Ty2 -> Ty3@.
-rewriteHofType :: forall lang. (LanguagePretty lang, LanguageBuiltins lang)
-               => B.Type lang
-               -> (B.Type lang, HofsList lang)
+rewriteHofType ::
+  forall lang.
+  (LanguagePretty lang, LanguageBuiltins lang) =>
+  B.Type lang ->
+  (B.Type lang, HofsList lang)
 rewriteHofType = go 0
   where
     go :: Integer -> B.Type lang -> (B.Type lang, [Maybe (DefunHofArgInfo lang)])
@@ -267,24 +291,25 @@ rewriteHofType = go 0
         (cod', applies) = go (pos + 1) cod
         (dom', posApply) =
           case dom of
-               SystF.TyFun{} -> (closureType dom, Just $ DefunHofArgInfo dom)
-               _ -> (dom, Nothing)
-    go _    ty@SystF.TyApp{} = (ty, []) -- this doesn't defun things like `List (foo -> bar)`, which is fine for now
+            SystF.TyFun {} -> (closureType dom, Just $ DefunHofArgInfo dom)
+            _ -> (dom, Nothing)
+    go _ ty@SystF.TyApp {} = (ty, []) -- this doesn't defun things like `List (foo -> bar)`, which is fine for now
     go pos (SystF.TyAll ann k ty) = SystF.TyAll ann k *** (Nothing :) $ go (pos + 1) ty
     go pos (SystF.TyLam ann k ty) = error "unexpected arg type" -- TODO mention the type
 
 -- Assumes the body is normalized enough so that all the binders are at the front.
 -- Dis-assuming this is merely about recursing on `App` ctor as well.
-rewriteHofBody :: (LanguagePretty lang, LanguageBuiltins lang)
-               => B.Term lang
-               -> B.Term lang
+rewriteHofBody ::
+  (LanguagePretty lang, LanguageBuiltins lang) =>
+  B.Term lang ->
+  B.Term lang
 rewriteHofBody = go
   where
-    go e@SystF.App{} = e
+    go e@SystF.App {} = e
     go (SystF.Abs ann kd body) = SystF.Abs ann kd $ go body
     go (SystF.Lam ann ty body) = case ty of
-                                      SystF.TyFun{} -> SystF.Lam ann (closureType ty) $ replaceApply (applyFunName ty) $ go body
-                                      _ -> SystF.Lam ann ty $ go body
+      SystF.TyFun {} -> SystF.Lam ann (closureType ty) $ replaceApply (applyFunName ty) $ go body
+      _ -> SystF.Lam ann ty $ go body
 
 replaceApply :: Name -> B.Term lang -> B.Term lang
 replaceApply applyFun = go 0
@@ -292,13 +317,14 @@ replaceApply applyFun = go 0
     go idx (SystF.Lam ann ty body) = SystF.Lam ann ty $ go (idx + 1) body
     go idx (SystF.Abs ann kd body) = SystF.Abs ann kd $ go (idx + 1) body
     go idx (SystF.App var args)
-      | SystF.Bound _ n <- var
-      , n == idx
-      , not $ null args = SystF.App (SystF.Free (TermSig applyFun)) (SystF.TermArg (SystF.App var []) : args')
+      | SystF.Bound _ n <- var,
+        n == idx,
+        not $ null args =
+        SystF.App (SystF.Free (TermSig applyFun)) (SystF.TermArg (SystF.App var []) : args')
       | otherwise = SystF.App var args'
       where
         args' = recurArg <$> args
-        recurArg arg@SystF.TyArg{} = arg
+        recurArg arg@SystF.TyArg {} = arg
         recurArg (SystF.TermArg arg) = SystF.TermArg $ go idx arg
 
 closureTypeName :: (LanguagePretty lang, LanguageBuiltins lang) => B.Type lang -> Name
@@ -312,6 +338,8 @@ closureType ty = SystF.Free (TySig $ closureTypeName ty) `SystF.TyApp` []
 
 funTyStr :: (LanguagePretty lang, LanguageBuiltins lang) => B.Type lang -> T.Text
 funTyStr (dom `SystF.TyFun` cod) = funTyStr dom <> " => " <> funTyStr cod
-funTyStr app@SystF.TyApp{} = argsToStr [app]
-funTyStr ty = error $ "unexpected arg type during defunctionalization:\n"
-                   <> renderSingleLineStr (pretty ty)
+funTyStr app@SystF.TyApp {} = argsToStr [app]
+funTyStr ty =
+  error $
+    "unexpected arg type during defunctionalization:\n"
+      <> renderSingleLineStr (pretty ty)

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Pirouette.Transformations.Utils where
 
@@ -13,57 +13,59 @@ import Data.Data
 import Data.Generics.Uniplate.Data
 import qualified Data.Map as M
 import qualified Data.Text as T
-import Prettyprinter hiding (Pretty, pretty)
-
 import Debug.Trace
-
 import Pirouette.Monad
 import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.SystemF hiding (Arg)
 import qualified Pirouette.Term.Syntax.SystemF as SystF
+import Prettyprinter hiding (Pretty, pretty)
 
 traceDefsId :: (LanguagePretty lang) => PrtUnorderedDefs lang -> PrtUnorderedDefs lang
 traceDefsId defs = renderSingleLineStr (pretty $ prtUODecls defs) `trace` defs
 
 data HofDefBody lang
   = HDBType (TypeDef lang)
-  | HDBFun  (FunDef lang)
+  | HDBFun (FunDef lang)
   deriving (Show, Eq, Ord)
 
 data HofDef lang = HofDef
-  { hofDefName :: Name
-  , hofDefBody :: HofDefBody lang
+  { hofDefName :: Name,
+    hofDefBody :: HofDefBody lang
   }
   deriving (Show, Eq, Ord)
 
 type HOFDefs lang = M.Map Name (HofDef lang)
 
-findFuns :: LanguageBuiltins lang
-         => [(Name, Definition lang)]
-         -> (FunDef lang -> Bool)
-         -> [(Name, HofDef lang)]
+findFuns ::
+  LanguageBuiltins lang =>
+  [(Name, Definition lang)] ->
+  (FunDef lang -> Bool) ->
+  [(Name, HofDef lang)]
 findFuns declsPairs funPred =
   [ (name, HofDef name $ HDBFun funDef)
-  | (name, DFunDef funDef) <- declsPairs
-  , funPred funDef
+    | (name, DFunDef funDef) <- declsPairs,
+      funPred funDef
   ]
 
-findTypes :: LanguageBuiltins lang
-          => [(Name, Definition lang)]
-          -> (Name -> TypeDef lang -> Bool)
-          -> [(Name, HofDef lang)]
+findTypes ::
+  LanguageBuiltins lang =>
+  [(Name, Definition lang)] ->
+  (Name -> TypeDef lang -> Bool) ->
+  [(Name, HofDef lang)]
 findTypes declsPairs tyPred =
   [ (name, HofDef tyName $ HDBType typeDef)
-  | (tyName, DTypeDef typeDef) <- declsPairs
-  , tyPred tyName typeDef
-  , name <- tyName : destructor typeDef : (fst <$> constructors typeDef)
+    | (tyName, DTypeDef typeDef) <- declsPairs,
+      tyPred tyName typeDef,
+      name <- tyName : destructor typeDef : (fst <$> constructors typeDef)
   ]
 
-findHOFDefs :: forall lang. LanguageBuiltins lang
-            => (FunDef lang -> Bool)
-            -> (Name -> TypeDef lang -> Bool)
-            -> [(Name, Definition lang)]
-            -> HOFDefs lang
+findHOFDefs ::
+  forall lang.
+  LanguageBuiltins lang =>
+  (FunDef lang -> Bool) ->
+  (Name -> TypeDef lang -> Bool) ->
+  [(Name, Definition lang)] ->
+  HOFDefs lang
 findHOFDefs funPred tyPred declsPairs =
   M.fromList $ findFuns declsPairs funPred' <> findTypes declsPairs tyPred'
   where
@@ -72,7 +74,7 @@ findHOFDefs funPred tyPred declsPairs =
     tyPred' name typeDef = tyPred name typeDef && (hasHOFuns . snd) `any` constructors typeDef
 
 hasHOFuns :: (Data ann, Data ty) => AnnType ann ty -> Bool
-hasHOFuns ty = isHOFTy `any` [ f | f@TyFun {} <- universe ty ]
+hasHOFuns ty = isHOFTy `any` [f | f@TyFun {} <- universe ty]
 
 isHOFTy :: AnnType ann ty -> Bool
 isHOFTy (TyFun TyFun {} _) = True
@@ -86,12 +88,13 @@ data FlatArgType lang
   deriving (Show)
 
 flattenType :: Type lang -> ([FlatArgType lang], Type lang)
-flattenType ty@TyApp{} = ([], ty)
+flattenType ty@TyApp {} = ([], ty)
 flattenType (dom `TyFun` cod) = first (FlatTermArg dom :) $ flattenType cod
 flattenType (TyAll _ k ty) = first (FlatTyArg k :) $ flattenType ty
-flattenType TyLam{} = error "unnormalized type"
+flattenType TyLam {} = error "unnormalized type"
 
 -- * @splitArgs n args@ splits @args@ into the first @n@ type arguments and everything else.
+
 --
 -- For instance, @splitArgs 2 [Arg a, TyArg A, TyArg B, Arg b, TyArg C]@
 -- yields @([A, B], [Arg a, Arg b, TyArg C])@.
@@ -111,7 +114,7 @@ argsToStr = T.intercalate "@" . map f
 -- This really belongs to a Pretty module, but we need them here for nicer debugging anyway for now.
 instance (Pretty (BuiltinTypes lang), Pretty (FunDef lang)) => Pretty (HofDefBody lang) where
   pretty (HDBType defn) = "<typ>" <+> pretty defn
-  pretty (HDBFun  defn) = "<fun>" <+> pretty defn
+  pretty (HDBFun defn) = "<fun>" <+> pretty defn
 
 instance (Pretty (BuiltinTypes lang), Pretty (FunDef lang)) => Pretty (HofDef lang) where
   pretty = pretty . hofDefBody


### PR DESCRIPTION
Our eta-expansion did not distinguish well between type and term variables. I fixed it (it makes tests on eta to success).
However, I do not understand why Ormolu made such a difference in the files, I thought Ormolu was applied by default to all our commits.