### PR TITLE
Use pure `solve` function

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ dependencies:
   - optics-core
   - optics-th
   - ansi-terminal
+  - parallel
 
 library:
   source-dirs: src
@@ -50,6 +51,7 @@ library:
     -Wall
     -Wno-orphans
     -fplugin=StackTrace.Plugin
+    -threaded
 
 tests:
   spec:
@@ -58,3 +60,5 @@ tests:
       - tests/unit
     dependencies:
       - pirouette
+    ghc-options:
+      -threaded

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -65,7 +65,7 @@ library
       Paths_pirouette
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wno-orphans -fplugin=StackTrace.Plugin
+  ghc-options: -Wall -Wno-orphans -fplugin=StackTrace.Plugin -threaded
   build-depends:
       QuickCheck
     , aeson
@@ -86,6 +86,7 @@ library
     , optics-core
     , optics-th
     , optparse-applicative
+    , parallel
     , parser-combinators
     , plutus-core
     , prettyprinter
@@ -126,6 +127,7 @@ test-suite spec
       Paths_pirouette
   hs-source-dirs:
       tests/unit
+  ghc-options: -threaded
   build-depends:
       QuickCheck
     , aeson
@@ -146,6 +148,7 @@ test-suite spec
     , optics-core
     , optics-th
     , optparse-applicative
+    , parallel
     , parser-combinators
     , pirouette
     , plutus-core

--- a/src/ListT/Weighted.hs
+++ b/src/ListT/Weighted.hs
@@ -8,7 +8,7 @@
 -- | A re-implementation of @weighted-search@
 -- as a monad transformer.
 module ListT.Weighted
-  ( WeightedListT,
+  ( WeightedListT(..),
     WeightedList,
     MonadWeightedList (..),
     (<|>),

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -161,7 +161,8 @@ runSymEvalWorker defs st f = do
   let sharedSolve :: SolverProblem lang res -> res
       sharedSolve = PureSMT.solve solverCtx
   let solvers = SymEvalSolvers (sharedSolve . CheckPath) (sharedSolve . CheckProperty)
-  solvPair <- runSymEvalRaw solvers defs st f
+  let st' = st { sestKnownNames = solverSharedCtxUsedNames solverCtx `S.union` sestKnownNames st }
+  solvPair <- runSymEvalRaw solvers defs st' f
   let paths = uncurry path solvPair
   return paths
   where

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -352,7 +352,10 @@ symEvalOneStep t@(R.App hd args) = case hd of
           R.TermArg
           args
 
--- A-ha... it's the state monad annoying us
+-- A-ha... it's the state monad annoying us. Maybe if we can understand whether
+-- we really need the state monad we can better understand the parallelism possibilities
+-- in here. If we do really need the monad, we can only paralellize the prune and pruneAndValidate
+-- functions, if not, we could paralellize everything.
 symEvalParallel ::
   forall lang .
   (SymEvalConstr lang) =>
@@ -373,7 +376,7 @@ symEvalMatchesFirst ::
   (TermMeta lang SymVar -> a) ->
   [a] ->
   WriterT Any (SymEval lang) [a]
-symEvalMatchesFirst f g exprs = withStrategy (parList rpar) <$> go [] exprs
+symEvalMatchesFirst f g exprs = go [] exprs
   where
     -- we came to the end without a match,
     -- so we execute one step in parallel

--- a/src/Pirouette/Symbolic/Prover.hs
+++ b/src/Pirouette/Symbolic/Prover.hs
@@ -6,7 +6,6 @@
 
 module Pirouette.Symbolic.Prover where
 
-import Control.Monad.Except
 import Control.Monad.State
 import Control.Monad.Writer
 import qualified Data.Text as T
@@ -60,7 +59,7 @@ rESULTNAME = "__result"
 
 -- |Executes the problem returning /all/ paths (up to some stopping condition).
 prove ::
-  (SymEvalConstr lang m, MonadIO m) =>
+  (SymEvalConstr lang m) =>
   StoppingCondition ->
   Problem lang ->
   m [Path lang (EvaluationWitness lang)]
@@ -71,7 +70,7 @@ prove shouldStop problem = symevalT shouldStop $ proveRaw problem
 -- means that on all paths that we looked at they were either verified or
 -- they reached the stopping condition.
 proveAny ::
-  (SymEvalConstr lang m, MonadIO m) =>
+  (SymEvalConstr lang m) =>
   StoppingCondition ->
   (Path lang (EvaluationWitness lang) -> Bool) ->
   Problem lang ->

--- a/src/Pirouette/Symbolic/Prover.hs
+++ b/src/Pirouette/Symbolic/Prover.hs
@@ -9,7 +9,7 @@ module Pirouette.Symbolic.Prover where
 import Control.Monad.State
 import Control.Monad.Writer
 import qualified Data.Text as T
-import Pirouette.Monad (termIsWHNFOrMeta)
+import Pirouette.Monad (termIsWHNFOrMeta, PirouetteDepOrder)
 import Pirouette.SMT.Base (LanguageSMT (isStuckBuiltin))
 import Pirouette.SMT.Constraints
 import PureSMT (SExpr (..))
@@ -59,18 +59,18 @@ rESULTNAME = "__result"
 
 -- |Executes the problem returning /all/ paths (up to some stopping condition).
 prove ::
-  (SymEvalConstr lang m) =>
+  (SymEvalConstr lang, PirouetteDepOrder lang m) =>
   StoppingCondition ->
   Problem lang ->
   m [Path lang (EvaluationWitness lang)]
-prove shouldStop problem = symevalT shouldStop $ proveRaw problem
+prove shouldStop problem = symeval shouldStop $ proveRaw problem
 
 -- |Executes the problem while the stopping condition is valid until
 -- the supplied predicate returns @True@. A return value of @Nothing@
 -- means that on all paths that we looked at they were either verified or
 -- they reached the stopping condition.
 proveAny ::
-  (SymEvalConstr lang m) =>
+  (SymEvalConstr lang, PirouetteDepOrder lang m) =>
   StoppingCondition ->
   (Path lang (EvaluationWitness lang) -> Bool) ->
   Problem lang ->
@@ -78,10 +78,10 @@ proveAny ::
 proveAny shouldStop p problem = symevalAnyPath shouldStop p $ proveRaw problem
 
 proveRaw ::
-  forall lang m.
-  SymEvalConstr lang m =>
+  forall lang.
+  SymEvalConstr lang =>
   Problem lang ->
-  SymEvalT lang m (EvaluationWitness lang)
+  SymEval lang (EvaluationWitness lang)
 proveRaw Problem {..} = do
   -- get types for lambdas
   let (lams, _) = R.getHeadLams problemBody
@@ -106,13 +106,13 @@ proveRaw Problem {..} = do
     refineWitness _ w = w
 
 worker ::
-  forall lang m.
-  SymEvalConstr lang m =>
+  forall lang.
+  SymEvalConstr lang =>
   SymVar ->
   SymTerm lang ->
   SymTerm lang ->
   SymTerm lang ->
-  SymEvalT lang m (EvaluationWitness lang)
+  SymEval lang (EvaluationWitness lang)
 worker resultVar bodyTerm assumeTerm proveTerm = do
   -- liftIO $ putStrLn "ONE STEP"
   -- liftIO $ print (pretty bodyTerm)

--- a/src/Pirouette/Symbolic/Prover.hs
+++ b/src/Pirouette/Symbolic/Prover.hs
@@ -163,8 +163,8 @@ worker resultVar bodyTerm assumeTerm proveTerm = do
     _ -> do
       -- one step of evaluation on each,
       -- but going into matches first
-      ([bodyTerm', assumeTerm', proveTerm'], somethingWasEval) <- prune $ runWriterT $
-        symEvalMatchesFirst Just id [bodyTerm, assumeTerm, proveTerm]
+      ([bodyTerm', assumeTerm', proveTerm'], somethingWasEval) <- prune $
+        symEvalParallel [bodyTerm, assumeTerm, proveTerm]
       -- liftIO $ putStrLn "ONE STEP"
       -- liftIO $ print (pretty bodyTerm')
       -- liftIO $ print (pretty assumeTerm')

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -12,6 +12,7 @@ import Control.Concurrent.MVar
 import Control.Concurrent.QSem
 import System.IO.Unsafe (unsafePerformIO)
 import Control.Monad
+import GHC.Conc (numCapabilities)
 
 -- |In order to use the pure 'solve' function, you must provide an instance of 'Solve'
 -- for your particular domain. The methods of the 'Solve' class are not meant to
@@ -57,11 +58,6 @@ launchAll ctx = replicateM numCapabilities $ do
   initSolver @domain ctx s
   newMVar s
   where
-    -- TODO: these constants should become parameters at some point; the solver command too!
-
-    numCapabilities :: Int
-    numCapabilities = 3
-
     debug0 :: Bool
     debug0 = False
 

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -55,10 +55,10 @@ launchAll ctx = replicateM numCapabilities $ do
     -- TODO: these constants should become parameters at some point; the solver command too!
 
     numCapabilities :: Int
-    numCapabilities = 1
+    numCapabilities = 4
 
     debug0 :: Bool
-    debug0 = False
+    debug0 = True
 
 -- * Async Locks
 

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -55,7 +55,7 @@ launchAll ctx = replicateM numCapabilities $ do
     -- TODO: these constants should become parameters at some point; the solver command too!
 
     numCapabilities :: Int
-    numCapabilities = 4
+    numCapabilities = 1
 
     debug0 :: Bool
     debug0 = False

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -60,7 +60,7 @@ recv solver = do
     Nothing -> fail "no response from solver"
     Just (sexpr, _) -> do
       pid <- unsafeSolverPid solver
-      when (debug solver) $ do
+      when (debug solver && sexpr /= Atom "success") $ do
         putStrLn ("[recv: " ++ show pid ++ "] " ++ showsSExpr sexpr "")
       return sexpr
 


### PR DESCRIPTION
Using a `pure` solve function and parallel symbolic evaluation seems promising; our state monad is hurting us a little, I might work on removing that state monad if not extremely necessary. 

Also, another curious fact is that keeping the lock in `pushMStack` and `popMStack` causes a deadlock, but removing it makes everything go through. I'm a bit puzzled by it.