### PR TITLE
Merge different symeval implementations

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -34,8 +34,8 @@ import Pirouette.Monad.Logger
 import Language.Pirouette.PlutusIR.SMT ()
 import Language.Pirouette.PlutusIR.Builtins
 import Language.Pirouette.PlutusIR.ToTerm
-import Pirouette.Term.Symbolic.Eval as SymbolicEval
-import Pirouette.Term.Symbolic.Interface as SymbolicEval
+import Pirouette.Term.Symbolic.Eval (runFor, AvailableFuel(..))
+import Pirouette.Term.Symbolic.Interface (runIncorrectness)
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as R
 import Pirouette.Term.Transformations
@@ -139,9 +139,8 @@ mainOpts opts uDefs = do
     symbolicExec n (DFunction _ t _) =
       let fil = constraintFile opts in
       if fil == ""
-      then SymbolicEval.runFor n t
-      else
-        SymbolicEval.runIncorrectness (constraintFile opts) t
+      then runFor (Fuel 10) n t
+      else runIncorrectness (constraintFile opts) t
     symbolicExec _ _ = throwError' (PEOther "Impossible to symbolic execute a symbol which is not a function")
 
 processDecls :: (LanguageBuiltins lang, LanguagePretty lang, MonadIO m) => CliOpts -> PrtUnorderedDefs lang -> PrtT m (PrtOrderedDefs lang)

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -4,5 +4,5 @@
 let
   ourpkgs = import ./packages.nix {};
 in pkgs.mkShell {
-    buildInputs = ourpkgs.build-deps ++ runtime-deps;
+    buildInputs = ourpkgs.build-deps;
 }

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -3,6 +3,9 @@
 { pkgs ? import (import ./sources.nix {}).nixpkgs {} }:
 let
   ourpkgs = import ./packages.nix {};
+  runtime-deps = [
+      ourpkgs.nixPkgsProxy.cvc4
+    ];
 in pkgs.mkShell {
-    buildInputs = ourpkgs.build-deps;
+    buildInputs = ourpkgs.build-deps ++ runtime-deps;
 }

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -3,9 +3,6 @@
 { pkgs ? import (import ./sources.nix {}).nixpkgs {} }:
 let
   ourpkgs = import ./packages.nix {};
-  runtime-deps = [
-      ourpkgs.nixPkgsProxy.cvc4
-    ];
 in pkgs.mkShell {
     buildInputs = ourpkgs.build-deps ++ runtime-deps;
 }

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -48,6 +48,7 @@ in {
         hlint
         ormolu
         haskellPackages.happy
+        cvc4 # required to run pirouette once its built
      ] ++ [
         # iohk-specific stuff that we require
         iohkpkgs.haskell-nix.internal-cabal-install

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ executable:
   ghc-options:
     -Wall
     -Wno-orphans
+    -fplugin=StackTrace.Plugin
 
 tests:
   spec:

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -142,6 +142,7 @@ test-suite spec
   other-modules:
       Language.Pirouette.ExampleSpec
       Language.Pirouette.PlutusIR.ToTermSpec
+      Pirouette.Term.SymbolicEvalSpec
       Pirouette.Term.Syntax.BaseSpec
       Pirouette.Term.Syntax.SystemFSpec
       Pirouette.Term.TransformationsSpec

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -98,7 +98,7 @@ executable pirouette
       Paths_pirouette
   hs-source-dirs:
       executable
-  ghc-options: -Wall -Wno-orphans
+  ghc-options: -Wall -Wno-orphans -fplugin=StackTrace.Plugin
   build-depends:
       QuickCheck
     , aeson

--- a/shell.nix
+++ b/shell.nix
@@ -2,8 +2,6 @@
 let
   ourpkgs = import ./nix/packages.nix {};
   runtime-deps = [
-      ourpkgs.nixPkgsProxy.cvc4
-
       # graphmod is a nice tool to visualize the project module structure; run:
       # $ graphmod -p --no-cluster | xdot -
       # to see it in action!

--- a/src/Language/Pirouette/Example/Syntax.hs
+++ b/src/Language/Pirouette/Example/Syntax.hs
@@ -36,6 +36,8 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Void
 import Language.Haskell.TH.Syntax (Lift)
+import Pirouette.SMT
+import qualified Pirouette.SMT.SimpleSMT as SimpleSMT
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Text.Megaparsec
@@ -111,6 +113,17 @@ instance LanguageBuiltinTypes Ex where
 tInt, tBool :: Type Ex
 tInt = SystF.tyPure $ SystF.Free $ TyBuiltin TyInteger
 tBool = SystF.tyPure $ SystF.Free $ TyBuiltin TyBool
+
+instance LanguageSMT Ex where
+  translateBuiltinType TyInteger = SimpleSMT.tInt
+  translateBuiltinType TyBool = SimpleSMT.tBool
+  translateBuiltinTerm TermAdd = SimpleSMT.Atom "+"
+  translateBuiltinTerm TermSub = SimpleSMT.Atom "-"
+  translateBuiltinTerm TermLt = SimpleSMT.Atom "<"
+  translateBuiltinTerm TermEq = SimpleSMT.Atom "="
+  translateBuiltinTerm TermIte = SimpleSMT.Atom "ite"
+  translateConstant (ConstInt n) = SimpleSMT.int n
+  translateConstant (ConstBool b) = SimpleSMT.bool b
 
 -- ** Syntactical Categories
 

--- a/src/Language/Pirouette/Example/ToTerm.hs
+++ b/src/Language/Pirouette/Example/ToTerm.hs
@@ -80,11 +80,12 @@ trTerm tyEnv termEnv (ExprLam s ty ex) =
   SystF.Lam (SystF.Ann $ fromString s) <$> trType tyEnv ty <*> trTerm tyEnv (s : termEnv) ex
 trTerm tyEnv termEnv (ExprAbs s ki ex) =
   SystF.Abs (SystF.Ann $ fromString s) ki <$> trTerm (s : tyEnv) termEnv ex
-trTerm tyEnv termEnv (ExprIf c t e) = do
+trTerm tyEnv termEnv (ExprIf ty c t e) = do
+  ty' <- trType tyEnv ty
   c' <- trTerm tyEnv termEnv c
   t' <- trTerm tyEnv termEnv t
   e' <- trTerm tyEnv termEnv e
-  return $ SystF.App (SystF.Free $ Builtin TermIte) $ map SystF.TermArg [c', t', e']
+  return $ SystF.App (SystF.Free $ Builtin TermIte) $ SystF.TyArg ty' : map SystF.TermArg [c', t', e']
 trTerm _ termEnv (ExprVar s) =
   case s `elemIndex` termEnv of
     Just i -> return $ SystF.termPure $ SystF.Bound (SystF.Ann $ fromString s) (fromIntegral i)

--- a/src/Language/Pirouette/PlutusIR/SMT.hs
+++ b/src/Language/Pirouette/PlutusIR/SMT.hs
@@ -2,12 +2,16 @@ module Language.Pirouette.PlutusIR.SMT where
 
 import Language.Pirouette.PlutusIR.Builtins
 import Pirouette.SMT.Base
+import Pirouette.SMT.Constraints
 import qualified Pirouette.SMT.SimpleSMT as SimpleSMT
 
 instance LanguageSMT BuiltinsOfPIR where
   translateBuiltinType = trPIRType
   translateBuiltinTerm = error "translateBuiltinTerm (t :: BuiltinTerms PlutusIR): not yet impl"
   translateConstant = error "translateConstant (t :: Constants PlutusIR): not yet impl"
+
+instance LanguageSMTBranches BuiltinsOfPIR where
+  branchesBuiltinTerm _tm _args = Nothing
 
 trPIRType :: PIRBuiltinType -> SimpleSMT.SExpr
 trPIRType PIRTypeInteger = SimpleSMT.tInt

--- a/src/Pirouette/SMT.hs
+++ b/src/Pirouette/SMT.hs
@@ -31,6 +31,8 @@ module Pirouette.SMT
     AtomicConstraint (..),
     SimpleSMT.Result (..),
     module Base,
+    Branch(..),
+    LanguageSMTBranches(..)
   )
 where
 

--- a/src/Pirouette/SMT/Base.hs
+++ b/src/Pirouette/SMT/Base.hs
@@ -7,6 +7,7 @@ import Data.Void
 import qualified Pirouette.SMT.SimpleSMT as SimpleSMT
 import Pirouette.Term.Syntax
 
+
 -- | Captures the languages that can be translated to SMTLIB; namelly,
 -- we need to be able to translate each individual base syntactical category.
 --
@@ -14,7 +15,7 @@ import Pirouette.Term.Syntax
 -- should be used with @-XTypeApplications@ whenever necessary.
 class (LanguageBuiltins lang) => LanguageSMT lang where
   translateBuiltinType :: BuiltinTypes lang -> SimpleSMT.SExpr
-  translateBuiltinTerm :: BuiltinTerms lang -> SimpleSMT.SExpr
+  translateBuiltinTerm :: BuiltinTerms lang -> [SimpleSMT.SExpr] -> Maybe SimpleSMT.SExpr
   translateConstant :: Constants lang -> SimpleSMT.SExpr
 
 -- | Captures arbitrary types that can be translated to SMTLIB.

--- a/src/Pirouette/SMT/Constraints.hs
+++ b/src/Pirouette/SMT/Constraints.hs
@@ -43,10 +43,12 @@ data AtomicConstraint lang meta
   | NonInlinableSymbolEq (TermMeta lang meta) (TermMeta lang meta)
   | OutOfFuelEq (TermMeta lang meta) (TermMeta lang meta)
   | Native SimpleSMT.SExpr
+  deriving (Eq, Show)
 
 data Constraint lang meta
   = And [AtomicConstraint lang meta]
   | Bot
+  deriving (Eq, Show)
 
 instance Semigroup (Constraint lang meta) where
   (<>) = andConstr

--- a/src/Pirouette/SMT/Constraints.hs
+++ b/src/Pirouette/SMT/Constraints.hs
@@ -56,6 +56,20 @@ instance Semigroup (Constraint lang meta) where
 instance Monoid (Constraint lang meta) where
   mempty = And []
 
+data Branch lang meta =
+  Branch { additionalInfo :: Constraint lang meta 
+         , newTerm :: TermMeta lang meta }
+
+class (LanguageSMT lang) => LanguageSMTBranches lang where
+  -- | Injection of different cases in the symbolic evaluator.
+  -- For example, one can introduce a 'if_then_else' built-in
+  -- and implement this method to look at both possibilities.
+  branchesBuiltinTerm 
+    :: ToSMT meta
+    => BuiltinTerms lang -> [ArgMeta lang meta]
+    -> Maybe [Branch lang meta]
+  branchesBuiltinTerm _ _ = Nothing
+
 -- Essentially list concatenation, with the specificity that `Bot` is absorbing.
 andConstr :: Constraint lang meta -> Constraint lang meta -> Constraint lang meta
 andConstr Bot _ = Bot
@@ -170,7 +184,7 @@ translateData ::
   TypeMeta lang meta ->
   TermMeta lang meta ->
   ExceptT String m SimpleSMT.SExpr
-translateData knownNames _ (App var []) = translateVar knownNames var
+translateData knownNames _ (App var []) = translateApp knownNames var []
 translateData knownNames ty (App (Free (TermSig name)) args) = do
   guard (name `elem` knownNames)
   SimpleSMT.app

--- a/src/Pirouette/Term/Symbolic/Eval.hs
+++ b/src/Pirouette/Term/Symbolic/Eval.hs
@@ -275,8 +275,10 @@ symEvalOneStep R.Abs {} = error "Can't symbolically evaluate polymorphic things"
 -- and evaluate the corresponding application.
 symEvalOneStep t@(R.Lam (R.Ann _x) _ty _) = do
   {-
-  This is the case in which there's a lambda as argument to a function
-  (if it has the head of a function it would have been reduced by normalizeTerm).
+  Note that our AST only represents terms in normal form,
+  so it cannot be the case that we have:
+  > App (Lam ...) ...
+  So beta-reduction does not enter the game here.
   We have two options at this point:
   -}
   {-

--- a/src/Pirouette/Term/Symbolic/Eval.hs
+++ b/src/Pirouette/Term/Symbolic/Eval.hs
@@ -449,7 +449,7 @@ pathsIncorrectnessWorker UserDeclaredConstraints {..} t = do
     void $ liftIO udcAdditionalDefs
     svars <- declSymVars udcInputs
     let tApplied = R.appN (termToMeta t) $ map (R.TermArg . (`R.App` []) . R.Meta) svars
-    liftIO $ putStrLn $ "Conditionally evaluating: " ++ show (pretty tApplied)
+    -- liftIO $ putStrLn $ "Conditionally evaluating: " ++ show (pretty tApplied)
     conditionalEval tApplied udcOutputCond udcInputCond udcAxioms
 
 conditionalEval :: (SymEvalConstr lang m, MonadIO m)

--- a/tests/unit/Language/Pirouette/ExampleSpec.hs
+++ b/tests/unit/Language/Pirouette/ExampleSpec.hs
@@ -33,7 +33,7 @@ tests =
     testGroup
       "Can parse terms"
       [ testCase "Example 1" $
-          canParseTerm [term| if 3 < 5 then 42 + 1 else 0 |],
+          canParseTerm [term| if @Integer 3 < 5 then 42 + 1 else 0 |],
         testCase "Example 2" $
           canParseTerm [term| /\ (f : Type -> Type) (x : Type) . \k : f (Either x Bool) . fmap whatever k |]
       ],

--- a/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
@@ -38,7 +38,7 @@ thing `satisfies` property = do
   given <- thing
   case given of
     Left e -> assertFailure $ "finished with errors: " <> e
-    Right x -> assertBool "property is not satisfied" $ property x
+    Right x -> assertBool ("property not satisfied: " <> show x) (property x)
 
 add1 :: (Program Ex, Term Ex)
 add1 = (

--- a/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
@@ -26,6 +26,19 @@ symbolicExec program term = fmap fst $ mockPrtT $ do
   flip runReaderT orderedDecls $ do
     pathsFor (Fuel 10) "main" term
 
+incorrectnessExec :: Program Ex -> Term Ex -> InCond Ex -> OutCond Ex -> IO (Either String [Path Ex (EvaluationWitness Ex)])
+incorrectnessExec program term inC outC = fmap fst $ mockPrtT $ do
+  let decls = uncurry PrtUnorderedDefs program
+  orderedDecls <- elimEvenOddMutRec decls
+  flip runReaderT orderedDecls $ do
+    pathsIncorrectness UserDeclaredConstraints {
+      udcInputs = [], 
+      udcOutputCond = outC, 
+      udcInputCond = inC, 
+      udcAdditionalDefs = pure [], 
+      udcAxioms = [] } 
+      term
+
 (*=*) :: (Eq a, Show a) => IO (Either String a) -> a -> Assertion
 thing *=* expected = do
   given <- thing

--- a/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Pirouette.Term.SymbolicEvalSpec (tests) where
+
+import Control.Monad.Reader
+import Language.Pirouette.Example
+import Pirouette.Monad
+import Pirouette.Term.Syntax.Base
+import Pirouette.Term.Symbolic.Eval
+import Pirouette.Term.Transformations
+import Pirouette.Transformations ( elimEvenOddMutRec )
+import Test.Tasty
+import Test.Tasty.HUnit
+
+symbolicExec :: Program Ex -> Term Ex -> IO (Either String [Path Ex (TermMeta Ex SymVar)])
+symbolicExec program term = fmap fst $ mockPrtT $ do
+  let decls = uncurry PrtUnorderedDefs program
+  orderedDecls <- elimEvenOddMutRec decls
+  flip runReaderT orderedDecls $ do
+    pathsFor InfiniteFuel "main" term
+
+tests :: [TestTree]
+tests = [ ]

--- a/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
@@ -71,17 +71,21 @@ fun main : Integer = 42
   [term| \(z : Integer) . sumar z 1 |])
 
 botConditions :: (Constraint Ex, TermMeta Ex SymVar -> Constraint Ex)
-botConditions = (SMT.And [], const SMT.Bot)
+botConditions = (SMT.Bot, const mempty)
 
 topConditions :: (Constraint Ex, TermMeta Ex SymVar -> Constraint Ex)
-topConditions = (SMT.And [], const (SMT.And []))
+topConditions = (mempty, const mempty)
+
+isSingleton :: [a] -> Bool
+isSingleton [_] = True
+isSingleton _ = False
 
 tests :: [TestTree]
 tests = [ 
   testCase "add 1" $
-    symbolicExec' add1 `satisfies` (\r -> length r == 1),
+    symbolicExec' add1 `satisfies` isSingleton,
   testCase "add 1, bot" $
-    incorrectnessExec' add1 botConditions `satisfies` null,
+    incorrectnessExec' add1 botConditions `satisfies` isSingleton,
   testCase "add 1, top" $
     incorrectnessExec' add1 topConditions `satisfies` null
   ]

--- a/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
@@ -60,6 +60,21 @@ thing `satisfies` property = do
     Left e -> assertFailure $ "finished with errors: " <> e
     Right x -> assertBool ("property not satisfied: " <> show x) (property x)
 
+pathSatisfies :: (LanguageBuiltins lang, Show res) => IO (Either String [Path lang res]) -> ([Path lang res] -> Bool) -> Assertion
+thing `pathSatisfies` property = do
+  given <- thing
+  case given of
+    Left e -> assertFailure $ "finished with errors: " <> e
+    Right paths -> assertBool ("property not satisfied: " <> show paths) (property paths)
+
+singleVerified :: [Path lang (EvaluationWitness lang)] -> Bool
+singleVerified [Path { pathResult = Verified }] = True
+singleVerified _ = False
+
+singleCounter :: [Path lang (EvaluationWitness lang)] -> Bool
+singleCounter [Path { pathResult = CounterExample _ }] = True
+singleCounter _ = False 
+
 add1 :: (Program Ex, Term Ex)
 add1 = (
   [prog|
@@ -69,6 +84,26 @@ fun sumar : Integer -> Integer -> Integer
 fun main : Integer = 42
   |],
   [term| \(z : Integer) . sumar z 1 |])
+
+oneFake :: (Program Ex, Term Ex)
+oneFake = (
+  [prog|
+fun oneFake : Integer -> Integer -> Integer
+  = \(x : Integer) (y : Integer) . if @Integer 1 < 0 then x else y
+
+fun main : Integer = 42
+  |],
+  [term| \(x : Integer) (y : Integer) . oneFake x y |])
+
+whoKnows :: (Program Ex, Term Ex)
+whoKnows = (
+  [prog|
+fun whoKnows : Integer -> Integer -> Integer -> Integer
+  = \(n : Integer) (x : Integer) (y : Integer) . if @Integer n < 0 then x else y
+
+fun main : Integer = 42
+  |],
+  [term| \(n : Integer) (x : Integer) (y : Integer) . whoKnows n x y |])
 
 botConditions :: (Constraint Ex, TermMeta Ex SymVar -> Constraint Ex)
 botConditions = (SMT.Bot, const mempty)
@@ -85,7 +120,11 @@ tests = [
   testCase "add 1" $
     symbolicExec' add1 `satisfies` isSingleton,
   testCase "add 1, bot" $
-    incorrectnessExec' add1 botConditions `satisfies` isSingleton,
+    incorrectnessExec' add1 botConditions `pathSatisfies` singleCounter,
   testCase "add 1, top" $
-    incorrectnessExec' add1 topConditions `satisfies` null
+    incorrectnessExec' add1 topConditions `pathSatisfies` singleVerified,
+  testCase "one fake branch" $
+    incorrectnessExec' oneFake botConditions `pathSatisfies` singleCounter
+  -- testCase "who knows should have two branches" $
+  --   incorrectnessExec' whoKnows botConditions `pathSatisfies` (\x -> length x == 2)
   ]

--- a/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
@@ -12,17 +12,46 @@ import Language.Pirouette.Example
 import Pirouette.Monad
 import Pirouette.Term.Syntax.Base
 import Pirouette.Term.Symbolic.Eval
-import Pirouette.Term.Transformations
 import Pirouette.Transformations ( elimEvenOddMutRec )
 import Test.Tasty
 import Test.Tasty.HUnit
+
+symbolicExec' :: (Program Ex, Term Ex) -> IO (Either String [Path Ex (TermMeta Ex SymVar)])
+symbolicExec' = uncurry symbolicExec
 
 symbolicExec :: Program Ex -> Term Ex -> IO (Either String [Path Ex (TermMeta Ex SymVar)])
 symbolicExec program term = fmap fst $ mockPrtT $ do
   let decls = uncurry PrtUnorderedDefs program
   orderedDecls <- elimEvenOddMutRec decls
   flip runReaderT orderedDecls $ do
-    pathsFor InfiniteFuel "main" term
+    pathsFor (Fuel 10) "main" term
+
+(*=*) :: (Eq a, Show a) => IO (Either String a) -> a -> Assertion
+thing *=* expected = do
+  given <- thing
+  case given of
+    Left e -> assertFailure $ "finished with errors: " <> e
+    Right x -> x @=? expected
+
+satisfies :: (Eq a, Show a) => IO (Either String a) -> (a -> Bool) -> Assertion
+thing `satisfies` property = do
+  given <- thing
+  case given of
+    Left e -> assertFailure $ "finished with errors: " <> e
+    Right x -> assertBool "property is not satisfied" $ property x
+
+add1 :: (Program Ex, Term Ex)
+add1 = (
+  [prog|
+fun sumar : Integer -> Integer -> Integer
+  = \(x : Integer) (y : Integer) . x + y
+
+fun main : Integer = 42
+  |],
+  [term| \(z : Integer) . sumar z 1 |])
 
 tests :: [TestTree]
-tests = [ ]
+tests = [ 
+  testCase "add 1" $
+    symbolicExec' add1 `satisfies` (\r -> length r == 1)
+  ]

--- a/tests/unit/Spec.hs
+++ b/tests/unit/Spec.hs
@@ -1,6 +1,7 @@
 import qualified Language.Pirouette.ExampleSpec as Ex
 import qualified Language.Pirouette.PlutusIR.ToTermSpec as FP
 import qualified Pirouette.Term.Syntax.SystemFSpec as SF
+import qualified Pirouette.Term.SymbolicEvalSpec as SymbolicEval
 import qualified Pirouette.Term.TransformationsSpec as Tr
 import qualified Pirouette.Transformations.DefunctionalizationSpec as Defunc
 import qualified Pirouette.Transformations.EtaExpandSpec as Eta
@@ -23,10 +24,11 @@ tests =
          testGroup "EtaExpand" Eta.tests,
          testGroup "Monomorphization" Mono.tests,
          testGroup "Prenex" Prenex.tests],
-      testGroup "Term"
-        [testGroup "Transformations" Tr.tests,
-         testGroup "Base" Base.tests
-        ],
+      testGroup
+        "Term" 
+        [testGroup "Base" Base.tests,
+         testGroup "Transformations" Tr.tests,
+         testGroup "Symbolic evaluation" SymbolicEval.tests],
       testGroup
         "Language"
         [ testGroup "PlutusIR" FP.tests,


### PR DESCRIPTION
The goal of this PR is to reduce the current duplication in `Pirouette.Term.Symbolic.Eval` by merging the `symeval'` and `symevalOneStep` functions into a common core, maybe with some additional parametrization.

- [X] Introduce "infinite fuel" for those cases in which symbolic evaluation should continue until the end
- [X] Merge into a single `symevalOneStep`
- [x] Add tests for symbolic evaluation
- [x] Evaluation of built-ins