### PR TITLE
Uncovers a bug on constraint translation, crashing the SMT; Adds tests to symbolic prover

### DIFF
--- a/src/Pirouette/SMT/Constraints.hs
+++ b/src/Pirouette/SMT/Constraints.hs
@@ -20,6 +20,7 @@ import Pirouette.SMT.Translation
 import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.SystemF
 import Prettyprinter hiding (Pretty (..))
+import Debug.Trace (trace)
 
 -- TODO: this module should probably be refactored somewhere;
 -- I'm not entirely onboard with the 'translateData' funct as it is;
@@ -59,14 +60,14 @@ instance Monoid (Constraint lang meta) where
   mempty = And []
 
 data Branch lang meta =
-  Branch { additionalInfo :: Constraint lang meta 
+  Branch { additionalInfo :: Constraint lang meta
          , newTerm :: TermMeta lang meta }
 
 class (LanguageSMT lang) => LanguageSMTBranches lang where
   -- | Injection of different cases in the symbolic evaluator.
   -- For example, one can introduce a 'if_then_else' built-in
   -- and implement this method to look at both possibilities.
-  branchesBuiltinTerm 
+  branchesBuiltinTerm
     :: ToSMT meta
     => BuiltinTerms lang -> [ArgMeta lang meta]
     -> Maybe [Branch lang meta]
@@ -188,6 +189,8 @@ translateData ::
 translateData knownNames _ (App var []) = translateApp knownNames var []
 translateData knownNames ty (App (Free (TermSig name)) args) = do
   guard (name `elem` knownNames)
+  ty' <- translateType ty
+  _ <- trace ("translateData: " ++ show name ++ "; " ++ show ty') (return ())
   SimpleSMT.app
     <$> (SimpleSMT.as (SimpleSMT.symbol (toSmtName name)) <$> translateType ty)
     -- VCM: Isn't this a bug? We're translating the arguments with the same type as we're

--- a/tests/unit/Pirouette/Term/SymbolicEvalUtils.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalUtils.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Pirouette.Term.SymbolicEvalUtils where
 
 import Pirouette.Term.Syntax.Base
+import Pirouette.Term.Syntax.Pretty
 import Pirouette.Term.Symbolic.Eval
 import Test.Tasty.HUnit
+import Prettyprinter (vsep)
 
 (*=*) :: (Eq a, Show a) => IO (Either String a) -> a -> Assertion
 thing *=* expected = do
@@ -18,12 +21,12 @@ thing `satisfies` property = do
     Left e -> assertFailure $ "finished with errors: " <> e
     Right x -> assertBool ("property not satisfied: " <> show x) (property x)
 
-pathSatisfies :: (LanguageBuiltins lang, Show res) => IO (Either String [Path lang res]) -> ([Path lang res] -> Bool) -> Assertion
+pathSatisfies :: (Language lang, Pretty res, Show res) => IO (Either String [Path lang res]) -> ([Path lang res] -> Bool) -> Assertion
 thing `pathSatisfies` property = do
   given <- thing
   case given of
     Left e -> assertFailure $ "finished with errors: " <> e
-    Right paths -> assertBool ("property not satisfied: " <> show paths) (property paths)
+    Right paths -> assertBool ("property not satisfied:\n" <> show (vsep $ map pretty paths)) (property paths)
 
 (.&.) :: (a -> Bool) -> (a -> Bool) -> (a -> Bool)
 p .&. q = \x -> p x && q x
@@ -38,6 +41,10 @@ isDischarged _ = False
 
 isCounter Path { pathResult = CounterExample _ _ } = True
 isCounter _ = False
+
+isCounterWith :: (Model -> Bool) -> Path lang (EvaluationWitness lang) -> Bool
+isCounterWith f Path { pathResult = CounterExample _ m } = f m
+isCounterWith f _ = False
 
 isNoCounter = not . isCounter
 

--- a/tests/unit/Pirouette/Term/SymbolicProveSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicProveSpec.hs
@@ -1,34 +1,38 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Pirouette.Term.SymbolicProveSpec (tests) where
 
 import Control.Monad.Reader
 import Language.Pirouette.Example
 import Pirouette.Monad
-import Pirouette.Term.Syntax.Base
+import qualified Pirouette.SMT.SimpleSMT as SimpleSMT
 import Pirouette.Term.Symbolic.Eval
 import Pirouette.Term.Symbolic.Prover
-import Pirouette.Transformations ( elimEvenOddMutRec )
+import Pirouette.Term.SymbolicEvalUtils
+import Pirouette.Term.Syntax.Base
+import Pirouette.Transformations (elimEvenOddMutRec)
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Pirouette.Term.SymbolicEvalUtils
-
-exec :: (Program Ex, Type Ex, Term Ex) -> (Term Ex, Term Ex)
-     -> IO (Either String [Path Ex (EvaluationWitness Ex)])
-exec (program, tyRes, fn) (assume, toProve) = fmap fst $ mockPrtT $ do
-  let decls = uncurry PrtUnorderedDefs program
-  orderedDecls <- elimEvenOddMutRec decls
-  flip runReaderT orderedDecls $ 
-    prove (Problem tyRes fn assume toProve)
+exec ::
+  (Program Ex, Type Ex, Term Ex) ->
+  (Term Ex, Term Ex) ->
+  IO (Either String [Path Ex (EvaluationWitness Ex)])
+exec (program, tyRes, fn) (assume, toProve) = fmap fst $
+  mockPrtT $ do
+    let decls = uncurry PrtUnorderedDefs program
+    orderedDecls <- elimEvenOddMutRec decls
+    flip runReaderT orderedDecls $
+      prove (Problem tyRes fn assume toProve)
 
 add1 :: (Program Ex, Type Ex, Term Ex)
-add1 = (
-  [prog|
+add1 =
+  ( [prog|
 fun add1 : Integer -> Integer
   = \(x : Integer) . x + 1
 
@@ -40,21 +44,25 @@ fun greaterThan1 : Integer -> Bool
 
 fun main : Integer = 42
   |],
-  [ty|Integer|],
-  [term| \(x : Integer) . add1 x |])
+    [ty|Integer|],
+    [term| \(x : Integer) . add1 x |]
+  )
 
 input0Output0 :: (Term Ex, Term Ex)
-input0Output0 = (
-  [term| \(result : Integer) (x : Integer) . greaterThan0 result |],
-  [term| \(result : Integer) (x : Integer) . greaterThan0 x |])
+input0Output0 =
+  ( [term| \(result : Integer) (x : Integer) . greaterThan0 result |],
+    [term| \(result : Integer) (x : Integer) . greaterThan0 x |]
+  )
 
 input0Output1 :: (Term Ex, Term Ex)
-input0Output1 = (
-  [term| \(result : Integer) (x : Integer) . greaterThan1 result |],
-  [term| \(result : Integer) (x : Integer) . greaterThan0 x |])
+input0Output1 =
+  ( [term| \(result : Integer) (x : Integer) . greaterThan1 result |],
+    [term| \(result : Integer) (x : Integer) . greaterThan0 x |]
+  )
 
 maybes :: Program Ex
-maybes = [prog|
+maybes =
+  [prog|
 data MaybeInt
   = JustInt : Integer -> Maybe Int
   | NothingInt : Maybe Int
@@ -71,29 +79,224 @@ fun not : Bool -> Bool
 fun main : Integer = 42
 |]
 
+-- This is a small example taken from O'Hearn's paper; besides being interesting for
+-- testing conditionals, it is also interesting in and of itself. This is the example:
+--
+-- > [z == 11]
+-- > if (even x) {
+-- >   if (odd y) {
+-- >     z == 42
+-- >   }
+-- > }
+-- > [z == 42]
+--
+-- Do you think the IL triple above is satisfiable? Surprisingly, it's not. In the imperative setting,
+-- the statement @[P] f [Q]@ means that forall state s1 satisfying @Q@, there exists s0 such that s1 is reachable
+-- from s0 by f and s0 satisfies @P@. With that in mind, the state @[(z, 42), (x, 3), (y, 2)]@ satisfies @Q@
+-- and, albeit reachable, it is not reachable from a state satisfying the precondition @z == 11@.
+-- Therefore the IL triple is falsifiable and we'd expect such a counterexample from our tool.
+-- A IL triple really /means/:
+--
+-- > [P] f [Q] <=> { s' | s' \in post f && Q s' } \subseteq { f s | P s }
+--
+-- Which makes it obvious that, @[(z, 42), (x, 3), (y, 2)]@ is both a post state and satisfies Q,
+-- but its not an element of { f s | P s } because all elements of that set satisfy z == 11.
+--
+-- If we enrich our postcondition to read:
+--
+-- > [z == 42 && even x && odd y]
+--
+-- Now we have a valid IL triple, and this provides an interesting test case for pirouette.
+-- Firstly, though, we have to translate the semantics of triples. In a pure setting we have
+-- no notion of reachability, only termination. Hence,
+--
+-- [P] f [Q] <=> { o | \Ex i . o = f i && Q o } \subseteq { f i | P i }
+--
+-- Which translates to:
+--
+-- >    forall x . x \in { o | \Ex i . o = f i && Q o } `implies` x \in { f i | P i }
+-- > == forall x . (\Ex i1 . x = f i1 && Q x) `implies` (\Ex i2 . P i2 && x = f i2)
+--
+-- (TODO: Exercise for the writer: double check these statements!)
+--
+-- To translate the code block given by O'Hearn on their paper to Haskell, we could get
+-- something like:
+--
+-- > ohearn :: (Integer, Integer) -> (Integer, Integer)
+-- > ohearn x y
+-- >   | even x = (x, 42)
+-- >   | otherwise = (x, y)
+--
+-- Now, if we ask the question of whether or not the following triple is valid:
+--
+-- > [\(x, y) -> y == 11] ohearn [\(rx, ry) (x, y) -> ry == 42]
+--
+-- Or, in other words:
+--
+-- > forall rx ry . (\Ex x y . (rx, ry) == f (x, y) && ry == 42) `implies` (\Ex x y . (rx, ry) == f (x, y) && y == 11)
+--
+-- It's still not valid! A similar model gives us a counterexample: f (3, 42) == (3, 42) && y /= 11
+-- In fact, any choice of an odd value for the first component of the input pair will yield a counterexample.
+-- Again, strengthtening the postcondition gives us a valid triple:
+--
+-- > [\(x, y) -> y == 11] ohearn [\(rx, ry) (x, y) -> even x && ry == 42]
+--
+
+conditionals1 :: (Program Ex, Type Ex, Term Ex)
+conditionals1 =
+  ( [prog|
+data Delta = D : Integer -> Integer -> Delta
+
+fun fst : Delta -> Integer
+  = \(x : Delta) . match_Delta x @Integer (\(a : Integer) (b : Integer) . a)
+
+fun snd : Delta -> Integer
+  = \(x : Delta) . match_Delta x @Integer (\(a : Integer) (b : Integer) . b)
+
+fun even : Integer -> Bool
+  = \(x : Integer) . if @Bool x == 0 then True else odd (x - 1)
+
+fun odd : Integer -> Bool
+  = \(x : Integer) . if @Bool x == 0 then False else even (x - 1)
+
+fun and : Bool -> Bool -> Bool
+  = \(x : Bool) (y : Bool) . if @Bool x then y else False
+
+fun ohearn : Delta -> Delta
+  = \(xy : Delta)
+  . if @Delta even (fst xy)
+    then D (fst xy) 42
+    else xy
+
+fun main : Integer = 42
+  |],
+    [ty|Delta|],
+    [term| \(x : Delta) . ohearn x |]
+  )
+
+condWrongTriple :: (Term Ex, Term Ex)
+condWrongTriple =
+  ( [term| \(result : Delta) (x : Delta) . snd x == 11 |],
+    [term| \(result : Delta) (x : Delta) . snd result == 42 |]
+  )
+
+condCorrectTriple :: (Term Ex, Term Ex)
+condCorrectTriple =
+  ( [term| \(result : Delta) (x : Delta) . snd x == 11 |],
+    [term| \(result : Delta) (x : Delta) . (and (snd result == 42) (even (fst result))) |]
+  )
+
+ohearnTest :: TestTree
+ohearnTest =
+  testGroup
+    "OHearn"
+    [ testCase "[y == 11] ohearn [snd result == 42] counter" $
+        let isValidCounter = \case
+              SimpleSMT.Other (SimpleSMT.List [SimpleSMT.Atom "pir_D", SimpleSMT.Atom fstX, _]) -> odd (read fstX)
+              _ -> False
+         in exec conditionals1 condWrongTriple `pathSatisfies` all (isCounterWith $ maybe False isValidCounter . lookup (SimpleSMT.Atom "pir_x")),
+      testCase "[y == 11] ohearn [snd result == 42 && even (fst result)] verified" $
+        exec conditionals1 condCorrectTriple `pathSatisfies` all isVerified
+    ]
+
+-- We didn't have much success with builtins integers; let me try the same with peano naturals:
+
+conditionals1Peano :: (Program Ex, Type Ex, Term Ex)
+conditionals1Peano =
+  ( [prog|
+data Nat = Z : Nat | S : Nat -> Nat
+
+fun eq : Nat -> Nat -> Bool
+  = \(x : Nat) (y : Nat)
+  . match_Nat x @Bool
+      (match_Nat y @Bool True (\(yy : Nat) . False))
+      (\(xx : Nat) . match_Nat y @Bool False (\(yy : Nat) . eq xx yy))
+
+fun even : Nat -> Bool
+  = \(x : Nat) . match_Nat x @Bool True odd
+
+fun odd : Nat -> Bool
+  = \(x : Nat) . match_Nat x @Bool False even
+
+data Delta = D : Nat -> Nat -> Delta
+
+fun fst : Delta -> Nat
+  = \(x : Delta) . match_Delta x @Nat (\(a : Nat) (b : Nat) . a)
+
+fun snd : Delta -> Nat
+  = \(x : Delta) . match_Delta x @Nat (\(a : Nat) (b : Nat) . b)
+
+fun and : Bool -> Bool -> Bool
+  = \(x : Bool) (y : Bool) . if @Bool x then y else False
+
+fun ohearn : Delta -> Delta
+  = \(xy : Delta)
+  . if @Delta even (fst xy)
+    then D (fst xy) (S (S Z))
+    else xy
+
+fun main : Integer = 42
+  |],
+    [ty|Delta|],
+    [term| \(x : Delta) . ohearn x |]
+  )
+
+condWrongTriplePeano :: (Term Ex, Term Ex)
+condWrongTriplePeano =
+  ( [term| \(result : Delta) (x : Delta) . eq (snd x) (S Z)  |],
+    [term| \(result : Delta) (x : Delta) . False -- eq (snd result) (S (S Z)) |]
+  )
+
+condCorrectTriplePeano :: (Term Ex, Term Ex)
+condCorrectTriplePeano =
+  ( [term| \(result : Delta) (x : Delta) . eq (snd x) (S Z) |],
+    [term| \(result : Delta) (x : Delta) . (and (eq (snd result) (S (S Z))) (even (fst result))) |]
+  )
+
+-- XXX: The following tests are hitting the bug on Pirouette.SMT.Constraints, line 196
+
+ohearnTestPeano :: TestTree
+ohearnTestPeano =
+  testGroup
+    "OHearn Peano"
+    [ testCase "[y == 1] ohearn-peano [snd result == 2] counter" $
+        let isValidCounter = \case
+              SimpleSMT.Other (SimpleSMT.List [SimpleSMT.Atom "pir_D", SimpleSMT.Atom fstX, _]) -> odd (read fstX)
+              _ -> False
+         in exec conditionals1Peano condWrongTriplePeano `pathSatisfies` all isVerified -- (isCounterWith $ maybe False isValidCounter . lookup (SimpleSMT.Atom "pir_x")),
+      -- testCase "[y == 1] ohearn-peano [snd result == 2 && even (fst result)] verified" $
+      --   exec conditionals1Peano condCorrectTriplePeano `pathSatisfies` all isVerified
+    ]
+
 switchSides :: (Term Ex, Term Ex) -> (Term Ex, Term Ex)
 switchSides (assume, prove) = (prove, assume)
 
 tests :: [TestTree]
-tests = [
-  testGroup "incorrectness triples" 
-    [ testCase "[input > 0] add 1 [result > 0] counter" $
-        exec add1 input0Output0 `pathSatisfies` (isSingleton .&. all isCounter),
-      testCase "[input > 0] add 1 [result > 1] verified" $
-        exec add1 input0Output1 `pathSatisfies` (isSingleton .&. all isVerified),
-      testCase "[isNothing x] isJust x [not result] verified" $
-        exec (maybes, [ty|Bool|], [term|\(x:MaybeInt) . isJust x|]) 
-             ([term|\(r:Bool) (x:MaybeInt) . not r|], [term|\(r:Bool) (x:MaybeInt) . isNothing x|])
-          `pathSatisfies` (all isNoCounter .&. any isVerified),
-      testCase "[isJust x] isJust x [not result] counter" $
-        exec (maybes, [ty|Bool|], [term|\(x:MaybeInt) . isJust x|]) 
-             ([term|\(r:Bool) (x:MaybeInt) . not r|], [term|\(r:Bool) (x:MaybeInt) . isJust x|])
-          `pathSatisfies` any isCounter
-    ],
-  testGroup "Hoare triples" 
-    [ testCase "{input > 0} add 1 {result > 0} verified" $
-        exec add1 (switchSides input0Output0) `pathSatisfies` (isSingleton .&. all isVerified),
-      testCase "{input > 0} add 1 {result > 1} verified" $
-        exec add1 (switchSides input0Output1) `pathSatisfies` (isSingleton .&. all isVerified)
-    ]
+tests =
+  [ testGroup
+      "incorrectness triples"
+      [ testCase "[input > 0] add 1 [result > 0] counter" $
+          exec add1 input0Output0 `pathSatisfies` (isSingleton .&. all isCounter),
+        testCase "[input > 0] add 1 [result > 1] verified" $
+          exec add1 input0Output1 `pathSatisfies` (isSingleton .&. all isVerified),
+        testCase "[isNothing x] isJust x [not result] verified" $
+          exec
+            (maybes, [ty|Bool|], [term|\(x:MaybeInt) . isJust x|])
+            ([term|\(r:Bool) (x:MaybeInt) . not r|], [term|\(r:Bool) (x:MaybeInt) . isNothing x|])
+            `pathSatisfies` (all isNoCounter .&. any isVerified),
+        testCase "[isJust x] isJust x [not result] counter" $
+          exec
+            (maybes, [ty|Bool|], [term|\(x:MaybeInt) . isJust x|])
+            ([term|\(r:Bool) (x:MaybeInt) . not r|], [term|\(r:Bool) (x:MaybeInt) . isJust x|])
+            `pathSatisfies` any isCounter
+      ],
+    testGroup
+      "Hoare triples"
+      [ testCase "{input > 0} add 1 {result > 0} verified" $
+          exec add1 (switchSides input0Output0) `pathSatisfies` (isSingleton .&. all isVerified),
+        testCase "{input > 0} add 1 {result > 1} verified" $
+          exec add1 (switchSides input0Output1) `pathSatisfies` (isSingleton .&. all isVerified)
+      ],
+    ohearnTest,
+    ohearnTestPeano
   ]


### PR DESCRIPTION
I wanted to add some more involved tests to our prover and ended up finding a bug on `translateData`. While trying to diagnose the problem, I left a number of `trace` calls through the code. I found where the problem comes from, but I won't have time to solve this now, so this probably has more value as a separate PR that someone can pick up or I can continue later.

## The Bug 

Seeing the SMT crash with:
```
            Result: (error "Parse Error: <stdin>:337.79: Type ascription on constructor not satisfied, term pir_S expected sort pir_Delta but has sort pir_Nat ...pir_D pir_Delta )
```

### The Reason

We're sending the following statement to the SMT:

```
(assert (and (= pir___result ((as pir_D pir_Delta ) pir_s0 ((as pir_S pir_Delta ) ((as pir_S pir_Delta ) pir_Z ) ) ) )  ... )
```

But `D` and `S` are constructors of different types:

```
data Delta = D : Nat -> Nat -> Delta
data Nat = Z : Nat | S : Nat -> Nat
```

We should be sending the following to the SMT instead:

```
(assert (and (= pir___result ((as pir_D pir_Delta ) pir_s0 ((as pir_S pir_Nat ) ((as pir_S pir_Nat ) pir_Z ) ) ) )  ... )
```

The bug happens in the [translateData](https://github.com/tweag/pirouette/blob/dev/src/Pirouette/SMT/Constraints.hs#L192) function. Seems like my comment in there was correct, it *is* a bug! :) 

### Reproducing

The bug can be reproduced running:
```
$ cabal run spec -- -p '/prove/ && /Peano/'
```

## Orthogonal: Documentation

This PR also adds a large comment on the test inspired by the incorrectness logic paper; would be good to read that one carefully later on.