### PR TITLE
Use haskell-language-server 1.6.1.1

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -10,6 +10,11 @@
     haskellNix.nixpkgsArgs
 }:
 let
+  # updated haskell.nix to get the latest haskell-language-server
+  # idea obtained from https://input-output-hk.github.io/haskell.nix/tutorials/development.html#how-to-get-an-ad-hoc-development-shell-including-certain-packages
+  updatedHaskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/82832676a10a5a0d73eab60e58cc8f1bb591c214.tar.gz) {};
+  updatedNixpkgs = import updatedHaskellNix.sources.nixpkgs updatedHaskellNix.nixpkgsArgs;
+  updatedHaskell = updatedNixpkgs.haskell-nix;
   # The only difficulty we face is making sure to build the haskell-language-server
   # with the same version of GHC that is used for plutus; doing so, however,
   # requires patching ghcide, a dependency of haskell-language-server.
@@ -18,10 +23,10 @@ let
   # inside its 'modules' key:
   custom-hls =
     with
-    (iohkpkgs.haskell-nix.hackage-package {
+    (updatedHaskell.hackage-package {
       compiler-nix-name = "ghc810420210212";
       name = "haskell-language-server";
-      version = "1.5.1.0";
+      version = "1.6.1.1";
       modules = [{
         packages.ghcide.patches = [ patches/ghcide_partial_iface.patch ];
         packages.ghcide.flags.ghc-patched-unboxed-bytecode = true;

--- a/nix/patches/ghcide_partial_iface.patch
+++ b/nix/patches/ghcide_partial_iface.patch
@@ -1,9 +1,9 @@
-diff --git i/src/Development/IDE/Core/Compile.hs w/src/Development/IDE/Core/Compile.hs
-index 3d33b6c..ce86f9c 100644
---- i/src/Development/IDE/Core/Compile.hs
-+++ w/src/Development/IDE/Core/Compile.hs
-@@ -279,7 +279,7 @@ mkHiFileResultCompile session' tcm simplified_guts ltype = catchErrs $ do
- 
+diff --git a/src/Development/IDE/Core/Compile.hs b/src/Development/IDE/Core/Compile.hs
+index 9279abd2..8c5dbda4 100644
+--- a/src/Development/IDE/Core/Compile.hs
++++ b/src/Development/IDE/Core/Compile.hs
+@@ -271,7 +271,7 @@ mkHiFileResultCompile session' tcm simplified_guts ltype = catchErrs $ do
+   let !partial_iface = force (mkPartialIface session details simplified_guts)
    final_iface <- mkFullIface session partial_iface Nothing
  #elif MIN_VERSION_ghc(8,10,0)
 -  let !partial_iface = force (mkPartialIface session details simplified_guts)


### PR DESCRIPTION
This allows us to use a more recent version of the Haskell Language Server, which brings [lots of niceties](https://github.com/haskell/haskell-language-server/releases). In the future we can keep up with the releases by simply updating the `packages.nix` file.