### PR TITLE
More Plutus IR built-ins

### DIFF
--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -37,6 +37,7 @@ library
       Pirouette.SMT.FromTerm
       Pirouette.SMT.Monadic
       Pirouette.Symbolic.Eval
+      Pirouette.Symbolic.Eval.Helpers
       Pirouette.Symbolic.Eval.SMT
       Pirouette.Symbolic.Eval.Types
       Pirouette.Symbolic.Prover

--- a/src/Language/Pirouette/Example.hs
+++ b/src/Language/Pirouette/Example.hs
@@ -36,6 +36,7 @@ import Pirouette.SMT.Base
 import Pirouette.SMT.Constraints
 import qualified PureSMT
 import Pirouette.Term.Syntax
+import Pirouette.Symbolic.Eval.Helpers
 import Pirouette.Symbolic.Eval.Types
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Prettyprinter (dquotes)
@@ -256,64 +257,11 @@ instance LanguageSymEval Ex where
       let isEq TermEq = True
           isEq TermStrEq = True
           isEq _ = False
-          t' = t `SystF.appN` excess
-          e' = e `SystF.appN` excess
-       in case c of
-            BTrue -> pure $ Just [Branch (And []) t]
-            BFalse -> pure $ Just [Branch (And []) e]
-            SystF.App (SystF.Free (Builtin eq)) [SystF.TermArg x, SystF.TermArg y]
-              -- try to generate the best type of constraint
-              -- from the available equality ones
-              | isEq eq,
-                Just x1 <- termIsMeta x,
-                Just y1 <- termIsMeta y ->
-                pure $
-                  Just
-                    [ -- either they are equal
-                      Branch (And [VarEq x1 y1]) t',
-                      -- or they are not
-                      Branch (And [NonInlinableSymbolNotEq x y]) e'
-                    ]
-              | isEq eq,
-                Just x1 <- termIsMeta x,
-                isStuckBuiltin y ->
-                pure $
-                  Just
-                    [ -- either they are equal
-                      Branch (And [Assign x1 y]) t',
-                      -- or they are not
-                      Branch (And [NonInlinableSymbolNotEq x y]) e'
-                    ]
-              | isEq eq,
-                isStuckBuiltin x,
-                Just y1 <- termIsMeta y ->
-                pure $
-                  Just
-                    [ -- either they are equal
-                      Branch (And [Assign y1 x]) t',
-                      -- or they are not
-                      Branch (And [NonInlinableSymbolNotEq y x]) e'
-                    ]
-              | isEq eq,
-                isStuckBuiltin x,
-                isStuckBuiltin y ->
-                pure $
-                  Just
-                    [ -- either they are equal
-                      Branch (And [NonInlinableSymbolEq x y]) t',
-                      -- or they are not
-                      Branch (And [NonInlinableSymbolNotEq x y]) e'
-                    ]
-            _
-              | Just v <- termIsMeta c ->
-                pure $
-                  Just
-                    [ -- c is True => t is executed
-                      Branch (And [Assign v BTrue]) t',
-                      -- c is False => e is executed
-                      Branch (And [Assign v BFalse]) e'
-                    ]
-            _ -> pure Nothing
+          isTrue BTrue = True
+          isTrue _ = False
+          isFalse BFalse = True
+          isFalse _ = False
+       in ifThenElseBranching isTrue BTrue isFalse BFalse isEq c t e excess
   branchesBuiltinTerm _ _ _ = pure Nothing
 
 -- * QuasiQuoters

--- a/src/Language/Pirouette/PlutusIR/SMT.hs
+++ b/src/Language/Pirouette/PlutusIR/SMT.hs
@@ -207,7 +207,7 @@ trPIRFun op [x, y] =
     P.EqualsData -> Just $ PureSMT.eq x y
     -- constructors
     P.MkCons -> Just $ PureSMT.fun "Cons" [x, y]
-    P.MkPairData -> Just $ PureSMT.tuple [x, y]
+    P.MkPairData -> Just $ PureSMT.fun "Tuple2" [x, y]
     _ ->
       error $
         "Translate builtin to SMT: "

--- a/src/Language/Pirouette/PlutusIR/SMT.hs
+++ b/src/Language/Pirouette/PlutusIR/SMT.hs
@@ -151,6 +151,24 @@ trPIRFun :: P.DefaultFun -> [PureSMT.SExpr] -> Maybe PureSMT.SExpr
 --     P.DecodeUtf8
 --
 
+-- Pattern matching in disguise,
+-- so we return here Nothing and then "translate"
+-- into an actual match in 'branchesBuiltinTerm'
+trPIRFun P.ChooseList _ = Nothing
+trPIRFun P.ChooseUnit _ = Nothing
+trPIRFun P.ChooseData _ = Nothing
+trPIRFun P.FstPair _ = Nothing
+trPIRFun P.SndPair _ = Nothing
+trPIRFun P.HeadList _ = Nothing
+trPIRFun P.TailList _ = Nothing
+trPIRFun P.UnConstrData _ = Nothing
+trPIRFun P.UnMapData _ = Nothing
+trPIRFun P.UnListData _ = Nothing
+trPIRFun P.UnIData _ = Nothing
+trPIRFun P.UnBData _ = Nothing
+-- If-then-else is complicated
+trPIRFun P.IfThenElse _ = Nothing
+
 -- Unary
 trPIRFun op [x] =
   case op of
@@ -171,6 +189,7 @@ trPIRFun op [x] =
         "Translate builtin to SMT: "
           <> show op
           <> " is not an implemented unary operator/function"
+
 -- Binary operations and relations
 trPIRFun op [x, y] =
   case op of
@@ -202,23 +221,7 @@ trPIRFun op [x, y] =
         "Translate builtin to SMT: "
           <> show op
           <> " is not an implemented binary operator/function"
--- Pattern matching in disguise,
--- so we return here Nothing and then "translate"
--- into an actual match in 'branchesBuiltinTerm'
-trPIRFun P.ChooseList _ = Nothing
-trPIRFun P.ChooseUnit _ = Nothing
-trPIRFun P.ChooseData _ = Nothing
-trPIRFun P.FstPair _ = Nothing
-trPIRFun P.SndPair _ = Nothing
-trPIRFun P.HeadList _ = Nothing
-trPIRFun P.TailList _ = Nothing
-trPIRFun P.UnConstrData _ = Nothing
-trPIRFun P.UnMapData _ = Nothing
-trPIRFun P.UnListData _ = Nothing
-trPIRFun P.UnIData _ = Nothing
-trPIRFun P.UnBData _ = Nothing
--- If-then-else is complicated
-trPIRFun P.IfThenElse _ = Nothing
+
 -- Remainder
 trPIRFun op _ =
   error $

--- a/src/Language/Pirouette/PlutusIR/SMT.hs
+++ b/src/Language/Pirouette/PlutusIR/SMT.hs
@@ -199,15 +199,15 @@ instance LanguageSymEval PlutusIR where
     continueWith "Nil" []
 
   branchesBuiltinTerm P.ConstrData _ args =
-    continueWith "Constr" args
+    continueWith "Data_Constr" args
   branchesBuiltinTerm P.MapData _ args =
-    continueWith "Map" args
+    continueWith "Data_Map" args
   branchesBuiltinTerm P.ListData _ args =
-    continueWith "List" args
+    continueWith "Data_List" args
   branchesBuiltinTerm P.IData _ args =
-    continueWith "I" args
+    continueWith "Data_I" args
   branchesBuiltinTerm P.BData _ args =
-    continueWith "B" args
+    continueWith "Data_B" args
 
   -- pattern matching and built-in matchers
 

--- a/src/Language/Pirouette/PlutusIR/SMT.hs
+++ b/src/Language/Pirouette/PlutusIR/SMT.hs
@@ -233,12 +233,21 @@ trPIRFun op _ =
       <> " is not an implemented constant/operator/function"
 
 instance LanguageSymEval PlutusIR where
-  branchesBuiltinTerm P.ChooseList _translator args = 
+  branchesBuiltinTerm P.ChooseList _ args = 
     continueWithMatch "Nil_match" args
-  branchesBuiltinTerm P.ChooseUnit _translator args = 
+  branchesBuiltinTerm P.ChooseUnit _ args = 
     continueWithMatch "Unit_match" args
-  branchesBuiltinTerm P.ChooseData _translator args = 
+  branchesBuiltinTerm P.ChooseData _ args = 
     continueWithMatch "Data_match" args
+
+  branchesBuiltinTerm P.FstPair _ [tyA@(TyArg a), tyB@(TyArg b)] =
+    continueWithMatch "Tuple2_match"
+      [ tyA, tyB, tyA
+      , TermArg $ Lam (Ann "x") a $ Lam (Ann "y") b $ App (Bound (Ann "x") 1) [] ]
+  branchesBuiltinTerm P.SndPair _ [tyA@(TyArg a), tyB@(TyArg b)] =
+    continueWithMatch "Tuple2_match"
+      [ tyA, tyB, tyA
+      , TermArg $ Lam (Ann "x") a $ Lam (Ann "y") b $ App (Bound (Ann "y") 0) [] ]
 
   branchesBuiltinTerm _rest _translator _args = 
     pure Nothing

--- a/src/Language/Pirouette/PlutusIR/SMT.hs
+++ b/src/Language/Pirouette/PlutusIR/SMT.hs
@@ -1,12 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Language.Pirouette.PlutusIR.SMT where
 
-import qualified Data.Text as Text
 import Language.Pirouette.PlutusIR.Syntax
+import Pirouette.Monad
 import Pirouette.Symbolic.Eval.Types
 import Pirouette.SMT.Base
 import Pirouette.SMT.Constraints
+import Pirouette.Term.Syntax.Base
+import Pirouette.Term.Syntax.SystemF
 import qualified PlutusCore as P
 import qualified PureSMT
+
+-- See https://github.com/input-output-hk/plutus/blob/master/plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs
 
 instance LanguageSMT PlutusIR where
   translateBuiltinType = trPIRType
@@ -16,47 +22,63 @@ instance LanguageSMT PlutusIR where
   translateConstant = trPIRConstant
   isStuckBuiltin = error "isStuckBuiltin (t :: TermMeta PlutusIR meta): not yet impl"
 
-instance LanguageSymEval PlutusIR where
-  branchesBuiltinTerm _tm _translator _args = pure Nothing
+  builtinTypeDefinitions =
+    [("list", listTypeDef), ("unit", unitTypeDef)]
+    where
+      listTypeDef = Datatype {
+        kind = KTo KStar KStar
+      , typeVariables = [("a", KStar)]
+      , destructor = "list_match"
+      , constructors = [
+          ("Nil", TyAll (Ann "a") KStar listOfA)
+        , ("Cons", TyAll (Ann "a") KStar (TyFun variableA (TyFun listOfA listOfA)))
+        ]
+      }
+      variableA = TyApp (Bound (Ann "a") 0) []
+      listOfA = TyApp (Free $ TySig "list") [variableA]
+
+      unitTypeDef = Datatype {
+        kind = KStar
+      , typeVariables = []
+      , destructor = "unit_match"
+      , constructors = [("Unit", TyApp (Free $ TySig "unit") [])]
+      }
 
 trPIRType :: PIRBuiltinType -> PureSMT.SExpr
 trPIRType PIRTypeInteger = PureSMT.tInt
 trPIRType PIRTypeBool = PureSMT.tBool
 trPIRType PIRTypeString = PureSMT.tString
 trPIRType PIRTypeByteString = PureSMT.tString
-trPIRType PIRTypeUnit = PureSMT.tUnit
+trPIRType PIRTypeUnit = PureSMT.fun "unit" []
 trPIRType PIRTypeData = PureSMT.tUnit -- TODO: Temporary represention of data
 -- Note: why do Pair have maybes?
 -- Note answer, because types can be partially applied in System F,
 -- and `Pair a` is represented by `PIRTypePair (pirType a) Nothing`
 trPIRType (PIRTypePair (Just pirType1) (Just pirType2)) =
   PureSMT.tTuple [trPIRType pirType1, trPIRType pirType2]
+trPIRType (PIRTypeList (Just pirType)) =
+  PureSMT.fun "list" [trPIRType pirType]
 trPIRType pirType =
   error $ "Translate builtin type to smtlib: " <> show pirType <> " not yet handled."
 
 -- TODO Implement remaining constants
 trPIRConstant :: PIRConstant -> PureSMT.SExpr
 trPIRConstant (PIRConstInteger n) = PureSMT.int n
-trPIRConstant (PIRConstByteString bs) = error "Not implemented: PIRConstByteString to SMT"
-trPIRConstant PIRConstUnit = PureSMT.unit
+trPIRConstant (PIRConstByteString _bs) = error "Not implemented: PIRConstByteString to SMT"
+trPIRConstant PIRConstUnit = PureSMT.fun "Unit" []
 trPIRConstant (PIRConstBool b) = PureSMT.bool b
-trPIRConstant (PIRConstString txt) = PureSMT.string (Text.unpack txt)
-trPIRConstant (PIRConstList l) = error "Not implemented: PIRConstList to SMT"
-trPIRConstant (PIRConstPair x y) = error "Not implemented: PIRConstPair to SMT"
-trPIRConstant (PIRConstData dat) = error "Not implemented: PIRConstData to SMT"
+trPIRConstant (PIRConstString txt) = PureSMT.text txt
+trPIRConstant (PIRConstList lst) = go lst 
+  where go [] = PureSMT.fun "Nil" []
+        go (x:xs) = PureSMT.fun "Cons" [trPIRConstant x, go xs]
+trPIRConstant (PIRConstPair x y) = PureSMT.tuple [trPIRConstant x, trPIRConstant y]
+trPIRConstant (PIRConstData _dat) = error "Not implemented: PIRConstData to SMT"
 
 trPIRFun :: P.DefaultFun -> [PureSMT.SExpr] -> Maybe PureSMT.SExpr
 
 -- TODO Implement remaining builtins: those used by the "Auction" example
 -- validator are marked with an [A] and as commented out lines in the
 -- code afterwards
-
--- ** Integers **
-
---
---     P.QuotientInteger
---     P.RemainderInteger
---
 
 -- ** Bytestrings **
 
@@ -83,34 +105,13 @@ trPIRFun :: P.DefaultFun -> [PureSMT.SExpr] -> Maybe PureSMT.SExpr
 -- ** Strings and encoding **
 
 --
---     P.AppendString
---     P.EqualsString
 --     P.EncodeUtf8
 --     P.DecodeUtf8
 --
 
--- ** If then else **
-
---
--- [A] P.IfThenElse
---
-
--- ** Lists and pairs **
-
---
--- [A] P.FstPair
--- [A] P.SndPair
--- [A] P.ChooseList
---     P.MkCons
--- [A] P.HeadList
--- [A] P.TailList
---     P.NullList
-
 -- ** Data **
 
 --
---     P.ChooseUnit
--- [A] P.ChooseData
 --     P.ConstrData
 --     P.MapData
 --     P.ListData
@@ -121,65 +122,82 @@ trPIRFun :: P.DefaultFun -> [PureSMT.SExpr] -> Maybe PureSMT.SExpr
 --     P.UnListData
 -- [A] P.UnIData
 -- [A] P.UnBData
---     P.MkPairData
---     P.MkNilData
---     P.MkNilPairData
 
 -- Unary
 trPIRFun op [x] =
   case op of
     P.Trace -> Just $ PureSMT.List [x]
-    -- P.FstPair ->
-    -- P.SndPair ->
-    -- P.HeadList ->
-    -- P.TailList ->
-    -- P.UnConstrData ->
-    -- P.UnIData ->
-    -- P.UnBData ->
+    -- some simple operations
+    P.NullList -> Just $ PureSMT.eq x (PureSMT.fun "Nil" [])
+    P.FstPair -> Just $ PureSMT.tupleSel 0 x
+    P.SndPair -> Just $ PureSMT.tupleSel 1 x
+    -- constructors
+    -- those are defined as unary functions for historical reasons
+    P.MkNilData -> Just $ PureSMT.fun "Nil" []
+    P.MkNilPairData -> Just $ PureSMT.fun "Nil" []
     _ ->
       error $
         "Translate builtin to SMT: "
           <> show op
           <> " is not an implemented unary operator/function"
--- Binary
+-- Binary operations and relations
 trPIRFun op [x, y] =
   case op of
+    -- integer operations
     P.AddInteger -> Just $ PureSMT.add x y
     P.SubtractInteger -> Just $ PureSMT.sub x y
     P.MultiplyInteger -> Just $ PureSMT.mul x y
+    -- divMod and quotRem work differently
+    -- when not exact, but this is a good approximation
     P.DivideInteger -> Just $ PureSMT.div x y
     P.ModInteger -> Just $ PureSMT.mod x y
+    P.QuotientInteger -> Just $ PureSMT.div x y
+    P.RemainderInteger -> Just $ PureSMT.mod x y
+    -- operations over other types
+    P.AppendString -> Just $ PureSMT.fun "str.++" [x, y]
+    -- relations
     P.EqualsInteger -> Just $ PureSMT.eq x y
     P.LessThanInteger -> Just $ PureSMT.lt x y
     P.LessThanEqualsInteger -> Just $ PureSMT.leq x y
     P.EqualsByteString -> Just $ PureSMT.eq x y
     P.EqualsString -> Just $ PureSMT.eq x y
     P.EqualsData -> Just $ PureSMT.eq x y
+    -- constructors
+    P.MkCons -> Just $ PureSMT.fun "Cons" [x, y]
+    P.MkPairData -> Just $ PureSMT.tuple [x, y]
     _ ->
       error $
         "Translate builtin to SMT: "
           <> show op
           <> " is not an implemented binary operator/function"
--- Ternary
-trPIRFun op [x, y, z] =
-{-
-  case op of
-    -- P.IfThenElse ->
-    -- P.ChooseList ->
-    _ ->
--}
-      error $
-        "Translate builtin to SMT: "
-          <> show op
-          <> " is not an implemented ternary operator/function"
+-- Pattern matching in disguise
+trPIRFun P.IfThenElse _ = Nothing
+trPIRFun P.ChooseList _ = Nothing
+trPIRFun P.HeadList _ = Nothing
+trPIRFun P.TailList _ = Nothing
+trPIRFun P.ChooseUnit _ = Nothing
+trPIRFun P.ChooseData _ = Nothing
 -- Remainder
 trPIRFun op _ =
-{-
-  case op of
-    -- P.ChooseData ->
-    _ ->
--}
-      error $
-        "Translate builtin to SMT: "
-          <> show op
-          <> " is not an implemented constant/operator/function"
+  error $
+    "Translate builtin to SMT: "
+      <> show op
+      <> " is not an implemented constant/operator/function"
+
+instance LanguageSymEval PlutusIR where
+  branchesBuiltinTerm P.ChooseList _translator args = 
+    continueWithMatch "list_match" args
+  branchesBuiltinTerm P.ChooseUnit _translator args = 
+    continueWithMatch "unit_match" args
+  branchesBuiltinTerm P.ChooseData _translator args = 
+    continueWithMatch "data_match" args
+
+  branchesBuiltinTerm _rest _translator _args = 
+    pure Nothing
+
+continueWithMatch :: 
+  (ToSMT meta, PirouetteReadDefs lang m) =>
+  Name -> [ArgMeta lang meta] ->
+  m (Maybe [Branch lang meta])
+continueWithMatch destr args =
+  pure $ Just [ Branch { additionalInfo = mempty, newTerm = App (Free $ TermSig destr) args }]

--- a/src/Language/Pirouette/PlutusIR/Syntax.hs
+++ b/src/Language/Pirouette/PlutusIR/Syntax.hs
@@ -64,8 +64,8 @@ instance LanguageBuiltins PlutusIR where
   builtinTypeDefinitions definedTypes =
     -- only define List and Unit if they are not yet defined
     [ ("List", listTypeDef) | not (isDefined "List")]
-    ++ [ ("Unit", unitTypeDef) | not (isDefined "Unit") ]
-    ++ [ ("Tuple2", tuple2TypeDef) | not (isDefined "Tuple2") ]
+    ++ [ ("unit", unitTypeDef) | not (isDefined "Unit") ]
+    ++ [ ("pair", tuple2TypeDef) | not (isDefined "Tuple2") ]
     ++ [ ("Data", dataTypeDef) ]
     where
       a = TyApp (Bound (Ann "a") 0) []
@@ -110,11 +110,11 @@ instance LanguageBuiltins PlutusIR where
       , typeVariables = []
       , destructor = "Data_match"
       , constructors = [
-          ("Constr", TyFun (builtin PIRTypeInteger) (TyFun tyListData tyData))
-        , ("Map", TyFun (builtin $ PIRTypeList (Just (PIRTypePair (Just PIRTypeData) (Just PIRTypeData)))) tyData)
-        , ("List", TyFun tyListData tyData)
-        , ("I", TyFun (builtin PIRTypeInteger) tyData)
-        , ("B", TyFun (builtin PIRTypeByteString) tyData)
+          ("Data_Constr", TyFun (builtin PIRTypeInteger) (TyFun tyListData tyData))
+        , ("Data_Map", TyFun (builtin $ PIRTypeList (Just (PIRTypePair (Just PIRTypeData) (Just PIRTypeData)))) tyData)
+        , ("Data_List", TyFun tyListData tyData)
+        , ("Data_I", TyFun (builtin PIRTypeInteger) tyData)
+        , ("Data_B", TyFun (builtin PIRTypeByteString) tyData)
         ]
       }
 

--- a/src/Language/Pirouette/PlutusIR/Syntax.hs
+++ b/src/Language/Pirouette/PlutusIR/Syntax.hs
@@ -21,11 +21,12 @@ import Control.Monad.Combinators.Expr
 import qualified Data.ByteString as BS
 import Data.Data
 import Data.Foldable
+import Data.Maybe (isJust)
 import qualified Data.Text as T
 import Language.Haskell.TH.Syntax (Lift)
-import Language.Pirouette.QuasiQuoter.Syntax
+import Language.Pirouette.QuasiQuoter.Syntax hiding (TyAll, TyFun, TyApp)
 import Pirouette.Term.Syntax
-import qualified Pirouette.Term.Syntax.SystemF as SystF
+import Pirouette.Term.Syntax.SystemF as SystF
 import PlutusCore
   ( DefaultUni (..),
     pattern DefaultUniList,
@@ -59,6 +60,66 @@ instance LanguageBuiltins PlutusIR where
   type BuiltinTypes PlutusIR = PIRBuiltinType
   type BuiltinTerms PlutusIR = PIRDefaultFun
   type Constants PlutusIR = PIRConstant
+
+  builtinTypeDefinitions definedTypes =
+    -- only define List and Unit if they are not yet defined
+    [ ("List", listTypeDef) | not (isDefined "List")]
+    ++ [ ("Unit", unitTypeDef) | not (isDefined "Unit") ]
+    ++ [ ("Tuple2", tuple2TypeDef) | not (isDefined "Tuple2") ]
+    ++ [ ("Data", dataTypeDef) ]
+    where
+      a = TyApp (Bound (Ann "a") 0) []
+      b = TyApp (Bound (Ann "a") 1) []
+
+      isDefined nm = isJust (lookup nm definedTypes)
+
+      listOf x = TyApp (Free $ TySig "List") [x]
+      tuple2Of x y = TyApp (Free $ TySig "Tuple2") [x, y]
+      builtin nm = TyApp (Free $ TyBuiltin nm) []
+
+      listTypeDef = Datatype {
+        kind = KTo KStar KStar
+      , typeVariables = [("a", KStar)]
+      , destructor = "Nil_match"
+      , constructors = [
+          ("Nil", TyAll (Ann "a") KStar (listOf a))
+        , ("Cons", TyAll (Ann "a") KStar (TyFun a (TyFun (listOf a) (listOf a))))
+        ]
+      }
+
+      unitTypeDef = Datatype {
+        kind = KStar
+      , typeVariables = []
+      , destructor = "Unit_match"
+      , constructors = [("Unit", builtin PIRTypeUnit)]
+      }
+ 
+      -- !! warning, we define it as "Tuple2 b a" to reuse 'a' for both list and tuple
+      tuple2TypeDef = Datatype {
+        kind = KTo KStar (KTo KStar KStar)
+      , typeVariables = [("b", KStar), ("a", KStar)]
+      , destructor = "Tuple2_match"
+      , constructors = [
+          ("Tuple2", TyAll (Ann "b") KStar $ TyAll (Ann "a") KStar $ TyFun b (TyFun a (tuple2Of b a)))
+        ]
+      }
+
+      -- defined following https://github.com/input-output-hk/plutus/blob/master/plutus-core/plutus-core/src/PlutusCore/Data.hs
+      dataTypeDef = Datatype {
+        kind = KStar
+      , typeVariables = []
+      , destructor = "Data_match"
+      , constructors = [
+          ("Constr", TyFun (builtin PIRTypeInteger) (TyFun tyListData tyData))
+        , ("Map", TyFun (builtin $ PIRTypeList (Just (PIRTypePair (Just PIRTypeData) (Just PIRTypeData)))) tyData)
+        , ("List", TyFun tyListData tyData)
+        , ("I", TyFun (builtin PIRTypeInteger) tyData)
+        , ("B", TyFun (builtin PIRTypeByteString) tyData)
+        ]
+      }
+
+      tyListData = builtin (PIRTypeList (Just PIRTypeData))
+      tyData = builtin PIRTypeData
 
 cstToBuiltinType :: PIRConstant -> PIRBuiltinType
 cstToBuiltinType (PIRConstInteger _) = PIRTypeInteger

--- a/src/Language/Pirouette/PlutusIR/Syntax.hs
+++ b/src/Language/Pirouette/PlutusIR/Syntax.hs
@@ -64,8 +64,8 @@ instance LanguageBuiltins PlutusIR where
   builtinTypeDefinitions definedTypes =
     -- only define List and Unit if they are not yet defined
     [ ("List", listTypeDef) | not (isDefined "List")]
-    ++ [ ("unit", unitTypeDef) | not (isDefined "Unit") ]
-    ++ [ ("pair", tuple2TypeDef) | not (isDefined "Tuple2") ]
+    ++ [ ("Unit", unitTypeDef) | not (isDefined "Unit") ]
+    ++ [ ("Tuple2", tuple2TypeDef) | not (isDefined "Tuple2") ]
     ++ [ ("Data", dataTypeDef) ]
     where
       a = TyApp (Bound (Ann "a") 0) []

--- a/src/Language/Pirouette/PlutusIR/ToTerm.hs
+++ b/src/Language/Pirouette/PlutusIR/ToTerm.hs
@@ -444,6 +444,11 @@ trTerm mn t = do
         Nothing -> do
           args <- lift $ getTransitiveDepsAsArgs (toName n)
           return $ SystF.App (SystF.Free $ TermSig (toName n)) args
+    -- See [HACK: Translation of 'Bool']
+    go (PIR.TyInst _ (PIR.Apply _ v@(PIR.Var _ n) x) tyR)
+      | toName n == "Bool_match"
+      = SystF.app <$> (SystF.app <$> go v <*> lift (SystF.TyArg <$> trType tyR))
+                  <*> (SystF.TermArg <$> go x)
     go (PIR.Constant _ (P.Some (P.ValueOf tx x))) =
       return $ SystF.termPure $ SystF.Free $ Constant $ defUniToConstant tx x
     go (PIR.Builtin _ f) = return $ SystF.termPure $ SystF.Free $ Builtin f

--- a/src/Language/Pirouette/PlutusIR/Typing.hs
+++ b/src/Language/Pirouette/PlutusIR/Typing.hs
@@ -57,10 +57,16 @@ instance LanguageBuiltinTypes PlutusIR where
   typeOfConstant = systfType . cstToBuiltinType
 
   typeOfBuiltin P.AddInteger = tInt :->: tInt :->: tInt
+  typeOfBuiltin P.SubtractInteger = tInt :->: tInt :->: tInt
+  typeOfBuiltin P.MultiplyInteger = tInt :->: tInt :->: tInt
   typeOfBuiltin P.DivideInteger = tInt :->: tInt :->: tInt
+  typeOfBuiltin P.ModInteger = tInt :->: tInt :->: tInt
+  typeOfBuiltin P.QuotientInteger = tInt :->: tInt :->: tInt
+  typeOfBuiltin P.RemainderInteger = tInt :->: tInt :->: tInt
   typeOfBuiltin P.EqualsInteger = tInt :->: tInt :->: tBool
   typeOfBuiltin P.LessThanInteger = tInt :->: tInt :->: tBool
   typeOfBuiltin P.LessThanEqualsInteger = tInt :->: tInt :->: tBool
+  typeOfBuiltin P.EqualsString = tString :->: tString :->: tBool
   typeOfBuiltin P.EqualsByteString = tByteString :->: tByteString :->: tBool
   typeOfBuiltin P.IfThenElse = forall "a" (tBool :->: tVar "a" 0 :->: tVar "a" 0 :->: tVar "a" 0)
   typeOfBuiltin P.Trace = forall "a" (tString :->: tVar "a" 0 :->: tVar "a" 0)

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -89,6 +89,8 @@ quoter quote =
 
 deriving instance Lift ann => Lift (SystF.Ann ann)
 
+deriving instance Lift Namespace
+
 deriving instance Lift Name
 
 deriving instance Lift SystF.Kind

--- a/src/Pirouette/Monad.hs
+++ b/src/Pirouette/Monad.hs
@@ -60,31 +60,42 @@ prtError = error . show
 --  being compiled, we probably want to use 'PirouetteReadDefs' instead of 'PirouetteBase'
 class (LanguageBuiltins lang, Monad m) => PirouetteReadDefs lang m | m -> lang where
   -- | Returns all declarations in scope
-  prtAllDefs :: m (Map.Map Name (Definition lang))
+  prtAllDefs :: m (Map.Map (Namespace, Name) (Definition lang))
 
   -- | Returns the main program
   prtMain :: m (Term lang)
 
 -- | Returns the definition associated with a given name. Raises a 'PEUndefined'
 --  if the name doesn't exist.
-prtDefOf :: (PirouetteReadDefs lang m) => Name -> m (Definition lang)
-prtDefOf n = do
+prtDefOf :: (PirouetteReadDefs lang m) => Namespace -> Name -> m (Definition lang)
+prtDefOf space n = do
   defs <- prtAllDefs
-  case Map.lookup n defs of
+  case Map.lookup (space, n) defs of
     Nothing -> prtError $ PEUndefined n
     Just x -> return x
 
+prtDefOfAnyNamespace :: (PirouetteReadDefs lang m) => Name -> m (Definition lang)
+prtDefOfAnyNamespace n = do
+  defs <- prtAllDefs
+  let tm = Map.lookup (TermNamespace, n) defs
+      ty = Map.lookup (TypeNamespace, n) defs
+  case (tm, ty) of
+    (Just _, Just _)  -> prtError $ PEUndefined n
+    (Just t, Nothing) -> pure t
+    (Nothing, Just t) -> pure t
+    _ -> prtError $ PEUndefined n
+
 prtTypeDefOf :: (PirouetteReadDefs lang m) => Name -> m (TypeDef lang)
-prtTypeDefOf n = prtDefOf n >>= maybe (prtError $ PENotAType n) return . fromTypeDef
+prtTypeDefOf n = prtDefOf TypeNamespace n >>= maybe (prtError $ PENotAType n) return . fromTypeDef
 
 prtTermDefOf :: (PirouetteReadDefs lang m) => Name -> m (Term lang)
-prtTermDefOf n = prtDefOf n >>= maybe (prtError $ PENotATerm n) return . fromTermDef
+prtTermDefOf n = prtDefOf TermNamespace n >>= maybe (prtError $ PENotATerm n) return . fromTermDef
 
 prtIsDest :: (PirouetteReadDefs lang m) => Name -> MaybeT m TyName
-prtIsDest n = MaybeT $ fromDestDef <$> prtDefOf n
+prtIsDest n = MaybeT $ fromDestDef <$> prtDefOf TermNamespace n
 
 prtIsConst :: (PirouetteReadDefs lang m) => Name -> MaybeT m (Int, TyName)
-prtIsConst n = MaybeT $ fromConstDef <$> prtDefOf n
+prtIsConst n = MaybeT $ fromConstDef <$> prtDefOf TermNamespace n
 
 instance {-# OVERLAPPABLE #-} (PirouetteReadDefs lang m) => PirouetteReadDefs lang (Lazy.StateT s m) where
   prtAllDefs = lift prtAllDefs
@@ -109,7 +120,7 @@ instance {-# OVERLAPPABLE #-} (PirouetteReadDefs lang m) => PirouetteReadDefs la
 -- | Returns the type of an identifier
 typeOfIdent :: (PirouetteReadDefs lang m) => Name -> m (Type lang)
 typeOfIdent n = do
-  dn <- prtDefOf n
+  dn <- prtDefOf TermNamespace n
   case dn of
     (DFunction _ _ ty) -> return ty
     (DConstructor i t) -> snd . (!! i) . constructors <$> prtTypeDefOf t
@@ -127,7 +138,7 @@ typeOfIdent n = do
 --  @SystF.Arg "f"@ in the result aswell, use "Pirouette.Term.TransitiveDeps.transitiveDepsOf" instead.
 directDepsOf :: (PirouetteReadDefs lang m) => Name -> m (Set.Set (SystF.Arg Name Name))
 directDepsOf n = do
-  ndef <- prtDefOf n
+  ndef <- prtDefOfAnyNamespace n
   return $ case ndef of
     DFunction _ t ty -> typeNames ty <> termNames t
     DTypeDef d ->
@@ -173,7 +184,7 @@ termIsWHNF (SystF.App vm args) = case vm of
   SystF.Meta {} -> pure Nothing
   SystF.Free (Constant c) -> pure $ Just (WHNFConstant c)
   SystF.Free (TermSig n) -> do
-    mDef <- prtDefOf n
+    mDef <- prtDefOf TermNamespace n
     case mDef of
       DConstructor ix ty -> pure $ Just (WHNFConstructor ix ty args)
       _ -> pure Nothing

--- a/src/Pirouette/Monad.hs
+++ b/src/Pirouette/Monad.hs
@@ -190,6 +190,10 @@ termIsBuiltin :: TermMeta lang meta -> Bool
 termIsBuiltin (SystF.App (SystF.Free (Builtin _)) _args) = True
 termIsBuiltin _ = False
 
+termIsConstant :: TermMeta lang meta -> Bool
+termIsConstant (SystF.App (SystF.Free (Constant _)) _args) = True
+termIsConstant _ = False
+
 -- | Returns whether a term is in Weak Head Normal Form,
 -- that is, a constant or a constructor followed by any arguments.
 termIsWHNFOrMeta :: (PirouetteReadDefs lang m) => TermMeta lang meta -> m Bool

--- a/src/Pirouette/SMT/Base.hs
+++ b/src/Pirouette/SMT/Base.hs
@@ -17,6 +17,9 @@ class (LanguageBuiltins lang) => LanguageSMT lang where
   translateBuiltinTerm :: BuiltinTerms lang -> [PureSMT.SExpr] -> Maybe PureSMT.SExpr
   translateConstant :: Constants lang -> PureSMT.SExpr
   isStuckBuiltin :: TermMeta lang meta -> Bool
+  -- | Definitions required for built-in types
+  builtinTypeDefinitions :: [(Name, TypeDef lang)]
+  builtinTypeDefinitions = []
 
 -- | Captures arbitrary types that can be translated to SMTLIB.
 class (Show t) => ToSMT t where

--- a/src/Pirouette/SMT/Base.hs
+++ b/src/Pirouette/SMT/Base.hs
@@ -17,11 +17,6 @@ class (LanguageBuiltins lang) => LanguageSMT lang where
   translateBuiltinTerm :: BuiltinTerms lang -> [PureSMT.SExpr] -> Maybe PureSMT.SExpr
   translateConstant :: Constants lang -> PureSMT.SExpr
   isStuckBuiltin :: TermMeta lang meta -> Bool
-  -- | Definitions required for built-in types
-  builtinTypeDefinitions :: 
-    [(Name, TypeDef lang)]    -- ^ types which are already defined
-    -> [(Name, TypeDef lang)] -- ^ additional definitions supporting those
-  builtinTypeDefinitions _ = []
 
 -- | Captures arbitrary types that can be translated to SMTLIB.
 class (Show t) => ToSMT t where

--- a/src/Pirouette/SMT/Base.hs
+++ b/src/Pirouette/SMT/Base.hs
@@ -18,8 +18,10 @@ class (LanguageBuiltins lang) => LanguageSMT lang where
   translateConstant :: Constants lang -> PureSMT.SExpr
   isStuckBuiltin :: TermMeta lang meta -> Bool
   -- | Definitions required for built-in types
-  builtinTypeDefinitions :: [(Name, TypeDef lang)]
-  builtinTypeDefinitions = []
+  builtinTypeDefinitions :: 
+    [(Name, TypeDef lang)]    -- ^ types which are already defined
+    -> [(Name, TypeDef lang)] -- ^ additional definitions supporting those
+  builtinTypeDefinitions _ = []
 
 -- | Captures arbitrary types that can be translated to SMTLIB.
 class (Show t) => ToSMT t where

--- a/src/Pirouette/SMT/FromTerm.hs
+++ b/src/Pirouette/SMT/FromTerm.hs
@@ -104,7 +104,7 @@ translateTerm knownNames (Raw.App var args) = case var of
       Just t -> return t
   Raw.Free (TermSig name) -> do
     _ <- traceMe ("translateApp: " ++ show name) (return ())
-    defn <- lift $ lift $ prtDefOf name
+    defn <- lift $ lift $ prtDefOf TermNamespace name
     case defn of
       DConstructor ix tname
         | name `S.notMember` knownNames ->

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -182,7 +182,7 @@ runSymEvalWorker defs st f = do
       let decls = prtDecls defs
           dependencyOrder = prtDepOrder defs
           definedTypes = mapMaybe (R.argElim (lkupTypeDefOf decls) (const Nothing)) dependencyOrder
-          types = SMT.builtinTypeDefinitions definedTypes <> definedTypes
+          types = builtinTypeDefinitions definedTypes <> definedTypes
           allFns = mapMaybe (R.argElim (const Nothing) (lkupFunDefOf decls)) dependencyOrder
           fns = mapMaybe (\(n, fd) -> (n,) <$> SMT.supportedUninterpretedFunction fd) allFns
        in SolverSharedCtx types fns

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -181,8 +181,8 @@ runSymEvalWorker defs st f = do
     solverCtx =
       let decls = prtDecls defs
           dependencyOrder = prtDepOrder defs
-          types = SMT.builtinTypeDefinitions 
-                    <> mapMaybe (R.argElim (lkupTypeDefOf decls) (const Nothing)) dependencyOrder
+          definedTypes = mapMaybe (R.argElim (lkupTypeDefOf decls) (const Nothing)) dependencyOrder
+          types = SMT.builtinTypeDefinitions definedTypes <> definedTypes
           allFns = mapMaybe (R.argElim (const Nothing) (lkupFunDefOf decls)) dependencyOrder
           fns = mapMaybe (\(n, fd) -> (n,) <$> SMT.supportedUninterpretedFunction fd) allFns
        in SolverSharedCtx types fns

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -181,7 +181,8 @@ runSymEvalWorker defs st f = do
     solverCtx =
       let decls = prtDecls defs
           dependencyOrder = prtDepOrder defs
-          types = mapMaybe (R.argElim (lkupTypeDefOf decls) (const Nothing)) dependencyOrder
+          types = SMT.builtinTypeDefinitions 
+                    <> mapMaybe (R.argElim (lkupTypeDefOf decls) (const Nothing)) dependencyOrder
           allFns = mapMaybe (R.argElim (const Nothing) (lkupFunDefOf decls)) dependencyOrder
           fns = mapMaybe (\(n, fd) -> (n,) <$> SMT.supportedUninterpretedFunction fd) allFns
        in SolverSharedCtx types fns

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -288,6 +288,7 @@ symEvalOneStep t@(R.Lam (R.Ann _x) _ty _) = do
 -- If we're evaluating an application, we distinguish between a number
 -- of constituent cases:
 symEvalOneStep t@(R.App hd args) = case hd of
+  R.Free Bottom -> empty -- we end in a bottom, so that branch is not useful
   R.Free (Builtin builtin) -> do
     -- try to evaluate the built-in
     let translator c = do

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -169,11 +169,11 @@ runSymEvalWorker defs st f = do
   let paths = uncurry path solvPair
   return paths
   where
-    lkupTypeDefOf decls name = case M.lookup name decls of
+    lkupTypeDefOf decls name = case M.lookup (TypeNamespace, name) decls of
       Just (DTypeDef tdef) -> Just (name, tdef)
       _ -> Nothing
 
-    lkupFunDefOf decls name = case M.lookup name decls of
+    lkupFunDefOf decls name = case M.lookup (TermNamespace, name) decls of
       Just (DFunDef fdef) -> Just (name, fdef)
       _ -> Nothing
 
@@ -308,7 +308,7 @@ symEvalOneStep t@(R.App hd args) = case hd of
       -- if it's not ready, just keep evaluating the arguments
       Nothing -> justEvaluateArgs
   R.Free (TermSig n) -> do
-    mDefHead <- Just <$> lift (prtDefOf n)
+    mDefHead <- Just <$> lift (prtDefOf TermNamespace n)
     case mDefHead of
       -- If hd is not defined, we symbolically evaluate the arguments and reconstruct the term.
       Nothing -> justEvaluateArgs
@@ -402,7 +402,7 @@ isDestructor ::
   TermMeta lang SymVar ->
   m (Maybe Name)
 isDestructor (R.App (R.Free (TermSig n)) _args) = do
-  mDefHead <- Just <$> prtDefOf n
+  mDefHead <- Just <$> prtDefOf TermNamespace n
   pure $ case mDefHead of
     Just (DDestructor tyName) -> Just tyName
     _ -> Nothing

--- a/src/Pirouette/Symbolic/Eval/Helpers.hs
+++ b/src/Pirouette/Symbolic/Eval/Helpers.hs
@@ -1,0 +1,74 @@
+module Pirouette.Symbolic.Eval.Helpers where
+
+import Pirouette.Monad
+import Pirouette.SMT.Base
+import Pirouette.SMT.Constraints
+import Pirouette.Term.Syntax
+import qualified Pirouette.Term.Syntax.SystemF as SystF
+
+ifThenElseBranching :: 
+  (Applicative f, LanguageSMT lang, Show meta) =>
+  (TermMeta lang meta -> Bool) -> TermMeta lang meta ->
+  (TermMeta lang meta -> Bool) -> TermMeta lang meta -> 
+  (BuiltinTerms lang -> Bool) ->
+  TermMeta lang meta -> TermMeta lang meta -> TermMeta lang meta -> [ArgMeta lang meta] ->
+  f (Maybe [Branch lang meta])
+ifThenElseBranching isTrue trueTm isFalse falseTm isEq c t e excess =
+    let t' = t `SystF.appN` excess
+        e' = e `SystF.appN` excess
+      in case c of
+          _ | isTrue c -> pure $ Just [Branch (And []) t]
+          _ | isFalse c -> pure $ Just [Branch (And []) e]
+          SystF.App (SystF.Free (Builtin eq)) [SystF.TermArg x, SystF.TermArg y]
+            -- try to generate the best type of constraint
+            -- from the available equality ones
+            | isEq eq,
+              Just x1 <- termIsMeta x,
+              Just y1 <- termIsMeta y ->
+              pure $
+                Just
+                  [ -- either they are equal
+                    Branch (And [VarEq x1 y1]) t',
+                    -- or they are not
+                    Branch (And [NonInlinableSymbolNotEq x y]) e'
+                  ]
+            | isEq eq,
+              Just x1 <- termIsMeta x,
+              isStuckBuiltin y ->
+              pure $
+                Just
+                  [ -- either they are equal
+                    Branch (And [Assign x1 y]) t',
+                    -- or they are not
+                    Branch (And [NonInlinableSymbolNotEq x y]) e'
+                  ]
+            | isEq eq,
+              isStuckBuiltin x,
+              Just y1 <- termIsMeta y ->
+              pure $
+                Just
+                  [ -- either they are equal
+                    Branch (And [Assign y1 x]) t',
+                    -- or they are not
+                    Branch (And [NonInlinableSymbolNotEq y x]) e'
+                  ]
+            | isEq eq,
+              isStuckBuiltin x,
+              isStuckBuiltin y ->
+              pure $
+                Just
+                  [ -- either they are equal
+                    Branch (And [NonInlinableSymbolEq x y]) t',
+                    -- or they are not
+                    Branch (And [NonInlinableSymbolNotEq x y]) e'
+                  ]
+          _
+            | Just v <- termIsMeta c ->
+              pure $
+                Just
+                  [ -- c is True => t is executed
+                    Branch (And [Assign v trueTm]) t',
+                    -- c is False => e is executed
+                    Branch (And [Assign v falseTm]) e'
+                  ]
+          _ -> pure Nothing

--- a/src/Pirouette/Term/Syntax.hs
+++ b/src/Pirouette/Term/Syntax.hs
@@ -84,13 +84,13 @@ declsUniqueNames decls mainFun = first Map.fromList (go (Map.toList decls))
     onPairM f g (x, y) = (,) <$> f x <*> g y
 
     go ::
-      [(Name, Definition lang)] ->
-      ([(Name, Definition lang)], Term lang)
+      [((Namespace, Name), Definition lang)] ->
+      ([((Namespace, Name), Definition lang)], Term lang)
     go ds =
       let (_, ks) =
-            flip runState Map.empty $ mapM (onPairM unNameCollect defUNCollect) ds
+            flip runState Map.empty $ mapM (onPairM (onPairM pure unNameCollect) defUNCollect) ds
        in runReader
-            (onPairM (mapM (onPairM unNameSubst defUNSubst)) termUNSubst (ds, mainFun))
+            (onPairM (mapM (onPairM (onPairM pure unNameSubst) defUNSubst)) termUNSubst (ds, mainFun))
             (Map.map Set.toList ks)
 
 -- *** Auxiliar Definitions for Unique Naming

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -20,6 +20,8 @@ import Control.Arrow ((&&&))
 import Control.Monad.Identity
 import Data.Data
 import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import Data.String
 import qualified Data.Text as Text
@@ -338,6 +340,20 @@ class (LanguageConstrs lang) => LanguageBuiltins lang where
   type BuiltinTypes lang :: *
   type BuiltinTerms lang :: *
   type Constants lang :: *
+
+  -- | Definitions required for built-in types
+  builtinTypeDefinitions :: 
+    [(Name, TypeDef lang)]    -- ^ types which are already defined
+    -> [(Name, TypeDef lang)] -- ^ additional definitions supporting those
+  builtinTypeDefinitions _ = []
+
+builtinTypeDecls :: (LanguageBuiltins lang) => Decls lang -> Decls lang
+builtinTypeDecls m = 
+  let defs = flip mapMaybe (Map.toList m) $ \(nm, def) -> case def of
+               DTypeDef td -> Just (nm, td)
+               _ -> Nothing
+      newTypeDefs = builtinTypeDefinitions defs
+  in Map.fromList [(nm, DTypeDef td) | (nm, td) <- newTypeDefs]
 
 -- | Auxiliary constraint for pretty-printing terms of a given language.
 type LanguagePretty lang =

--- a/src/Pirouette/Term/Syntax/Pretty.hs
+++ b/src/Pirouette/Term/Syntax/Pretty.hs
@@ -86,7 +86,12 @@ instance (Pretty (BuiltinTypes lang)) => Pretty (TypeDef lang) where
                   ++ map (\(n, ty) -> pretty n <+> ":" <+> pretty ty) cs
             )
 
+instance Pretty Namespace where
+  pretty TypeNamespace = "type"
+  pretty TermNamespace = "term"
+
 instance (LanguagePretty lang) => Pretty (Decls lang) where
   pretty = align . vsep . map prettyDef . Map.toList
     where
-      prettyDef (name, def) = vsep [pretty name <+> "|->", indent 2 (pretty def)]
+      prettyDef ((namespace, name), def) = 
+        vsep [pretty namespace <+> pretty name <+> "|->", indent 2 (pretty def)]

--- a/src/Pirouette/Term/Transformations.hs
+++ b/src/Pirouette/Term/Transformations.hs
@@ -135,7 +135,7 @@ expandDefs = fmap deshadowBoundNames . rewriteM (runMaybeT . go)
       if isRec
         then fail "expandDefs: wont expand"
         else do
-          def <- MaybeT (fromTermDef <$> prtDefOf n)
+          def <- MaybeT (fromTermDef <$> prtDefOf TermNamespace n)
           let res = SystF.appN def args
           return res
     go _ = fail "expandDefs: not an SystF.App"

--- a/src/Pirouette/Term/TransitiveDeps.hs
+++ b/src/Pirouette/Term/TransitiveDeps.hs
@@ -24,8 +24,8 @@ sortAllDeps = do
   let funOrTyDefs = mapMaybe (uncurry funOrType) . M.toList $ allDefs
   evalStateT (sortDepsCached funOrTyDefs) (TranDepsCache M.empty)
   where
-    funOrType n DFunction {} = Just $ R.TermArg n
-    funOrType n DTypeDef {} = Just $ R.TyArg n
+    funOrType (_, n) DFunction {} = Just $ R.TermArg n
+    funOrType (_, n) DTypeDef {} = Just $ R.TyArg n
     funOrType _ _ = Nothing
 
 -- | Returns the type and term-level transitive dependencies associated with a name.

--- a/src/Pirouette/Transformations.hs
+++ b/src/Pirouette/Transformations.hs
@@ -119,7 +119,7 @@ expandAllNonRec keep prtDefs =
       let (decls', kDef) = expandDefsIn inlinableDecls currDecls k
        in if SystF.TermArg k `Set.member` termNames kDef || keep k
             then (SystF.TermArg k : names, decls', inlinableDecls)
-            else (names, Map.delete k decls', Map.insert k kDef inlinableDecls)
+            else (names, Map.delete (TermNamespace, k) decls', Map.insert k kDef inlinableDecls)
 
 expandDefsIn ::
   (LanguageBuiltins lang) =>
@@ -128,11 +128,11 @@ expandDefsIn ::
   Name ->
   (Decls lang, Term lang)
 expandDefsIn inlinables decls k =
-  case Map.lookup k decls of
+  case Map.lookup (TermNamespace, k) decls of
     Nothing -> error $ "expandDefsIn: term " ++ show k ++ " undefined in decls"
     Just (DFunction r t ty) ->
       let t' = deshadowBoundNames $ rewrite (inlineAll inlinables) t
-       in (Map.insert k (DFunction r t' ty) decls, t')
+       in (Map.insert (TermNamespace, k) (DFunction r t' ty) decls, t')
     Just _ -> error $ "expandDefsIn: term " ++ show k ++ " not a function"
 
 inlineAll :: (LanguageBuiltins lang) => Map.Map Name (Term lang) -> Term lang -> Maybe (Term lang)

--- a/src/Pirouette/Transformations/Contextualize.hs
+++ b/src/Pirouette/Transformations/Contextualize.hs
@@ -29,67 +29,63 @@ contextualizeType tm = fixContextType <$> prtAllDefs <*> pure tm
 -- | Make a 'Name's in the type with empty uniques
 -- refer to those in the context.
 contextualizeTermName :: (PirouetteReadDefs lang m) => T.Text -> m Name
-contextualizeTermName nm = fixContextName FixTerm <$> prtAllDefs <*> pure (Name nm Nothing)
+contextualizeTermName nm = fixContextName <$> prtAllDefs <*> pure TermNamespace <*> pure (Name nm Nothing)
 
 -- | Make a 'Name's in the type with empty uniques
 -- refer to those in the context.
 resolve :: (PirouetteReadDefs lang m) => T.Text -> m Name
 resolve = contextualizeTermName
 
-fixContextName :: FixContextElement -> Map.Map Name (Definition lang) -> Name -> Name
-fixContextName elt inScope nm
+fixContextName :: Map.Map (Namespace, Name) (Definition lang) -> Namespace -> Name -> Name
+fixContextName inScope space nm
   | Just _ <- nameUnique nm = nm  -- if it has a unique, don't change it
   | otherwise =
-    let sameName = Map.filterWithKey (\k d -> nameString k == nameString nm && chooseElement elt d) inScope
+    let sameName = Map.filterWithKey (\(s, k) _ -> nameString k == nameString nm && s == space) inScope
     in case Map.size sameName of
       0 -> nm
-      1 -> fst $ head $ Map.toList sameName  -- we know we have just one
+      1 -> snd $ fst $ head $ Map.toList sameName  -- we know we have just one
       _ -> error $ "cannot fix " <> T.unpack (nameString nm)
 
 
-fixContextTermVar :: Map.Map Name (Definition lang)
+fixContextTermVar :: Map.Map (Namespace, Name) (Definition lang)
                   -> SystF.VarMeta meta ann (TermBase lang)
                   -> SystF.VarMeta meta ann (TermBase lang)
-fixContextTermVar inScope (Free (TermSig nm)) = Free (TermSig (fixContextName FixTerm inScope nm))
+fixContextTermVar inScope (Free (TermSig nm)) = Free (TermSig (fixContextName inScope TermNamespace nm))
 fixContextTermVar _inScope other = other
 
-fixContextTypeVar :: Map.Map Name (Definition lang)
+fixContextTypeVar :: Map.Map (Namespace, Name) (Definition lang)
                   -> SystF.VarMeta meta ann (TypeBase lang)
                   -> SystF.VarMeta meta ann (TypeBase lang)
-fixContextTypeVar inScope (Free (TySig nm)) = Free (TySig (fixContextName FixType inScope nm))
+fixContextTypeVar inScope (Free (TySig nm)) = Free (TySig (fixContextName inScope TypeNamespace nm))
 fixContextTypeVar _inScope other = other
 
-fixContextTerm :: Map.Map Name (Definition lang) -> Term lang -> Term lang
+fixContextTerm :: Map.Map (Namespace, Name) (Definition lang) -> Term lang -> Term lang
 fixContextTerm inScope (App var args) =
   App (fixContextTermVar inScope var)
       [argMap (fixContextType inScope) (fixContextTerm inScope) arg | arg <- args]
 fixContextTerm inScope (Abs var@(Ann this) ki body) = 
   let -- remove shadowed types from scope
-      inScope' = removeFromScope FixType inScope this
+      inScope' = removeFromScope inScope TypeNamespace this
   in Abs var ki (fixContextTerm inScope' body)
 fixContextTerm inScope (Lam var@(Ann this) ty body) = 
   let -- remove shadowed terms from scope
-      inScope' = removeFromScope FixTerm inScope this
+      inScope' = removeFromScope inScope TermNamespace this
   in Lam var (fixContextType inScope' ty) (fixContextTerm inScope' body)
 
-fixContextType :: Map.Map Name (Definition lang) -> Type lang -> Type lang
+fixContextType :: Map.Map (Namespace, Name) (Definition lang) -> Type lang -> Type lang
 fixContextType inScope (TyApp v args) =
   TyApp (fixContextTypeVar inScope v) [fixContextType inScope arg | arg <- args]
 fixContextType inScope (TyFun a b) =
   TyFun (fixContextType inScope a) (fixContextType inScope b)
 fixContextType inScope (TyLam var@(Ann this) ki rest) =
-  let inScope' = removeFromScope FixType inScope this
+  let inScope' = removeFromScope inScope TypeNamespace this
   in TyLam var ki (fixContextType inScope' rest)
 fixContextType inScope (TyAll var@(Ann this) ki rest) =
-  let inScope' = removeFromScope FixType inScope this
+  let inScope' = removeFromScope inScope TypeNamespace this
   in TyAll var ki (fixContextType inScope' rest)
 
-data FixContextElement = FixType | FixTerm
-
-chooseElement :: FixContextElement -> Definition lang -> Bool
-chooseElement FixType = isTypeDef
-chooseElement FixTerm = not . isTypeDef
-
-removeFromScope :: FixContextElement -> Map.Map Name (Definition lang) -> Name -> Map.Map Name (Definition lang)
-removeFromScope elt inScope nm =
-  Map.filterWithKey (\k d -> nameString k /= nameString nm && chooseElement elt d) inScope
+removeFromScope :: Map.Map (Namespace, Name) (Definition lang)
+                -> Namespace -> Name
+                -> Map.Map (Namespace, Name) (Definition lang)
+removeFromScope inScope space nm =
+  Map.delete (space, nm) inScope

--- a/src/Pirouette/Transformations/Contextualize.hs
+++ b/src/Pirouette/Transformations/Contextualize.hs
@@ -31,6 +31,11 @@ contextualizeType tm = fixContextType <$> prtAllDefs <*> pure tm
 contextualizeTermName :: (PirouetteReadDefs lang m) => T.Text -> m Name
 contextualizeTermName nm = fixContextName FixTerm <$> prtAllDefs <*> pure (Name nm Nothing)
 
+-- | Make a 'Name's in the type with empty uniques
+-- refer to those in the context.
+resolve :: (PirouetteReadDefs lang m) => T.Text -> m Name
+resolve = contextualizeTermName
+
 fixContextName :: FixContextElement -> Map.Map Name (Definition lang) -> Name -> Name
 fixContextName elt inScope nm
   | Just _ <- nameUnique nm = nm  -- if it has a unique, don't change it

--- a/src/Pirouette/Transformations/Contextualize.hs
+++ b/src/Pirouette/Transformations/Contextualize.hs
@@ -26,6 +26,11 @@ contextualizeTerm tm = fixContextTerm <$> prtAllDefs <*> pure tm
 contextualizeType :: (PirouetteReadDefs lang m) => Type lang -> m (Type lang)
 contextualizeType tm = fixContextType <$> prtAllDefs <*> pure tm
 
+-- | Make a 'Name's in the type with empty uniques
+-- refer to those in the context.
+contextualizeTermName :: (PirouetteReadDefs lang m) => T.Text -> m Name
+contextualizeTermName nm = fixContextName FixTerm <$> prtAllDefs <*> pure (Name nm Nothing)
+
 fixContextName :: FixContextElement -> Map.Map Name (Definition lang) -> Name -> Name
 fixContextName elt inScope nm
   | Just _ <- nameUnique nm = nm  -- if it has a unique, don't change it

--- a/src/Pirouette/Transformations/EtaExpand.hs
+++ b/src/Pirouette/Transformations/EtaExpand.hs
@@ -122,7 +122,7 @@ findType ::
   Var lang ->
   Maybe (Type lang)
 findType decls _env (SystF.Free (TermSig f)) =
-  case M.lookup f decls of
+  case M.lookup (TermNamespace, f) decls of
     Just (DFunction _ _ ty) -> pure ty
     Just (DDestructor t) -> do
       tdef <- typeDef decls t
@@ -145,6 +145,6 @@ typeDef ::
   Name ->
   Maybe (TypeDef lang)
 typeDef decls nm = do
-  case M.lookup nm decls of
+  case M.lookup (TypeNamespace, nm) decls of
     Just (DTypeDef def) -> pure def
     _ -> Nothing

--- a/src/Pirouette/Transformations/Prenex.hs
+++ b/src/Pirouette/Transformations/Prenex.hs
@@ -109,7 +109,7 @@ prenexExpr newDecls = goTerm
        in case hd of
             -- we only change the applications of known names
             SystemF.Free (TermSig name)
-              | Just (DFunDef FunDef {funTy}) <- Map.lookup name newDecls ->
+              | Just (DFunDef FunDef {funTy}) <- Map.lookup (TermNamespace, name) newDecls ->
                 SystemF.App hd (zipArgs prenexArgs funTy)
             _other -> SystemF.App hd prenexArgs
 

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -34,27 +34,27 @@ data HofDef lang = HofDef
   }
   deriving (Show, Eq, Ord)
 
-type HOFDefs lang = M.Map Name (HofDef lang)
+type HOFDefs lang = M.Map (Namespace, Name) (HofDef lang)
 
 findFuns ::
   LanguageBuiltins lang =>
-  [(Name, Definition lang)] ->
+  [((space, Name), Definition lang)] ->
   (FunDef lang -> Bool) ->
-  [(Name, HofDef lang)]
+  [((space, Name), HofDef lang)]
 findFuns declsPairs funPred =
-  [ (name, HofDef name $ HDBFun funDef)
-    | (name, DFunDef funDef) <- declsPairs,
+  [ ((sp, name), HofDef name $ HDBFun funDef)
+    | ((sp, name), DFunDef funDef) <- declsPairs,
       funPred funDef
   ]
 
 findTypes ::
   LanguageBuiltins lang =>
-  [(Name, Definition lang)] ->
+  [((space, Name), Definition lang)] ->
   (Name -> TypeDef lang -> Bool) ->
-  [(Name, HofDef lang)]
+  [((space, Name), HofDef lang)]
 findTypes declsPairs tyPred =
-  [ (name, HofDef tyName $ HDBType typeDef)
-    | (tyName, DTypeDef typeDef) <- declsPairs,
+  [ ((sp, name), HofDef tyName $ HDBType typeDef)
+    | ((sp, tyName), DTypeDef typeDef) <- declsPairs,
       tyPred tyName typeDef,
       name <- tyName : destructor typeDef : (fst <$> constructors typeDef)
   ]
@@ -64,7 +64,7 @@ findHOFDefs ::
   LanguageBuiltins lang =>
   (FunDef lang -> Bool) ->
   (Name -> TypeDef lang -> Bool) ->
-  [(Name, Definition lang)] ->
+  [((Namespace, Name), Definition lang)] ->
   HOFDefs lang
 findHOFDefs funPred tyPred declsPairs =
   M.fromList $ findFuns declsPairs funPred' <> findTypes declsPairs tyPred'

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -59,7 +59,7 @@ launchAll ctx = replicateM numCapabilities $ do
   newMVar s
   where
     debug0 :: Bool
-    debug0 = True -- False
+    debug0 = False
 
 -- * Async Stacks
 

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -59,7 +59,7 @@ launchAll ctx = replicateM numCapabilities $ do
   newMVar s
   where
     debug0 :: Bool
-    debug0 = False
+    debug0 = True -- False
 
 -- * Async Stacks
 

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -5,6 +5,7 @@ import Data.Bits (testBit)
 import Data.Char (isDigit, isSpace)
 import Data.List (intersperse)
 import Data.Ratio (denominator, numerator, (%))
+import qualified Data.Text
 import Numeric (showFFloat, showHex, readHex)
 import Prelude hiding (abs, and, concat, const, div, mod, not, or)
 import qualified Prelude as P
@@ -341,10 +342,21 @@ real x
 string :: String -> SExpr
 string str = Atom ("\"" <> str <> "\"")
 
+-- | String literals, from Text
+text :: Data.Text.Text -> SExpr
+text str = Atom ("\"" <> Data.Text.unpack str <> "\"")
+
 -- | The unit value: a tuple of arity 0
 -- Tweag
 unit :: SExpr
 unit = const "mkTuple"
+
+-- | Create a new tuple
+tuple :: [SExpr] -> SExpr
+tuple = fun "mkTuple"
+
+tupleSel :: Integer -> SExpr -> SExpr
+tupleSel n t = List [fun "_" [Atom "tupSel", int n], t]
 
 -- | A bit vector represented in binary.
 --

--- a/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
@@ -66,12 +66,12 @@ tests =
               [pir| \(result : Integer) (x : Integer) . 0 < x |]
             )
             `pathSatisfies` (isSingleton .&. all isCounter)
-      , expectFail $ testCase "[input > 0] add 1 [result > 1] verified" $
+      , testCase "[input > 0] add 1 [result > 1] verified" $
           execFromPIRFile proveUnbounded 
             "tests/unit/resources/fromPlutusIRSpec-01.pir"
             ( [pirTy| Integer |], [pir| \(x : Integer) . addone x |])
-            ( [pir| \(result : Integer) (x : Integer) . 0 < result |],
-              [pir| \(result : Integer) (x : Integer) . 1 < x |]
+            ( [pir| \(result : Integer) (x : Integer) . 1 < result |],
+              [pir| \(result : Integer) (x : Integer) . 0 < x |]
             )
             `pathSatisfies` (isSingleton .&. all isVerified)
       ]

--- a/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
@@ -58,7 +58,7 @@ tests :: [TestTree]
 tests =
   [ testGroup
       "simple triples"
-      [ expectFail $ testCase "just evaluation" $
+      [ testCase "[input > 0] add 1 [result > 0] counter" $
           execFromPIRFile proveUnbounded 
             "tests/unit/resources/fromPlutusIRSpec-01.pir"
             ( [pirTy| Integer |], [pir| \(x : Integer) . addone x |])
@@ -66,5 +66,13 @@ tests =
               [pir| \(result : Integer) (x : Integer) . 0 < x |]
             )
             `pathSatisfies` (isSingleton .&. all isCounter)
+      , expectFail $ testCase "[input > 0] add 1 [result > 1] verified" $
+          execFromPIRFile proveUnbounded 
+            "tests/unit/resources/fromPlutusIRSpec-01.pir"
+            ( [pirTy| Integer |], [pir| \(x : Integer) . addone x |])
+            ( [pir| \(result : Integer) (x : Integer) . 0 < result |],
+              [pir| \(result : Integer) (x : Integer) . 1 < x |]
+            )
+            `pathSatisfies` (isSingleton .&. all isVerified)
       ]
   ]

--- a/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
@@ -61,7 +61,7 @@ tests =
       [ expectFail $ testCase "just evaluation" $
           execFromPIRFile proveUnbounded 
             "tests/unit/resources/fromPlutusIRSpec-01.pir"
-            ( [pirTy| Bool |], [pir| \(x : Integer) . addone x |])
+            ( [pirTy| Integer |], [pir| \(x : Integer) . addone x |])
             ( [pir| \(result : Integer) (x : Integer) . 0 < result |],
               [pir| \(result : Integer) (x : Integer) . 0 < x |]
             )

--- a/tests/unit/Language/Pirouette/PlutusIR/SyntaxSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/SyntaxSpec.hs
@@ -5,6 +5,7 @@
 module Language.Pirouette.PlutusIR.SyntaxSpec where
 
 import Control.Monad.Except
+import Data.Foldable (toList)
 import GHC.Float (rationalToDouble)
 import Language.Pirouette.PlutusIR
 import Pirouette.Term.TypeChecker
@@ -42,7 +43,7 @@ assertTrProgramOk flatFilePath = do
     Left err -> assertFailure $ "Translate program: " ++ show err
     Right (_, decls) -> do
       -- writeFile "decls.pirouette" (show $ pretty decls)
-      case typeCheckDecls decls of
+      case typeCheckDecls (builtinTypeDecls decls <> decls) of
         Left err -> assertFailure $ "Typecheck program: " ++ show (pretty err)
         Right _ -> return ()
   return ()

--- a/tests/unit/Language/Pirouette/PlutusIR/SyntaxSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/SyntaxSpec.hs
@@ -5,6 +5,7 @@
 module Language.Pirouette.PlutusIR.SyntaxSpec where
 
 import Control.Monad.Except
+import Data.Map (keys)
 import Data.Foldable (toList)
 import GHC.Float (rationalToDouble)
 import Language.Pirouette.PlutusIR
@@ -43,7 +44,9 @@ assertTrProgramOk flatFilePath = do
     Left err -> assertFailure $ "Translate program: " ++ show err
     Right (_, decls) -> do
       -- writeFile "decls.pirouette" (show $ pretty decls)
-      case typeCheckDecls (builtinTypeDecls decls <> decls) of
+      let allDecls = builtinTypeDecls decls <> decls
+      -- print $ pretty allDecls
+      case typeCheckDecls allDecls of
         Left err -> assertFailure $ "Typecheck program: " ++ show (pretty err)
         Right _ -> return ()
   return ()

--- a/tests/unit/Language/Pirouette/PlutusIR/ToTermSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/ToTermSpec.hs
@@ -28,16 +28,16 @@ tests = (:[]) $ withResource acquire (const $ return ()) $ \progAct ->
       -- Test that two declarations are present
       testCase "Decls contain 'long' and 'short' terms" $ do
         decls <- progAct
-        let longN = head $ filter ((== "long") . nameString) $ M.keys decls
-        let shortN = head $ filter ((== "short") . nameString) $ M.keys decls
+        let longN = head $ filter ((== "long") . nameString . snd) $ M.keys decls
+        let shortN = head $ filter ((== "short") . nameString . snd) $ M.keys decls
         case (,) <$> M.lookup longN decls <*> M.lookup shortN decls of
           Just _ -> return ()
           Nothing -> assertFailure "long/short not declared",
       -- Test that expanding one declaration yields the other declaration
       testCase "expandDefs produces NF terms" $ do
         decls <- progAct
-        let longN = head $ filter ((== "long") . nameString) $ M.keys decls
-        let shortN = head $ filter ((== "short") . nameString) $ M.keys decls
+        let longN = head $ filter ((== "long") . nameString . snd) $ M.keys decls
+        let shortN = head $ filter ((== "short") . nameString . snd) $ M.keys decls
         let (DFunction _ long _) = fromJust $ M.lookup longN decls
         let (DFunction _ short _) = fromJust $ M.lookup shortN decls
         runReader (expandDefs long) (mocked decls) @?= short

--- a/tests/unit/resources/fromPlutusIRSpec-01.pir
+++ b/tests/unit/resources/fromPlutusIRSpec-01.pir
@@ -25,7 +25,7 @@
         (tyvardecl a (type))
         (tyvardecl b (type))
         TxConstraints_match
-        (vardecl TxConstraint (fun [List TxConstraint] [[TxConstraint a] b]))))
+        (vardecl Txs (fun [List TxConstraint] [[TxConstraint a] b]))))
     (termbind
       (strict)
       (vardecl build (all a (type) (fun (all b (type) (fun (fun a (fun b b)) (fun b b))) [List a])))
@@ -36,7 +36,7 @@
       (strict)
       (vardecl mustBeTrue (all a (type) (all b (type) (fun Bool [[TxConstraints a] b]))))
       (abs a (type) (abs b (type) (lam x Bool
-        [ {{ TxConstraints a } b } 
+        [ {{ Txs a } b } 
           [ {build TxConstraint} 
             (abs k (type) (lam c (fun TxConstraint (fun k k)) (lam n k
              [[c [MustBeTrue x] ] n ]
@@ -58,7 +58,7 @@
     (termbind
       (strict)
         (vardecl short [[TxConstraints Bool] Bool])
-        [{{ TxConstraints Bool } Bool } 
+        [{{ Txs Bool } Bool } 
           [[ { Cons TxConstraint } [MustBeTrue False] ] { Nil TxConstraint } ] ]
     )
     (termbind 


### PR DESCRIPTION
This implements quite some Plutus IR primitives, leaving aside those which have to make with encoding and cryptography, which require some thinking about their representation. Some additional notes:
- This PR introduces a separation between a type and a term namespace. This was the only way I could resolve identifiers to their proper meanings, given that Plutus IR code (following Haskell) uses a lot of type/constructor punning.
- The `Data` type is represented by an additional datatype defined internally.
- Some commonalities between the `Example` and `PlutusIR` evaluators have been moved into a single `Pirouette.Symbolic.Eval.Helpers` module.