### PR TITLE
Generalized stopping conditions for symbolic evaluation

### DIFF
--- a/executable/Main.hs
+++ b/executable/Main.hs
@@ -34,7 +34,7 @@ import Pirouette.Monad.Logger
 import Language.Pirouette.PlutusIR.SMT ()
 import Language.Pirouette.PlutusIR.Builtins
 import Language.Pirouette.PlutusIR.ToTerm
-import Pirouette.Term.Symbolic.Eval (runFor, AvailableFuel(..))
+import Pirouette.Term.Symbolic.Eval (runFor, SymEvalStatistics(..))
 import Pirouette.Term.Symbolic.Interface (runIncorrectness)
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as R
@@ -139,7 +139,7 @@ mainOpts opts uDefs = do
     symbolicExec n (DFunction _ t _) =
       let fil = constraintFile opts in
       if fil == ""
-      then runFor (Fuel 10) n t
+      then runFor (\st -> sestConsumedFuel st > 10) n t
       else runIncorrectness (constraintFile opts) t
     symbolicExec _ _ = throwError' (PEOther "Impossible to symbolic execute a symbol which is not a function")
 

--- a/src/Language/Pirouette/Example/MinSwap.hs
+++ b/src/Language/Pirouette/Example/MinSwap.hs
@@ -10,7 +10,7 @@ import Pirouette.Term.Syntax.Base
 checkWrong :: IO ()
 checkWrong =
   incorrectnessLogic
-    200 -- amount of steps
+    15 -- amount of steps
     minswap -- entire program
     [term| \(tx : TxInfo) . validator tx |] -- validator
     ( [term| \(result : Bool) (tx : TxInfo) . result |] -- incorrectness triple
@@ -20,7 +20,7 @@ checkWrong =
 checkOk :: IO ()
 checkOk =
   incorrectnessLogic
-    100 -- amount of steps
+    20 -- amount of steps
     minswap -- entire program
     [term| \(tx : TxInfo) . correct_validator tx |] -- validator
     ( [term| \(result : Bool) (tx : TxInfo) . result |] -- incorrectness triple

--- a/src/Pirouette/Term/Symbolic/Interface.hs
+++ b/src/Pirouette/Term/Symbolic/Interface.hs
@@ -456,7 +456,7 @@ runIncorrectness ::
   Term lang ->
   m ()
 runIncorrectness fil t = do
-  paths <- flip pathsIncorrectness_ t $ \solver -> do
+  paths <- flip (pathsIncorrectness_ (const False)) t $ \solver -> do
     constrDescription <- liftIO $ eitherDecodeFileStrict fil
     case constrDescription of
       Left l -> error $ "Impossible to parse this file\n" ++ l

--- a/src/Pirouette/Term/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Term/Symbolic/Prover/Runner.hs
@@ -26,7 +26,8 @@ incorrectnessLogic ::
   Term lang ->
   AssumeProve lang ->
   IO ()
-incorrectnessLogic fuel program validator (post :==>: pre) = do
+incorrectnessLogic maxCstrs program validator (post :==>: pre) = do
+  let shouldStop = \st -> sestConstructors st > maxCstrs
   (result, _logs) <- mockPrtT $ do
     let prog0 = uncurry PrtUnorderedDefs program
     let prog1 = monomorphize prog0
@@ -37,8 +38,8 @@ incorrectnessLogic fuel program validator (post :==>: pre) = do
             flip runReaderT ((prtDecls orderedDecls, []), [DeclPath "validator"]) $
               typeInferTerm validator
     flip runReaderT orderedDecls $ do
-      proveAnyWithFuel fuel isCounter (Problem resultTy validator post pre)
-  printResult fuel result
+      proveAny shouldStop isCounter (Problem resultTy validator post pre)
+  printResult maxCstrs result
   where
     isCounter Path {pathResult = CounterExample _ _, pathStatus = s}
       | s /= OutOfFuel = True

--- a/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
+++ b/tests/unit/Pirouette/Term/SymbolicEvalSpec.hs
@@ -27,7 +27,7 @@ symbolicExec program term = fmap fst $ mockPrtT $ do
   let decls = uncurry PrtUnorderedDefs program
   orderedDecls <- elimEvenOddMutRec decls
   flip runReaderT orderedDecls $ do
-    pathsFor (Fuel 10) "main" term
+    pathsFor (\st -> sestConsumedFuel st > 10) "main" term
 
 incorrectnessExec' :: (Program Ex, Term Ex) -> (Constraint Ex, TermMeta Ex SymVar -> Constraint Ex)
                    -> IO (Either String [Path Ex (EvaluationWitness Ex)])
@@ -39,7 +39,7 @@ incorrectnessExec program term inC outC = fmap fst $ mockPrtT $ do
   let decls = uncurry PrtUnorderedDefs program
   orderedDecls <- elimEvenOddMutRec decls
   flip runReaderT orderedDecls $ do
-    pathsIncorrectness UserDeclaredConstraints {
+    pathsIncorrectness (const False) UserDeclaredConstraints {
       udcInputs = [], 
       udcOutputCond = outC, 
       udcInputCond = inC, 


### PR DESCRIPTION
This is a quick generalization of the usage of "fuel" to stop symbolic evaluation. The idea is
1. Gather different statistics during evaluation (fuel used, # of constructors introduced, etcetera);
2. The "runner" function take a new `StoppingCondition` which is nothing more than a predicate `SymEvalStatistics -> Bool`.

So now our previous runners become:
- Infinite runners simply use `const False` as `StoppingCondition`,
- Runners with limited fuel are implemented as `\st -> sestConsumedFuel st > availableFuel`,
- Runners limited by constructors can now be implemented as `\st -> sestConstructors st > maxConstructors`.