### PR TITLE
Defunctionalization tests

### DIFF
--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -143,6 +143,7 @@ test-suite spec
       Language.Pirouette.PlutusIR.ToTermSpec
       Pirouette.Term.Syntax.SystemFSpec
       Pirouette.Term.TransformationsSpec
+      Pirouette.Transformations.DefunctionalizationSpec
       Pirouette.Transformations.EtaExpandSpec
       Pirouette.Transformations.MonomorphizationSpec
       Pirouette.Transformations.PrenexSpec

--- a/src/Language/Pirouette/Example/Syntax.hs
+++ b/src/Language/Pirouette/Example/Syntax.hs
@@ -100,7 +100,7 @@ instance LanguageBuiltins Ex where
 data DataDecl = DataDecl [(String, SystF.Kind)] [(String, Ty)]
   deriving (Show)
 
-data FunDecl = FunDecl Ty Expr
+data FunDecl = FunDecl Rec Ty Expr
   deriving (Show)
 
 data Ty
@@ -163,12 +163,13 @@ parseDataDecl = label "Data declaration" $ do
 parseFunDecl :: Parser (String, FunDecl)
 parseFunDecl = label "Function declaration" $ do
   try (symbol "fun")
+  r <- NonRec <$ symbol "nonrec" <|> pure Rec
   i <- ident
   parseTyOf
   t <- parseType
   symbol "="
   x <- parseTerm
-  return (i, FunDecl t x)
+  return (i, FunDecl r t x)
 
 parseKind :: Parser SystF.Kind
 parseKind =
@@ -309,7 +310,7 @@ symbol = void . L.symbol spaceConsumer
 
 ident :: Parser String
 ident = label "identifier" $ do
-  i <- lexeme ((:) <$> lowerChar <*> restOfName)
+  i <- lexeme ((:) <$> (lowerChar <|> char '_') <*> restOfName)
   guard (i `S.notMember` reservedNames)
   return i
   where

--- a/src/Language/Pirouette/Example/ToTerm.hs
+++ b/src/Language/Pirouette/Example/ToTerm.hs
@@ -24,7 +24,7 @@ trProgram ::
   M.Map String (Either DataDecl FunDecl) ->
   FunDecl ->
   TrM (M.Map Name (Definition Ex), Term Ex)
-trProgram env (FunDecl _ main) =
+trProgram env (FunDecl _ _ main) =
   let decls =
         mapM (uncurry (\s -> either (trDataDecl s) (fmap ((: []) . (fromString s,)) . trFunDecl))) $
           M.toList env
@@ -39,8 +39,8 @@ trProgram env (FunDecl _ main) =
             else throwError $ "Repeaded definitions: " ++ show repeated
 
 trFunDecl :: FunDecl -> TrM (Definition Ex)
-trFunDecl (FunDecl ty expr) =
-  DFunDef <$> (FunDef Rec <$> trTerm [] [] expr <*> trType [] ty)
+trFunDecl (FunDecl rec ty expr) =
+  DFunDef <$> (FunDef rec <$> trTerm [] [] expr <*> trType [] ty)
 
 trDataDecl :: String -> DataDecl -> TrM [(Name, Definition Ex)]
 trDataDecl sName (DataDecl vars cons) = do

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -120,7 +120,7 @@ mkClosureTypes infos = M.fromList $ typeDecls <> ctorDecls <> dtorDecls
     dtorDecls = [ (dtorName tyName, DDestructor tyName) | tyName <- fst <$> types ]
 
 dtorName :: Name -> Name
-dtorName tyName = [i|#{tyName}_match|]
+dtorName tyName = [i|match_#{tyName}|]
 
 -- * Apply function generation
 
@@ -302,16 +302,16 @@ replaceApply applyFun = go 0
         recurArg (SystF.TermArg arg) = SystF.TermArg $ go idx arg
 
 closureTypeName :: (LanguagePretty lang, LanguageBuiltins lang) => B.Type lang -> Name
-closureTypeName ty = [i|Closure[#{funTyStr ty}]|]
+closureTypeName ty = [i|Closure!!#{funTyStr ty}|]
 
 applyFunName :: (LanguagePretty lang, LanguageBuiltins lang) => B.Type lang -> Name
-applyFunName ty = [i|Apply[#{funTyStr ty}]|]
+applyFunName ty = [i|_Apply!!#{funTyStr ty}|]
 
 closureType :: (LanguagePretty lang, LanguageBuiltins lang) => B.Type lang -> B.Type lang
 closureType ty = SystF.Free (TySig $ closureTypeName ty) `SystF.TyApp` []
 
 funTyStr :: (LanguagePretty lang, LanguageBuiltins lang) => B.Type lang -> T.Text
-funTyStr (dom `SystF.TyFun` cod) = funTyStr dom <> " => " <> funTyStr cod
+funTyStr (dom `SystF.TyFun` cod) = funTyStr dom <> "_" <> funTyStr cod
 funTyStr app@SystF.TyApp{} = argsToStr [app]
 funTyStr ty = error $ "unexpected arg type during defunctionalization:\n"
                    <> renderSingleLineStr (pretty ty)

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -34,7 +34,7 @@ import Control.Monad.Writer.Strict
 defunctionalize :: (LanguagePretty lang, LanguageBuiltins lang)
                 => PrtUnorderedDefs lang
                 -> PrtUnorderedDefs lang
-defunctionalize defs = traceDefsId defs' { prtUODecls = prtUODecls defs' <> typeDecls <> applyFunDecls }
+defunctionalize defs = defs' { prtUODecls = prtUODecls defs' <> typeDecls <> applyFunDecls }
   where
     (defs', closureCtorInfos) = evalRWS (defunFuns >=> defunTypes $ etaExpandAll defs) mempty (DefunState mempty)
 

--- a/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
@@ -29,7 +29,7 @@ fun add : Integer -> Integer -> Integer
 fun apply : (Integer -> Integer) -> Integer -> Integer
     = \(f : Integer -> Integer) (x : Integer) . f x
 
-fun two : Integer 
+fun two : Integer
     = apply (add 1) 1
 
 fun main : Integer = 42
@@ -47,7 +47,7 @@ fun add : Integer -> Integer -> Integer
 fun apply : Closure!!TyInteger_TyInteger -> Integer -> Integer
     = \(f : Closure!!TyInteger_TyInteger) (x : Integer) . _Apply!!TyInteger_TyInteger f x
 
-fun two : Integer 
+fun two : Integer
     = apply Closure!!TyInteger_TyInteger_ctor_0 1
 
 fun main : Integer = 42
@@ -65,10 +65,10 @@ fun const : Integer -> Integer -> Integer
 fun apply : (Integer -> Integer) -> Integer -> Integer
     = \ (f : Integer -> Integer) (x : Integer) . f x
 
-fun two : Integer 
+fun two : Integer
     = apply (add 1) 1
 
-fun three : Integer 
+fun three : Integer
     = apply (const 3) 10
 
 fun four : Integer
@@ -84,12 +84,12 @@ data Closure!!TyInteger_TyInteger
 
 fun nonrec _Apply!!TyInteger_TyInteger : Closure!!TyInteger_TyInteger -> Integer -> Integer
     = \(cls : Closure!!TyInteger_TyInteger) .
-      match_Closure!!TyInteger_TyInteger cls @Integer 
+      match_Closure!!TyInteger_TyInteger cls @Integer
         (\(η : Integer) . add 1 η)
         (\(η : Integer) . const 3 η)
         (\(η : Integer) . apply Closure!!TyInteger_TyInteger_ctor_0 η)
-        (\(η : Integer) . add 2 η) 
-        
+        (\(η : Integer) . add 2 η)
+
 fun add : Integer -> Integer -> Integer
     = \(x : Integer) (y : Integer) . x + y
 
@@ -102,10 +102,10 @@ fun const : Integer -> Integer -> Integer
 fun four : Integer
    = apply Closure!!TyInteger_TyInteger_ctor_1 2
 
-fun three : Integer 
+fun three : Integer
     = apply Closure!!TyInteger_TyInteger_ctor_2 10
 
-fun two : Integer 
+fun two : Integer
     = apply Closure!!TyInteger_TyInteger_ctor_3 1
 
 fun main : Integer = 42
@@ -120,23 +120,23 @@ data IntHomo
 fun applyIntHomoToOne : IntHomo -> Integer
   = \(h : IntHomo) . match_IntHomo h @Integer (\(f : Integer -> Integer) . f 1)
 
-fun main : Integer = applyIntHomoToOne (IntHomoC (\(x : Integer) . x + 2))
+fun main : Integer -> Integer = \(k : Integer) . applyIntHomoToOne (IntHomoC (\(x : Integer) . x + k))
 |], [prog|
 data Closure!!TyInteger_TyInteger
-  = Closure!!TyInteger_TyInteger_ctor_0 : Closure!!TyInteger_TyInteger
+  = Closure!!TyInteger_TyInteger_ctor_0 : Integer -> Closure!!TyInteger_TyInteger
 
 data IntHomo
   = IntHomoC : Closure!!TyInteger_TyInteger -> IntHomo
 
 fun nonrec _Apply!!TyInteger_TyInteger : Closure!!TyInteger_TyInteger -> Integer -> Integer
     = \(cls : Closure!!TyInteger_TyInteger) .
-      match_Closure!!TyInteger_TyInteger cls @Integer (\(η : Integer) . η + 2)
+      match_Closure!!TyInteger_TyInteger cls @Integer (\(k : Integer) (η : Integer) . η + k)
 
 fun applyIntHomoToOne : IntHomo -> Integer
   = \(h : IntHomo) . match_IntHomo h @Integer (\(f : Closure!!TyInteger_TyInteger) . _Apply!!TyInteger_TyInteger f 1)
 
-fun main : Integer = applyIntHomoToOne (IntHomoC Closure!!TyInteger_TyInteger_ctor_0)
-|]) 
+fun main : Integer -> Integer = \(k : Integer) . applyIntHomoToOne (IntHomoC (Closure!!TyInteger_TyInteger_ctor_0 k))
+|])
 
 addAndApplyPoly :: Program Ex
 addAndApplyPoly =
@@ -147,7 +147,7 @@ fun add : Integer -> Integer -> Integer
 fun apply : all (a : Type) (b : Type) . (a -> b) -> a -> b
     = /\ (a : Type) (b : Type) . \ (f : a -> b) (x : a) . f x
 
-fun two : Integer 
+fun two : Integer
     = apply @Integer @Integer (add 1) 1
 
 fun main : Integer = 42
@@ -165,10 +165,10 @@ fun const : all (a : Type) (b : Type) . a -> b -> a
 fun apply : all (a : Type) (b : Type) . (a -> b) -> a -> b
     = /\ (a : Type) (b : Type) . \ (f : a -> b) (x : a) . f x
 
-fun two : Integer 
+fun two : Integer
     = apply @Integer @Integer (add 1) 1
 
-fun three : Integer 
+fun three : Integer
     = apply @Integer @Integer (const @Integer @Integer 3) 10
 
 fun four : Integer
@@ -193,7 +193,7 @@ tests =
       defunctionalize (uDefs addAndApply) `equalModuloDestructors` uDefs addAndApplyDefunc,
     testCase "add and const, monomorphic" $
       defunctionalize (uDefs addConst) `equalModuloDestructors` uDefs addConstDefunc,
-    testCase "data type, monomorphic" $
+    testCase "data type, monomorphic, free variables" $
       defunctionalize (uDefs dataType) `equalModuloDestructors` uDefs dataTypeDefunc
     -- testCase "add and apply, polymorphic" $
     --   monoDefunc (uDefs addAndApplyPoly) `equalModuloDestructors` uDefs addAndApplyPoly,

--- a/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Pirouette.Transformations.DefunctionalizationSpec (tests) where
+
+import Control.Monad.Reader
+import Data.Map as Map
+import Language.Pirouette.Example
+import Pirouette.Monad
+import Pirouette.Term.Syntax
+import Pirouette.Transformations.Defunctionalization
+import Pirouette.Transformations.Monomorphization
+import Test.Tasty
+import Test.Tasty.HUnit
+
+uDefs :: Program Ex -> PrtUnorderedDefs Ex
+uDefs = uncurry PrtUnorderedDefs
+
+addAndApply, addAndApplyDefunc :: Program Ex
+(addAndApply, addAndApplyDefunc) =
+  ([prog|
+fun add : Integer -> Integer -> Integer
+    = \(x : Integer) (y : Integer) . x + y
+
+fun apply : (Integer -> Integer) -> Integer -> Integer
+    = \(f : Integer -> Integer) (x : Integer) . f x
+
+fun two : Integer 
+    = apply (add 1) 1
+
+fun main : Integer = 42
+|], [prog|
+fun nonrec _Apply!!TyInteger_TyInteger : Closure!!TyInteger_TyInteger -> Integer -> Integer
+    = \(cls : Closure!!TyInteger_TyInteger) .
+      match_Closure!!TyInteger_TyInteger cls @Integer (\(η : Integer) . add 1 η)
+
+data Closure!!TyInteger_TyInteger
+  = Closure!!TyInteger_TyInteger_ctor_0 : Closure!!TyInteger_TyInteger
+
+fun add : Integer -> Integer -> Integer
+    = \(x : Integer) (y : Integer) . x + y
+
+fun apply : Closure!!TyInteger_TyInteger -> Integer -> Integer
+    = \(f : Closure!!TyInteger_TyInteger) (x : Integer) . _Apply!!TyInteger_TyInteger f x
+
+fun two : Integer 
+    = apply Closure!!TyInteger_TyInteger_ctor_0 1
+
+fun main : Integer = 42
+|])
+
+addConst, addConstDefunc :: Program Ex
+(addConst, addConstDefunc) =
+  ([prog|
+fun add : Integer -> Integer -> Integer
+    = \(x : Integer) (y : Integer) . x + y
+
+fun const : Integer -> Integer -> Integer
+    = \ (x : Integer) (y : Integer) . x
+
+fun apply : (Integer -> Integer) -> Integer -> Integer
+    = \ (f : Integer -> Integer) (x : Integer) . f x
+
+fun two : Integer 
+    = apply (add 1) 1
+
+fun three : Integer 
+    = apply (const 3) 10
+
+fun four : Integer
+   = apply (apply add 2) 2
+
+fun main : Integer = 42
+|], [prog|
+data Closure!!TyInteger_TyInteger
+  = Closure!!TyInteger_TyInteger_ctor_0 : Closure!!TyInteger_TyInteger
+  | Closure!!TyInteger_TyInteger_ctor_1 : Closure!!TyInteger_TyInteger
+  | Closure!!TyInteger_TyInteger_ctor_2 : Closure!!TyInteger_TyInteger
+  | Closure!!TyInteger_TyInteger_ctor_3 : Closure!!TyInteger_TyInteger
+
+fun _Apply!!TyInteger_TyInteger : Closure!!TyInteger_TyInteger -> Integer -> Integer
+    = \(cls : Closure!!TyInteger_TyInteger) .
+      match_Closure!!TyInteger_TyInteger cls @Integer 
+        (\(η : Integer) . add 2 η) 
+        (\(η : Integer) . apply Closure!!TyInteger_TyInteger_ctor_1 2 η)
+        (\(η : Integer) . const 3 η)
+        (\(η : Integer) . add 1 η)
+
+fun add : Integer -> Integer -> Integer
+    = \(x : Integer) (y : Integer) . x + y
+
+fun apply : Closure!!TyInteger_TyInteger -> Integer -> Integer
+    = \(f : Closure!!TyInteger_TyInteger) (x : Integer) . _Apply!!TyInteger_TyInteger f x
+
+fun const : Integer -> Integer -> Integer
+    = \ (x : Integer) (y : Integer) . x
+
+fun four : Integer
+   = apply Closure!!TyInteger_TyInteger_ctor_1 2
+
+fun three : Integer 
+    = apply Closure!!TyInteger_TyInteger_ctor_2 10
+
+fun two : Integer 
+    = apply Closure!!TyInteger_TyInteger_ctor_3 1
+
+fun main : Integer = 42
+|])
+
+addAndApplyPoly :: Program Ex
+addAndApplyPoly =
+  [prog|
+fun add : Integer -> Integer -> Integer
+    = \(x : Integer) (y : Integer) . x + y
+
+fun apply : all (a : Type) (b : Type) . (a -> b) -> a -> b
+    = /\ (a : Type) (b : Type) . \ (f : a -> b) (x : a) . f x
+
+fun two : Integer 
+    = apply @Integer @Integer (add 1) 1
+
+fun main : Integer = 42
+|]
+
+addConstPoly :: Program Ex
+addConstPoly =
+  [prog|
+fun add : Integer -> Integer -> Integer
+    = \(x : Integer) (y : Integer) . x + y
+
+fun const : all (a : Type) (b : Type) . a -> b -> a
+    = /\ (a : Type) (b : Type) . \ (x : a) (y : b) . x
+
+fun apply : all (a : Type) (b : Type) . (a -> b) -> a -> b
+    = /\ (a : Type) (b : Type) . \ (f : a -> b) (x : a) . f x
+
+fun two : Integer 
+    = apply @Integer @Integer (add 1) 1
+
+fun three : Integer 
+    = apply @Integer @Integer (const @Integer @Integer 3) 10
+
+fun four : Integer
+   = apply @Integer @Integer (apply @Integer @Integer add 2) 2
+
+fun main : Integer = 42
+|]
+
+equalModuloDestructors :: PrtUnorderedDefs Ex -> PrtUnorderedDefs Ex -> Assertion
+equalModuloDestructors p1 p2 = do
+  let decls1 = Map.filter (not . isDestructor) $ prtUODecls p1
+      decls2 = Map.filter (not . isDestructor) $ prtUODecls p2
+  decls1 @=? decls2
+  prtUOMainTerm p1 @=? prtUOMainTerm p2
+  where
+      isDestructor DDestructor {} = True
+      isDestructor _              = False
+
+tests :: [TestTree]
+tests =
+  [ testCase "add and apply, monomorphic" $
+      defunctionalize (uDefs addAndApply) `equalModuloDestructors` uDefs addAndApplyDefunc,
+    testCase "add and const, monomorphic" $
+      defunctionalize (uDefs addConst) `equalModuloDestructors` uDefs addConstDefunc
+    -- testCase "add and apply, polymorphic" $
+    --   monoDefunc (uDefs addAndApplyPoly) `equalModuloDestructors` uDefs addAndApplyPoly,
+    -- testCase "add and const, polymorphic" $
+    --   monoDefunc (uDefs addConstPoly) `equalModuloDestructors` uDefs addConstPoly
+  ]
+  where
+    monoDefunc :: PrtUnorderedDefs Ex -> PrtUnorderedDefs Ex
+    monoDefunc = defunctionalize . monomorphize

--- a/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
@@ -73,7 +73,7 @@ tests =
     -- we rely on 'hofsClosure':
     testCase "hofsClosure picks the expected defs" $
       let ds = prtUODecls sampleUDefs
-       in M.keys (hofsClosure ds (findPolyHOFDefs ds)) @?= ["Mon", "Monoid", "fold", "match_Monoid"],
+       in M.keys (hofsClosure ds (findPolyHOFDefs ds)) @?= sort ["Mon", "Monoid", "fold", "match_Monoid"],
     -- Now we make sure that the function specialization requests are working as we expect:
     testGroup
       "specFunApp"

--- a/tests/unit/Spec.hs
+++ b/tests/unit/Spec.hs
@@ -2,6 +2,7 @@ import qualified Language.Pirouette.ExampleSpec as Ex
 import qualified Language.Pirouette.PlutusIR.ToTermSpec as FP
 import qualified Pirouette.Term.Syntax.SystemFSpec as SF
 import qualified Pirouette.Term.TransformationsSpec as Tr
+import qualified Pirouette.Transformations.DefunctionalizationSpec as Defunc
 import qualified Pirouette.Transformations.EtaExpandSpec as Eta
 import qualified Pirouette.Transformations.MonomorphizationSpec as Mono
 import qualified Pirouette.Transformations.PrenexSpec as Prenex
@@ -17,7 +18,8 @@ tests =
     [ testGroup "SystemF" SF.tests,
       testGroup
         "Transformations"
-        [testGroup "EtaExpand" Eta.tests,
+        [testGroup "Defunctionalization" Defunc.tests,
+         testGroup "EtaExpand" Eta.tests,
          testGroup "Monomorphization" Mono.tests,
          testGroup "Prenex" Prenex.tests],
       testGroup "Term" [testGroup "Transformations" Tr.tests],


### PR DESCRIPTION
This PR adds tests for the defunctionalization transformation. I've used only monomorphic types, because otherwise this transformation has to be preceded by monomorphization, and things become too complicated / big.

To make everything work fine there was a lot of small changes required here and there:
- I've made the different parsers and transformations agree on the names of destructors, they are now always `match_TypeName`.
- The parser in the quasiquoter now allows `_` as the initial character of an identifier.
- Since the parser makes no effort in checking whether a definition is recursive or not, I've added an additional keyword `nonrec` which you can add to state so. This has been quite useful in the tests.