### PR TITLE
Fix monomorphization bugs

### DIFF
--- a/src/Language/Pirouette/Example/Syntax.hs
+++ b/src/Language/Pirouette/Example/Syntax.hs
@@ -295,8 +295,7 @@ parseBinder binder parseVars parseBody = do
   vars <- parseVars
   guard (not $ null vars)
   b <- parseBody
-  let (n0, k0) : rest = reverse vars
-  return $ foldr (\(n, k) b' -> binder n k b') (binder n0 k0 b) rest
+  return $ foldr (uncurry binder) b vars
 
 lexeme :: Parser a -> Parser a
 lexeme = L.lexeme spaceConsumer
@@ -309,7 +308,7 @@ symbol = void . L.symbol spaceConsumer
 
 ident :: Parser String
 ident = label "identifier" $ do
-  i <- lexeme ((:) <$> lowerChar <*> many (alphaNumChar <|> char '_'))
+  i <- lexeme ((:) <$> lowerChar <*> many (alphaNumChar <|> char '_' <|> char '@'))
   guard (i `S.notMember` reservedNames)
   return i
   where
@@ -318,7 +317,7 @@ ident = label "identifier" $ do
 
 typeName :: Parser String
 typeName = label "type-identifier" $ do
-  t <- lexeme ((:) <$> upperChar <*> many (alphaNumChar <|> char '_'))
+  t <- lexeme ((:) <$> upperChar <*> many (alphaNumChar <|> char '_' <|> char '@'))
   guard (t `S.notMember` reservedTypeNames)
   return t
   where

--- a/src/Language/Pirouette/Example/Syntax.hs
+++ b/src/Language/Pirouette/Example/Syntax.hs
@@ -41,6 +41,7 @@ import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
+import Pirouette.Transformations.Utils (monoNameSep)
 
 -- * AST
 
@@ -308,7 +309,7 @@ symbol = void . L.symbol spaceConsumer
 
 ident :: Parser String
 ident = label "identifier" $ do
-  i <- lexeme ((:) <$> lowerChar <*> many (alphaNumChar <|> char '_' <|> char '@'))
+  i <- lexeme ((:) <$> lowerChar <*> restOfName)
   guard (i `S.notMember` reservedNames)
   return i
   where
@@ -317,9 +318,12 @@ ident = label "identifier" $ do
 
 typeName :: Parser String
 typeName = label "type-identifier" $ do
-  t <- lexeme ((:) <$> upperChar <*> many (alphaNumChar <|> char '_' <|> char '@'))
+  t <- lexeme ((:) <$> upperChar <*> restOfName)
   guard (t `S.notMember` reservedTypeNames)
   return t
   where
     reservedTypeNames :: S.Set String
     reservedTypeNames = S.fromList ["Integer", "Bool", "Type"]
+
+restOfName :: Parser String
+restOfName = many (alphaNumChar <|> char '_' <|> char monoNameSep)

--- a/src/Pirouette/Term/Syntax/SystemF.hs
+++ b/src/Pirouette/Term/Syntax/SystemF.hs
@@ -64,6 +64,16 @@ instance IsVar (VarMeta meta ann f) where
 data Kind = KStar | KTo Kind Kind
   deriving (Eq, Ord, Show, Data, Typeable)
 
+-- | Drop the n first arguments of a kind:
+--
+-- > kindDrop 1 (* -> (* -> *) -> * -> *) == (* -> *) -> * -> *
+-- > kindDrop 2 (* -> (* -> *) -> * -> *) == * -> *
+-- > kindDrop 3 (* -> (* -> *) -> * -> *) == *
+kindDrop :: Int -> Kind -> Kind
+kindDrop 0 k = k
+kindDrop n (KTo _ k) = kindDrop (n-1) k
+kindDrop _ _ = error "kindDrop: KStar has no arguments to drop"
+
 -- ** Types
 
 data AnnType ann tyVar

--- a/src/Pirouette/Transformations/Monomorphization.hs
+++ b/src/Pirouette/Transformations/Monomorphization.hs
@@ -8,8 +8,21 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE LambdaCase #-}
 
-module Pirouette.Transformations.Monomorphization (monomorphize, hofsClosure, findPolyHOFDefs, specFunApp, SpecRequest (..)) where
+module Pirouette.Transformations.Monomorphization
+  (
+    -- * Actual functionality
+    monomorphize,
+    -- * Exported for testing
+    hofsClosure,
+    findPolyHOFDefs,
+    specFunApp,
+    specTyApp,
+    executeSpecRequest,
+    SpecRequest (..),
+  )
+where
 
 import Control.Monad.Writer.Strict
 import Data.Data
@@ -22,6 +35,9 @@ import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.Subst
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Transformations.Utils
+
+import Debug.Trace
+import Data.List (isPrefixOf)
 
 -- * Monomorphization
 
@@ -156,11 +172,17 @@ executeSpecRequest SpecRequest {origDef = HofDef {..}, ..} = M.fromList $
       let tyName = fixName hofDefName
           dtorName = fixName destructor
           ctors =
-            [ (fixName ctorName, ctorTy `SystF.tyInstantiateN` specArgs)
+            [ (fixName ctorName, fixType $ ctorTy `SystF.tyInstantiateN` specArgs)
               | (ctorName, ctorTy) <- constructors
             ]
-          newDef = DTypeDef $ Datatype kind [] (fixName destructor) ctors -- TODO does this only apply to `kind ~ *`?
-       in [ (tyName, newDef),
+          newDef =
+            DTypeDef $
+              Datatype
+                (SystF.kindDrop specArgsLen kind)
+                (drop specArgsLen typeVariables)
+                (fixName destructor)
+                ctors -- TODO does this only apply to `kind ~ *`?
+       in trace (show specArgs) $ [ (tyName, newDef),
             (dtorName, DDestructor tyName)
           ]
             <> [ (ctorName, DConstructor i tyName)
@@ -169,31 +191,54 @@ executeSpecRequest SpecRequest {origDef = HofDef {..}, ..} = M.fromList $
                ]
   where
     fixName = genSpecName specArgs
+    specArgsLen = length specArgs
+
+    -- When specializing constructor types, we need to substitute occurences of
+    -- the un-specialized type with the fixed name. For instance, if we're specializing
+    -- a constructor:
+    --
+    -- > Bin : all a : Type . Bin a -> Bin a -> Bin a
+    --
+    -- that was applied to TyBool, the result has to be:
+    --
+    -- > Bin@TyBool : Bin@TyBool -> Bin@TyBool -> Bin@TyBool
+    --
+    fixType = rewrite $ \case
+      SystF.TyApp (SystF.Free (TySig n)) xs -> do
+        guard (n == hofDefName && specArgs `isPrefixOf` xs)
+        return $ SystF.Free (TySig $ fixName n) `SystF.TyApp` drop specArgsLen xs
+      _ -> Nothing
 
 -- | Specializes a function application of the form:
 --
---  > hof @Integer x y z
+--  > hof @Integer @Bool x y z
 --
 -- at call site, where @hof@ has been identified as
 -- 1. either a higher-order function itself,
 -- 2. or invoking a polymorphic higher-order function, perhaps, transitively;
 -- and its type argument contains no bound-variables: in other words,
--- we can substitute that call with @hof_Integer@ while creating a monomorphic
+-- we can substitute that call with @hof\@Integer\@Bool@ while creating a monomorphic
 -- definition for @hof@.
+--
+-- We only specialize type arguments that appear /before/ the first term-argument.
 --
 -- This function only does the substitution _at call site_ and emits a 'SpecRequest' denoting that the corresponding
 -- higher-order _definition_ needs to be specialized (which will be handled later by 'executeSpecRequest').
 specFunApp :: forall lang. (LanguageBuiltins lang) => HOFDefs lang -> SpecFunApp lang
 specFunApp hofDefs (SystF.App (SystF.Free (TermSig name)) args)
-  | Just someDef <- name `M.lookup` hofDefs, -- We compare the entire name, not just the nameString part: x0 /= x1.
-    all isSpecArg $ take hofPolyVarsCount tyArgs = do
+  -- We compare the entire name, not just the nameString part: x0 /= x1.
+  | Just someDef <- name `M.lookup` hofDefs,
+    -- Now we ensure that there is something to specialize and that the type arguments we've
+    -- gathered are specializable arguments (ie, no bound type-variables)
+    hofPolyVarsCount >= 1,
+    all isSpecArg tyArgs = do
     let (specArgs, remainingArgs) = splitArgs hofPolyVarsCount args
         speccedName = genSpecName specArgs name
     tell $ pure $ SpecRequest someDef specArgs
     pure $ SystF.Free (TermSig speccedName) `SystF.App` remainingArgs
   where
-    tyArgs = mapMaybe SystF.fromTyArg args
-    hofPolyVarsCount = 1 -- TODO don't hardcode 1
+    tyArgs = map (fromJust . SystF.fromTyArg) $ takeWhile SystF.isTyArg args
+    hofPolyVarsCount = length tyArgs
 specFunApp _ x = pure x
 
 -- | Specializes a type application of the form
@@ -211,20 +256,15 @@ specFunApp _ x = pure x
 specTyApp :: (LanguageBuiltins lang) => HOFDefs lang -> SpecTyApp lang
 specTyApp hofDefs (SystF.TyApp (SystF.Free (TySig name)) tyArgs)
   | Just someDef <- name `M.lookup` hofDefs,
-    all isSpecArg $ take hofPolyVarsCount tyArgs = do
+    hofPolyVarsCount >= 1,
+    all isSpecArg tyArgs = do
     let (specArgs, remainingArgs) = splitAt hofPolyVarsCount tyArgs
         speccedName = genSpecName specArgs name
     tell $ pure $ SpecRequest someDef specArgs
     pure $ SystF.Free (TySig speccedName) `SystF.TyApp` remainingArgs
   where
-    hofPolyVarsCount = 1 -- TODO don't hardcode 1
+    hofPolyVarsCount = length tyArgs
 specTyApp _ x = pure x
-
--- TODO the above definition shouldn't have hofPolyVarsCount as the _count_,
--- since the HOF-involved type args aren't necessarily at the front of the application.
--- A smarter approach would be to keep a list of type variables need to be monomorphized,
--- but this kludge together with hardcoding it to be `1` gets us far enough
--- to work with SMT on some realistic examples.
 
 genSpecName :: (LanguageBuiltins lang) => [Type lang] -> Name -> Name
 genSpecName args name = Name (nameString name <> "@" <> argsToStr args) Nothing

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -101,9 +101,22 @@ splitArgs n (TyArg tyArg : args) = first (tyArg :) $ splitArgs (n - 1) args
 splitArgs n (arg : args) = second (arg :) $ splitArgs n args
 splitArgs _ [] = error "Less args than poly args count"
 
-argsToStr :: (LanguageBuiltins lang) => [Type lang] -> T.Text
-argsToStr = T.intercalate "@" . map f
+-- |This is the character used to separate the type arguments and the term or type name
+-- when monomorphizing. Because we need to be able to test monomorphization, this
+-- is also recognized by the "Language.Pirouette.Example" as a valid part of an identifier
+monoNameSep :: Char
+monoNameSep = '!'
+
+genSpecName :: (LanguageBuiltins lang) => [Type lang] -> Name -> Name
+genSpecName args name = Name (nameString name <> msep <> argsToStr args) Nothing
   where
+    msep = T.pack [monoNameSep]
+
+argsToStr :: (LanguageBuiltins lang) => [Type lang] -> T.Text
+argsToStr = T.intercalate msep . map f
+  where
+    msep = T.pack [monoNameSep]
+
     f (SystF.Free n `TyApp` args) =
       tyBaseString n <> if null args then mempty else "<" <> argsToStr args <> ">"
     f arg = error $ "unexpected specializing arg" <> show arg

--- a/tests/unit/Language/Pirouette/ExampleSpec.hs
+++ b/tests/unit/Language/Pirouette/ExampleSpec.hs
@@ -27,8 +27,8 @@ tests =
       canParseType [ty| all a : Type . a -> all b : Type . a -> Integer |]
       canParseType [ty| all a : Type . a -> all b : (Type -> Type) . Integer -> b a -> Integer |],
      testCase "Type binders with or without parenthesis" $ do
-          let t1 = [ty| \(x : Type) (y : Type) . F x y |]
-              t2 = [ty| \(x : Type) . \(y : Type) . F x y |]
+          let t1 = [ty| \(x : Type) (y : Type) (z : Type) . F x y |]
+              t2 = [ty| \(x : Type) . \(y : Type) . \(z : Type) . F x y |]
            in (t1 :: Type Ex) @?= t2 ,
     testGroup
       "Can parse terms"

--- a/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
@@ -79,10 +79,10 @@ tests =
       "specFunApp"
       [ testCase "specFunApp (id @Bool True) == (id@Bool True, [SpecRequest ...])" $
            runWriter (specFunApp (M.singleton "id" idDef) [term| id @Bool True |])
-                @?= ([term| id@TyBool True |], [SpecRequest idDef [[ty| Bool |]]]),
-        testCase "specFunApp (const @Integer @Bool 42 False) == (const@Integer@Bool 42 False, [SpecRequest ...])" $
+                @?= ([term| id!TyBool True |], [SpecRequest idDef [[ty| Bool |]]]),
+        testCase "specFunApp (const @Integer @Bool 42 False) == (const!Integer!Bool 42 False, [SpecRequest ...])" $
            runWriter (specFunApp (M.singleton "const" constDef) [term| const @Integer @Bool 42 True |])
-                @?= ([term| const@TyInteger@TyBool 42 True |], [SpecRequest constDef [[ty| Integer |], [ty| Bool |]]])
+                @?= ([term| const!TyInteger!TyBool 42 True |], [SpecRequest constDef [[ty| Integer |], [ty| Bool |]]])
       ],
     testGroup
       "executeSpecRequest"
@@ -122,21 +122,21 @@ either3Def =
 either3Def_Bool_Integer_decls :: Decls Ex
 either3Def_Bool_Integer_decls =
   M.fromList
-    [ ( "Either3@TyBool@TyInteger",
+    [ ( "Either3!TyBool!TyInteger",
         DTypeDef
           Datatype
             { kind = SystF.KTo SystF.KStar SystF.KStar,
               typeVariables = [("c", SystF.KStar)],
-              destructor = "match_Either3@TyBool@TyInteger",
+              destructor = "match_Either3!TyBool!TyInteger",
               constructors =
-                [ ("Left@TyBool@TyInteger", [ty| all (c : Type) . Bool -> Either3@TyBool@TyInteger c |]),
-                  ("Mid@TyBool@TyInteger", [ty| all (c : Type) . Integer -> Either3@TyBool@TyInteger c |]),
-                  ("Right@TyBool@TyInteger", [ty| all (c : Type) . c -> Either3@TyBool@TyInteger c |])
+                [ ("Left!TyBool!TyInteger", [ty| all (c : Type) . Bool -> Either3!TyBool!TyInteger c |]),
+                  ("Mid!TyBool!TyInteger", [ty| all (c : Type) . Integer -> Either3!TyBool!TyInteger c |]),
+                  ("Right!TyBool!TyInteger", [ty| all (c : Type) . c -> Either3!TyBool!TyInteger c |])
                 ]
             }
       ),
-      ("match_Either3@TyBool@TyInteger", DDestructor "Either3@TyBool@TyInteger"),
-      ("Left@TyBool@TyInteger", DConstructor 0 "Either3@TyBool@TyInteger"),
-      ("Mid@TyBool@TyInteger", DConstructor 1 "Either3@TyBool@TyInteger"),
-      ("Right@TyBool@TyInteger", DConstructor 2 "Either3@TyBool@TyInteger")
+      ("match_Either3!TyBool!TyInteger", DDestructor "Either3!TyBool!TyInteger"),
+      ("Left!TyBool!TyInteger", DConstructor 0 "Either3!TyBool!TyInteger"),
+      ("Mid!TyBool!TyInteger", DConstructor 1 "Either3!TyBool!TyInteger"),
+      ("Right!TyBool!TyInteger", DConstructor 2 "Either3!TyBool!TyInteger")
     ]


### PR DESCRIPTION
This PR extends monomorphization to handle all type arguments before the first term argument; we can now fully monomorphize:

```haskell
const @Int @Bool x y
```

Which will replace the call site with `const@Int@Bool` and will produce a suitable definition.
We can't fully monomorphize:
```haskell
constWithWeirdArgs :: forall a . a -> forall b . -> b -> a

constWithWeirdArgs @Int x @Bool y
```

We will only monomoprhize the first type argument. It's unclear to me whether we want to produce a warning when we find definitions like `constWithWeirdArgs` above. Might be worthwhile for debugging purposes.

Additionally, this PR fixes important bugs in the computation of the types of monomorphized constructors and in the example parser.