### PR TITLE
Prenex transformation

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,8 @@ dependencies:
   - tasty-quickcheck
   - tasty-expected-failure
   - haskell-stack-trace-plugin
+  - optics-core
+  - optics-th
 
 library:
   source-dirs: src

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -48,6 +48,7 @@ library
       Pirouette.Transformations.Defunctionalization
       Pirouette.Transformations.EtaExpand
       Pirouette.Transformations.Monomorphization
+      Pirouette.Transformations.Prenex
       Pirouette.Transformations.Utils
   other-modules:
       Paths_pirouette
@@ -140,6 +141,7 @@ test-suite spec
       Pirouette.Term.TransformationsSpec
       Pirouette.Transformations.EtaExpandSpec
       Pirouette.Transformations.MonomorphizationSpec
+      Pirouette.Transformations.PrenexSpec
       Paths_pirouette
   hs-source-dirs:
       tests/unit

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -71,6 +71,8 @@ library
     , list-t
     , megaparsec
     , mtl >=2.2.2
+    , optics-core
+    , optics-th
     , optparse-applicative
     , parser-combinators
     , plutus-core
@@ -112,6 +114,8 @@ executable pirouette
     , list-t
     , megaparsec
     , mtl >=2.2.2
+    , optics-core
+    , optics-th
     , optparse-applicative
     , parser-combinators
     , pirouette
@@ -161,6 +165,8 @@ test-suite spec
     , list-t
     , megaparsec
     , mtl >=2.2.2
+    , optics-core
+    , optics-th
     , optparse-applicative
     , parser-combinators
     , pirouette

--- a/src/Pirouette/Monad.hs
+++ b/src/Pirouette/Monad.hs
@@ -189,7 +189,7 @@ data PrtUnorderedDefs lang = PrtUnorderedDefs
   { prtUODecls :: Decls lang,
     prtUOMainTerm :: Term lang
   }
-  deriving (Eq, Data)
+  deriving (Eq, Data, Show)
 
 addDecls :: Decls builtins -> PrtUnorderedDefs builtins -> PrtUnorderedDefs builtins
 addDecls decls defs = defs {prtUODecls = prtUODecls defs <> decls}

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |Provides the base syntactical elements for the languages supported by Pirouette.
@@ -22,6 +23,7 @@ import qualified Data.Set as Set
 import Data.String
 import qualified Data.Text as Text
 import Data.Void
+import Optics.TH
 import Pirouette.Term.Syntax.Pretty.Class
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 
@@ -302,3 +304,9 @@ type LanguagePretty lang =
 
 -- | Auxiliary constraint grouping everything we know about @lang@.
 type Language lang = (LanguageBuiltins lang, LanguagePretty lang)
+
+-- These must go at the end because of Template Haskell restrictions
+
+makePrisms ''Definition
+makePrisms ''TypeBase
+makePrisms ''TermBase

--- a/src/Pirouette/Term/Syntax/Subst.hs
+++ b/src/Pirouette/Term/Syntax/Subst.hs
@@ -61,11 +61,11 @@ class (IsVar (SubstVar term)) => HasSubst term where
   -- | How to apply a substitution
   subst :: HasCallStack => Sub term -> term -> term
 
-shiftCutoff :: (HasSubst term) => Integer -> Integer -> term -> term
-shiftCutoff cutoff k = subst $ foldr (\_ r -> Nothing :< r) (Inc k) [0 .. cutoff - 1]
+shiftFrom :: (HasSubst term) => Integer -> Integer -> term -> term
+shiftFrom cutoff k = subst $ foldr (\_ r -> Nothing :< r) (Inc k) [0 .. cutoff - 1]
 
 shift :: (HasSubst term) => Integer -> term -> term
-shift = shiftCutoff 0
+shift = shiftFrom 0
 
 -- | When traversing a binder, we want to leave Used in substitution when going under a binder
 liftSub :: Sub termv -> Sub termv

--- a/src/Pirouette/Transformations/Prenex.hs
+++ b/src/Pirouette/Transformations/Prenex.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Pirouette.Transformations.Prenex (prenex) where
+
+import qualified Data.Map as Map
+import Pirouette.Monad
+import Pirouette.Term.Syntax
+import qualified Pirouette.Term.Syntax.SystemF as SystemF
+
+-- | * Prenex form of types
+-- 
+-- This transformation tries to push the type abstractions
+-- (big lambdas /\ x : Type . ) to the front of terms,
+-- before any term abstractions (small lambdas \ x : Int . )
+--
+-- For example,
+--   /\ a : Type . \ x : a . /\ b : Type . \ y : b . ...
+-- is transformed to
+--   /\ a : Type . /\ b : Type . \ x : a . \ y : b . ...
+--
+-- This makes it easier for later transformations to apply
+-- on type abstractions. In fact, it's common to just bail
+-- out on non-prenex types in other transformations, because
+-- those cases are quite rare and difficult to handle
+-- (usually involving some impredicative types.)
+prenex :: 
+  PrtUnorderedDefs lang ->
+  PrtUnorderedDefs lang
+prenex PrtUnorderedDefs { prtUODecls, prtUOMainTerm } = do
+  -- this is done in two steps
+  -- step 1. prenexify the types and lambdas
+  let prenexDecls = Map.map prenexDefinitionLambdas prtUODecls
+  -- step 2. prenixify the bodies
+  PrtUnorderedDefs {
+    prtUODecls = Map.map (prenexDefinitionBody prenexDecls) prenexDecls,
+    prtUOMainTerm = prenexExpr prenexDecls prtUOMainTerm
+  }
+
+-- | Update the type and initial lambdas
+-- from a definition. This *must* be followed
+-- by 'prenexDefinitionBody' at a later point
+-- to make everything correct.
+prenexDefinitionLambdas ::
+  Definition lang ->
+  Definition lang
+prenexDefinitionLambdas = onlyOnFunDef $ \FunDef { .. } ->
+  let (newTy, newBody) = switchLambdas funTy funBody
+  in FunDef { funIsRec, funTy = newTy, funBody = newBody }
+
+-- invariant: in the result type all /\ appear before all \
+switchLambdas :: Type lang -> Term lang -> (Type lang, Term lang)
+-- this case pushes lambdas inwards
+-- \ x . /\ a . ty --> /\ a . \x . ty
+switchLambdas (SystemF.TyFun ty1 (SystemF.TyAll annTy kindTy restOfType)) 
+              (SystemF.Lam arg1 tyTm1 (SystemF.Abs annTm kindTm body))
+  = case switchLambdas (SystemF.TyFun ty1 restOfType) (SystemF.Lam arg1 tyTm1 body) of
+      (newTy, newBody) -> (SystemF.TyAll annTy kindTy newTy, SystemF.Abs annTm kindTm newBody)
+-- case of small lambda, we just need to keep the invariant (see *)
+switchLambdas (SystemF.TyFun ty1 ty2) (SystemF.Lam arg1 tyTm1 body)
+  = let (newTy, newBody) = switchLambdas ty2 body
+        newTy' = SystemF.TyFun ty1 newTy
+        newBody' = SystemF.Lam arg1 tyTm1 newBody
+    in case newTy of
+         -- (*) when we have a /\ on the top we are breaking the invariant
+         -- so run this again until everything is fine
+         SystemF.TyAll {} -> switchLambdas newTy' newBody'
+         _ -> (newTy', newBody')
+-- if we have a big lambda, just leave it
+switchLambdas (SystemF.TyAll annTy kindTy restOfType)
+              (SystemF.Abs annTm kindTm body)
+  = let (newTy, newBody) = switchLambdas restOfType body
+    in (SystemF.TyAll annTy kindTy newTy, SystemF.Abs annTm kindTm newBody)
+switchLambdas otherTy otherTm = (otherTy, otherTm)
+
+-- | Update the body of a definition
+-- with the prenex-ed types from 'newDecls'.
+prenexDefinitionBody ::
+  Decls lang ->
+  Definition lang ->
+  Definition lang
+prenexDefinitionBody newDecls = onlyOnFunDef $ \funDef ->
+  funDef { funBody = prenexExpr newDecls (funBody funDef) } 
+
+prenexExpr ::
+  forall lang.
+  Decls lang ->
+  Term lang ->
+  Term lang
+prenexExpr newDecls = goTerm
+  where 
+    goTerm :: Term lang -> Term lang
+    goTerm (SystemF.Lam ann ty body) = SystemF.Lam ann ty (goTerm body)
+    goTerm (SystemF.Abs ann ki body) = SystemF.Abs ann ki (goTerm body)
+    goTerm (SystemF.App hd args) =
+      let prenexArgs = map goArg args
+      in case hd of
+           -- we only change the applications of known names
+           SystemF.Free (TermSig name)
+             | Just (DFunDef FunDef { funTy }) <- Map.lookup name newDecls
+             -> SystemF.App hd (zipArgs prenexArgs funTy)
+           _other -> SystemF.App hd prenexArgs
+
+    goArg (SystemF.TermArg e) = SystemF.TermArg (goTerm e)
+    goArg (SystemF.TyArg ty) = SystemF.TyArg ty -- type arguments don't change
+
+    -- no more arguments
+    zipArgs [] _ = []
+    zipArgs args (SystemF.TyAll _ _ restOfTy) = case firstTyArg args of
+      Nothing -> args -- none was found, just use arg as is
+      Just (ty, moreArgs) -> ty : zipArgs moreArgs restOfTy
+    zipArgs args (SystemF.TyFun _ restOfTy) = case firstTermArg args of
+      Nothing -> args -- none was found, just use arg as is
+      Just (ty, moreArgs) -> ty : zipArgs moreArgs restOfTy
+    zipArgs args _ = args
+
+    firstTyArg [] = Nothing
+    firstTyArg (ty@SystemF.TyArg {} : rest) = Just (ty, rest)
+    firstTyArg (other : rest) = do
+      (ty, args) <- firstTyArg rest
+      pure (ty, other : args)
+
+    firstTermArg [] = Nothing
+    firstTermArg (ty@SystemF.TermArg {} : rest) = Just (ty, rest)
+    firstTermArg (other : rest) = do
+      (ty, args) <- firstTermArg rest
+      pure (ty, other : args)
+
+-- | Apply a function only to 'FunDef's
+-- and leave the rest of definitions unchanged.
+onlyOnFunDef ::
+  (FunDef lang -> FunDef lang) ->
+  Definition lang -> Definition lang
+onlyOnFunDef f = \case
+  DFunDef funDef -> DFunDef (f funDef)
+  other          -> other

--- a/src/Pirouette/Transformations/Prenex.hs
+++ b/src/Pirouette/Transformations/Prenex.hs
@@ -13,13 +13,13 @@ import qualified Pirouette.Term.Syntax.SystemF as SystemF
 -- | * Prenex form of types
 -- 
 -- This transformation tries to push the type abstractions
--- (big lambdas /\ x : Type . ) to the front of terms,
--- before any term abstractions (small lambdas \ x : Int . )
+-- (big lambdas @/\ x : Type .@ ) to the front of terms,
+-- before any term abstractions (small lambdas @\ x : Int .@ )
 --
 -- For example,
---   /\ a : Type . \ x : a . /\ b : Type . \ y : b . ...
+-- >  /\ a : Type . \ x : a . /\ b : Type . \ y : b . ...
 -- is transformed to
---   /\ a : Type . /\ b : Type . \ x : a . \ y : b . ...
+-- >  /\ a : Type . /\ b : Type . \ x : a . \ y : b . ...
 --
 -- This makes it easier for later transformations to apply
 -- on type abstractions. In fact, it's common to just bail
@@ -81,7 +81,7 @@ switchLambdas (SystemF.TyAll annTy kindTy restOfType)
 switchLambdas otherTy otherTm = (otherTy, otherTm)
 
 -- | Shift all the bound type variables,
--- starting from 'from' upwards.
+-- starting from @from@ upwards.
 shiftTyBy1 :: Integer -> Type lang -> Type lang
 shiftTyBy1 from = go
   where

--- a/tests/unit/Pirouette/Transformations/PrenexSpec.hs
+++ b/tests/unit/Pirouette/Transformations/PrenexSpec.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Pirouette.Transformations.PrenexSpec (tests) where
+
+import Control.Monad.Reader
+import Control.Monad.Writer
+import Data.List (sort)
+import qualified Data.Map as M
+import Language.Pirouette.Example
+import Pirouette.Monad
+import Pirouette.Term.Syntax
+import qualified Pirouette.Term.Syntax.SystemF as SystF
+import Pirouette.Transformations.Monomorphization
+import Pirouette.Transformations.Utils
+import Test.Tasty
+import Test.Tasty.ExpectedFailure
+import Test.Tasty.HUnit
+import Pirouette.Transformations.Prenex
+
+beforePrenex, afterPrenex :: Program Ex
+beforePrenex =
+  [prog|
+fun example : all a : Type . a -> all b : Type . b -> a
+  = /\ a : Type . \(x : a) . /\ b : Type . \(y : b) . a
+
+fun main : Integer = example @Integer 3 @Integer 4
+|]
+
+afterPrenex =
+  [prog|
+fun example : all a : Type . all b : Type . a -> b -> a
+  = /\ a : Type . /\ b : Type . \(x : a) (y : b) . a
+
+fun main : Integer = example @Integer @Integer 3 4
+|]
+
+uDefs :: Program Ex -> PrtUnorderedDefs Ex
+uDefs = uncurry PrtUnorderedDefs
+
+tests :: [TestTree]
+tests =
+  [ testCase "prenex example" $
+      prenex (uDefs beforePrenex) @=? uDefs afterPrenex
+  ]

--- a/tests/unit/Spec.hs
+++ b/tests/unit/Spec.hs
@@ -4,6 +4,7 @@ import qualified Pirouette.Term.Syntax.SystemFSpec as SF
 import qualified Pirouette.Term.TransformationsSpec as Tr
 import qualified Pirouette.Transformations.EtaExpandSpec as Eta
 import qualified Pirouette.Transformations.MonomorphizationSpec as Mono
+import qualified Pirouette.Transformations.PrenexSpec as Prenex
 import Test.Tasty
 
 main :: IO ()
@@ -17,7 +18,8 @@ tests =
       testGroup
         "Transformations"
         [testGroup "EtaExpand" Eta.tests,
-         testGroup "Monomorphization" Mono.tests],
+         testGroup "Monomorphization" Mono.tests,
+         testGroup "Prenex" Prenex.tests],
       testGroup "Term" [testGroup "Transformations" Tr.tests],
       testGroup
         "Language"


### PR DESCRIPTION
This transformation tries to push the type abstractions (big lambdas `/\ x : Type . `) to the front of terms, before any term abstractions (small lambdas `\ x : Int . `)

For example,

```
/\ a : Type . \ x : a . /\ b : Type . \ y : b . ...
```

is transformed to

```
/\ a : Type . /\ b : Type . \ x : a . \ y : b . ...
```

This makes it easier for later transformations to apply on type abstractions. In fact, it's common to just bail out on non-prenex types in other transformations, because those cases are quite rare and difficult to handle (usually involving some impredicative types.)