### PR TITLE
Register the update to haskellNix in `sources.json` instead of hardcoding it in the nixfile

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
         ## We can use the counter to invalidate the cache whenever necessary
         key: cabal-cache-0-${{ github.sha }}
         restore-keys: |
-          cabal-cache-0
+          cabal-cache-0-
 
     - name: Accessing the result cache
       uses: actions/cache@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,9 +25,10 @@ jobs:
         path: |
           ~/.cabal/store
           dist-newstyle
-        key: cabal-cache-${{ github.sha }}
+        ## We can use the counter to invalidate the cache whenever necessary
+        key: cabal-cache-0-${{ github.sha }}
         restore-keys: |
-          cabal-cache
+          cabal-cache-0
 
     - name: Accessing the result cache
       uses: actions/cache@v2

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -37,7 +37,6 @@ in {
         libsodium
         lzma
         zlib
-        stdenv.cc.cc.lib
 
         # required to build in a pure nix shell
         git

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -10,11 +10,6 @@
     haskellNix.nixpkgsArgs
 }:
 let
-  # updated haskell.nix to get the latest haskell-language-server
-  # idea obtained from https://input-output-hk.github.io/haskell.nix/tutorials/development.html#how-to-get-an-ad-hoc-development-shell-including-certain-packages
-  updatedHaskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/82832676a10a5a0d73eab60e58cc8f1bb591c214.tar.gz) {};
-  updatedNixpkgs = import updatedHaskellNix.sources.nixpkgs updatedHaskellNix.nixpkgsArgs;
-  updatedHaskell = updatedNixpkgs.haskell-nix;
   # The only difficulty we face is making sure to build the haskell-language-server
   # with the same version of GHC that is used for plutus; doing so, however,
   # requires patching ghcide, a dependency of haskell-language-server.
@@ -23,7 +18,7 @@ let
   # inside its 'modules' key:
   custom-hls =
     with
-    (updatedHaskell.hackage-package {
+    (iohkpkgs.haskell-nix.hackage-package {
       compiler-nix-name = "ghc810420210212";
       name = "haskell-language-server";
       version = "1.6.1.1";

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -47,6 +47,7 @@ in {
         hpack
         hlint
         ormolu
+        haskellPackages.happy
      ] ++ [
         # iohk-specific stuff that we require
         iohkpkgs.haskell-nix.internal-cabal-install

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "390926776d35a889852c6de9312661511fade9ed",
-        "sha256": "1dbvpkk0bgg3cirihzwj1s0m6xvjz66rw954ah8661bq96qlfqbr",
+        "rev": "5051bfa9d6b7c07d30f4d8eee23c49d9631ced7c",
+        "sha256": "0labmjfiv5rslgw4ybgkcb18vd457aybdsh0vshf60rlz0ypnnb1",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/390926776d35a889852c6de9312661511fade9ed.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/5051bfa9d6b7c07d30f4d8eee23c49d9631ced7c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
This should have been a comment to #75 , by @serras, but I missed it when I first saw it. The more idiomatic way of updating a pinned dependency is using niv:

```
$ nix-shell -p niv --run "niv update haskellNix"
```

This will update the haskellNix version pinned in `nix/sources.json` for us