### PR TITLE
Add ormolu, remove hlint.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,10 @@ jobs:
         echo "!! CABAL TEST OUTPUT:"
         cat pirouette-cabal-test.out
         cabal_res=$(cat pirouette-cabal-test.res | cut -d':' -f2)
-        if [[ "$cabal_res" != "0" ]]; then
+        echo "!! ORMOLU OUTPUT:"
+        cat pirouette-ormolu.out
+        ormolu_res=$(cat pirouette-ormolu.res | cut -d':' -f2)
+        if [[ "$cabal_res" != "0" ]] || [[ "$ormolu_res" != "0" ]]; then
           exit 1
         fi
 

--- a/src/Language/Pirouette/Example.hs
+++ b/src/Language/Pirouette/Example.hs
@@ -34,12 +34,12 @@ import Language.Pirouette.QuasiQuoter.Syntax
 import Pirouette.Monad (termIsConstant, termIsMeta)
 import Pirouette.SMT.Base
 import Pirouette.SMT.Constraints
-import qualified PureSMT
-import Pirouette.Term.Syntax
 import Pirouette.Symbolic.Eval.Helpers
 import Pirouette.Symbolic.Eval.Types
+import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Prettyprinter (dquotes)
+import qualified PureSMT
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
@@ -185,7 +185,6 @@ pattern TBool = SystF.TyPure (SystF.Free (TyBuiltin TyBool))
 pattern TString :: TypeMeta Ex meta
 pattern TString = SystF.TyPure (SystF.Free (TyBuiltin TyString))
 
-
 -- | If we want to be able to symbolically evaluate terms of our language, we need to instruct
 -- pirouette on how to translate the builtins, constants and types into SMT
 instance LanguageSMT Ex where
@@ -210,7 +209,7 @@ instance LanguageSMT Ex where
 
   -- they are stuck if they are constants, or a not-ite builtin
   isStuckBuiltin e
-    | termIsConstant  e = True
+    | termIsConstant e = True
   isStuckBuiltin (SystF.App (SystF.Free (Builtin op)) args)
     | exTermIsArithOp op || exTermIsStringOp op =
       let args' = map (\(SystF.TermArg a) -> a) args

--- a/src/Language/Pirouette/PlutusIR.hs
+++ b/src/Language/Pirouette/PlutusIR.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE TypeApplications #-}
+
 module Language.Pirouette.PlutusIR (module X, pir, pirTy) where
 
-import Language.Pirouette.PlutusIR.Typing as X ()
-import Language.Pirouette.PlutusIR.Syntax as X
 import Language.Pirouette.PlutusIR.SMT as X
+import Language.Pirouette.PlutusIR.Syntax as X
 import Language.Pirouette.PlutusIR.ToTerm as X (trProgram, trProgramDecls)
-
+import Language.Pirouette.PlutusIR.Typing as X ()
 import qualified Language.Pirouette.QuasiQuoter as QQ
 
 pir :: QQ.QuasiQuoter

--- a/src/Language/Pirouette/PlutusIR/SMT.hs
+++ b/src/Language/Pirouette/PlutusIR/SMT.hs
@@ -9,10 +9,10 @@ import qualified Data.ByteString as BS
 import Data.Text (Text)
 import Language.Pirouette.PlutusIR.Syntax
 import Pirouette.Monad
-import Pirouette.Symbolic.Eval.Helpers
-import Pirouette.Symbolic.Eval.Types
 import Pirouette.SMT.Base
 import Pirouette.SMT.Constraints
+import Pirouette.Symbolic.Eval.Helpers
+import Pirouette.Symbolic.Eval.Types
 import Pirouette.Term.Syntax.Base
 import Pirouette.Term.Syntax.SystemF as SystemF
 import qualified PlutusCore as P
@@ -31,10 +31,11 @@ instance LanguageSMT PlutusIR where
     | termIsConstant e = True
     | Just _ <- termIsMeta e = True
   isStuckBuiltin (App (Free (Builtin op)) args)
-    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels
-    , all isArg args  -- this ensures that we only have TermArg
-    = let args' = map (\(TermArg a) -> a) args
-      in all isStuckBuiltin args' && not (all termIsConstant args')
+    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels,
+      all isArg args -- this ensures that we only have TermArg
+      =
+      let args' = map (\(TermArg a) -> a) args
+       in all isStuckBuiltin args' && not (all termIsConstant args')
   isStuckBuiltin _ = False
 
 trPIRType :: PIRBuiltinType -> PureSMT.SExpr
@@ -61,9 +62,10 @@ trPIRConstant (PIRConstByteString _bs) = error "Not implemented: PIRConstByteStr
 trPIRConstant PIRConstUnit = PureSMT.fun "Unit" []
 trPIRConstant (PIRConstBool b) = PureSMT.bool b
 trPIRConstant (PIRConstString txt) = PureSMT.text txt
-trPIRConstant (PIRConstList lst) = go lst 
-  where go [] = PureSMT.fun "Nil" []
-        go (x:xs) = PureSMT.fun "Cons" [trPIRConstant x, go xs]
+trPIRConstant (PIRConstList lst) = go lst
+  where
+    go [] = PureSMT.fun "Nil" []
+    go (x : xs) = PureSMT.fun "Cons" [trPIRConstant x, go xs]
 trPIRConstant (PIRConstPair x y) = PureSMT.fun "Tuple2" [trPIRConstant x, trPIRConstant y]
 trPIRConstant (PIRConstData _dat) = error "Not implemented: PIRConstData to SMT"
 
@@ -71,19 +73,35 @@ trPIRConstant (PIRConstData _dat) = error "Not implemented: PIRConstData to SMT"
 -- if the given arguments are constants.
 -- For example, @3 + 4@ is *not* stuck.
 plutusIRBasicOps :: [P.DefaultFun]
-plutusIRBasicOps = [
-  P.AddInteger, P.SubtractInteger, P.MultiplyInteger,
-  P.DivideInteger, P.ModInteger, P.QuotientInteger, P.RemainderInteger,
-  P.AppendString, P.AppendByteString, P.ConsByteString, P.IndexByteString, P.SliceByteString ]
+plutusIRBasicOps =
+  [ P.AddInteger,
+    P.SubtractInteger,
+    P.MultiplyInteger,
+    P.DivideInteger,
+    P.ModInteger,
+    P.QuotientInteger,
+    P.RemainderInteger,
+    P.AppendString,
+    P.AppendByteString,
+    P.ConsByteString,
+    P.IndexByteString,
+    P.SliceByteString
+  ]
 
 -- | These relations can be fully evaluated
 -- if the given arguments are constants.
-  -- For example, @3 < 4@ is *not* stuck.
+-- For example, @3 < 4@ is *not* stuck.
 plutusIRBasicRels :: [P.DefaultFun]
-plutusIRBasicRels = [
-  P.EqualsInteger, P.LessThanInteger, P.LessThanEqualsInteger,
-  P.EqualsByteString, P.EqualsString, P.EqualsData,
-  P.LessThanByteString, P.LessThanEqualsByteString ]
+plutusIRBasicRels =
+  [ P.EqualsInteger,
+    P.LessThanInteger,
+    P.LessThanEqualsInteger,
+    P.EqualsByteString,
+    P.EqualsString,
+    P.EqualsData,
+    P.LessThanByteString,
+    P.LessThanEqualsByteString
+  ]
 
 trPIRFun :: P.DefaultFun -> [PureSMT.SExpr] -> Maybe PureSMT.SExpr
 
@@ -124,7 +142,6 @@ trPIRFun P.UnIData _ = Nothing
 trPIRFun P.UnBData _ = Nothing
 -- If-then-else is complicated
 trPIRFun P.IfThenElse _ = Nothing
-
 -- Unary
 trPIRFun op [x] =
   case op of
@@ -145,7 +162,6 @@ trPIRFun op [x] =
         "Translate builtin to SMT: "
           <> show op
           <> " is not an implemented unary operator/function"
-
 -- Binary operations and relations
 trPIRFun op [x, y] =
   case op of
@@ -177,7 +193,6 @@ trPIRFun op [x, y] =
         "Translate builtin to SMT: "
           <> show op
           <> " is not an implemented binary operator/function"
-
 -- Remainder
 trPIRFun op _ =
   error $
@@ -185,76 +200,75 @@ trPIRFun op _ =
       <> show op
       <> " is not an implemented constant/operator/function"
 
-
 pattern K :: Constants lang -> AnnTerm ty ann (SystemF.VarMeta meta ann (TermBase lang))
 pattern K n = App (Free (Constant n)) []
 
 instance LanguageSymEval PlutusIR where
   -- basic operations over constants
-  
+
   branchesBuiltinTerm op _ [TermArg (K (PIRConstInteger x)), TermArg (K (PIRConstInteger y))]
-    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels
-    = (\r -> pure $ Just [ Branch { additionalInfo = mempty, newTerm = K r }]) $
-      case op of
-        P.AddInteger -> PIRConstInteger $ x + y
-        P.SubtractInteger -> PIRConstInteger $ x - y
-        P.MultiplyInteger ->PIRConstInteger $  x * y
-        P.DivideInteger -> PIRConstInteger $ x `div` y
-        P.ModInteger -> PIRConstInteger $ x `mod` y
-        P.QuotientInteger -> PIRConstInteger $ x `quot` y
-        P.RemainderInteger -> PIRConstInteger $ x `rem` y
-        P.EqualsInteger -> PIRConstBool $ x == y
-        P.LessThanInteger -> PIRConstBool $ x < y
-        P.LessThanEqualsInteger -> PIRConstBool $ x <= y
-        _ -> error "ill-typed application"
-
+    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels =
+      (\r -> pure $ Just [Branch {additionalInfo = mempty, newTerm = K r}]) $
+        case op of
+          P.AddInteger -> PIRConstInteger $ x + y
+          P.SubtractInteger -> PIRConstInteger $ x - y
+          P.MultiplyInteger -> PIRConstInteger $ x * y
+          P.DivideInteger -> PIRConstInteger $ x `div` y
+          P.ModInteger -> PIRConstInteger $ x `mod` y
+          P.QuotientInteger -> PIRConstInteger $ x `quot` y
+          P.RemainderInteger -> PIRConstInteger $ x `rem` y
+          P.EqualsInteger -> PIRConstBool $ x == y
+          P.LessThanInteger -> PIRConstBool $ x < y
+          P.LessThanEqualsInteger -> PIRConstBool $ x <= y
+          _ -> error "ill-typed application"
   branchesBuiltinTerm op _ [TermArg (K (PIRConstByteString x)), TermArg (K (PIRConstByteString y))]
-    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels
-    = (\r -> pure $ Just [ Branch { additionalInfo = mempty, newTerm = K r }]) $
-      case op of
-        P.AppendByteString -> PIRConstByteString (x <> y)
-        P.EqualsByteString -> PIRConstBool $ x == y
-        P.LessThanByteString -> PIRConstBool $ x < y
-        P.LessThanEqualsByteString -> PIRConstBool $ x <= y
-        _ -> error "ill-typed application"
-
-  branchesBuiltinTerm P.LengthOfByteString _ [TermArg (K (PIRConstByteString b))]
-    = let r = K $ PIRConstInteger (fromIntegral $ BS.length b)
-      in pure $ Just [ Branch { additionalInfo = mempty, newTerm = r }]
-
-  branchesBuiltinTerm P.ConsByteString _ 
-    [TermArg (K (PIRConstInteger i)), TermArg (K (PIRConstByteString b))]
-    = let r = K $ PIRConstByteString (BS.cons (fromInteger i) b)
-      in pure $ Just [ Branch { additionalInfo = mempty, newTerm = r }]
-
-  branchesBuiltinTerm P.IndexByteString _ 
-    [TermArg (K (PIRConstByteString b)), TermArg (K (PIRConstInteger i))]
-    = let r = if i < 0 then errorTerm
-                       else K $ PIRConstInteger $ fromIntegral (BS.index b (fromInteger i))
-      in pure $ Just [ Branch { additionalInfo = mempty, newTerm = r }]
-
-  branchesBuiltinTerm P.IndexByteString _ 
-    [TermArg (K (PIRConstInteger start)), TermArg (K (PIRConstInteger n)), TermArg (K (PIRConstByteString xs))]
-    = let r = K $ PIRConstByteString $ BS.take (fromInteger n) (BS.drop (fromInteger start) xs)
-      in pure $ Just [ Branch { additionalInfo = mempty, newTerm = r }]
-
+    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels =
+      (\r -> pure $ Just [Branch {additionalInfo = mempty, newTerm = K r}]) $
+        case op of
+          P.AppendByteString -> PIRConstByteString (x <> y)
+          P.EqualsByteString -> PIRConstBool $ x == y
+          P.LessThanByteString -> PIRConstBool $ x < y
+          P.LessThanEqualsByteString -> PIRConstBool $ x <= y
+          _ -> error "ill-typed application"
+  branchesBuiltinTerm P.LengthOfByteString _ [TermArg (K (PIRConstByteString b))] =
+    let r = K $ PIRConstInteger (fromIntegral $ BS.length b)
+     in pure $ Just [Branch {additionalInfo = mempty, newTerm = r}]
+  branchesBuiltinTerm
+    P.ConsByteString
+    _
+    [TermArg (K (PIRConstInteger i)), TermArg (K (PIRConstByteString b))] =
+      let r = K $ PIRConstByteString (BS.cons (fromInteger i) b)
+       in pure $ Just [Branch {additionalInfo = mempty, newTerm = r}]
+  branchesBuiltinTerm
+    P.IndexByteString
+    _
+    [TermArg (K (PIRConstByteString b)), TermArg (K (PIRConstInteger i))] =
+      let r =
+            if i < 0
+              then errorTerm
+              else K $ PIRConstInteger $ fromIntegral (BS.index b (fromInteger i))
+       in pure $ Just [Branch {additionalInfo = mempty, newTerm = r}]
+  branchesBuiltinTerm
+    P.IndexByteString
+    _
+    [TermArg (K (PIRConstInteger start)), TermArg (K (PIRConstInteger n)), TermArg (K (PIRConstByteString xs))] =
+      let r = K $ PIRConstByteString $ BS.take (fromInteger n) (BS.drop (fromInteger start) xs)
+       in pure $ Just [Branch {additionalInfo = mempty, newTerm = r}]
   branchesBuiltinTerm op _ [TermArg (K (PIRConstString x)), TermArg (K (PIRConstString y))]
-    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels
-    = (\r -> pure $ Just [ Branch { additionalInfo = mempty, newTerm = K r }]) $
-      case op of
-        P.AppendString -> PIRConstString $ x <> y
-        P.EqualsString -> PIRConstBool $ x == y
-        _ -> error "ill-typed application"
-
+    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels =
+      (\r -> pure $ Just [Branch {additionalInfo = mempty, newTerm = K r}]) $
+        case op of
+          P.AppendString -> PIRConstString $ x <> y
+          P.EqualsString -> PIRConstBool $ x == y
+          _ -> error "ill-typed application"
   branchesBuiltinTerm op _ [TermArg (K (PIRConstData x)), TermArg (K (PIRConstData y))]
-    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels
-    = (\r -> pure $ Just [ Branch { additionalInfo = mempty, newTerm = K r }]) $
-      case op of
-        P.EqualsData -> PIRConstBool $ x == y
-        _ -> error "ill-typed application"
-
+    | op `elem` plutusIRBasicOps || op `elem` plutusIRBasicRels =
+      (\r -> pure $ Just [Branch {additionalInfo = mempty, newTerm = K r}]) $
+        case op of
+          P.EqualsData -> PIRConstBool $ x == y
+          _ -> error "ill-typed application"
   -- if-then-else goes to the helpers
-  branchesBuiltinTerm P.IfThenElse _  (TyArg _ : TermArg c : TermArg t : TermArg e : excess) =
+  branchesBuiltinTerm P.IfThenElse _ (TyArg _ : TermArg c : TermArg t : TermArg e : excess) =
     let isEq P.EqualsInteger = True
         isEq P.EqualsString = True
         isEq P.EqualsByteString = True
@@ -264,10 +278,16 @@ instance LanguageSymEval PlutusIR where
         isTrue _ = False
         isFalse (K (PIRConstBool False)) = True
         isFalse _ = False
-    in ifThenElseBranching
-         isTrue (K (PIRConstBool True)) isFalse (K (PIRConstBool False))
-         isEq c t e excess
-
+     in ifThenElseBranching
+          isTrue
+          (K (PIRConstBool True))
+          isFalse
+          (K (PIRConstBool False))
+          isEq
+          c
+          t
+          e
+          excess
   -- applying constructors functions during evaluation
   -- is quite useful because we tend can interact with
   -- the pattern matching much better b/c we know
@@ -279,7 +299,6 @@ instance LanguageSymEval PlutusIR where
     continueWith "Nil" []
   branchesBuiltinTerm P.MkCons _ _args =
     continueWith "Nil" []
-
   branchesBuiltinTerm P.ConstrData _ args =
     continueWith "Data_Constr" args
   branchesBuiltinTerm P.MapData _ args =
@@ -290,116 +309,179 @@ instance LanguageSymEval PlutusIR where
     continueWith "Data_I" args
   branchesBuiltinTerm P.BData _ args =
     continueWith "Data_B" args
-
   -- pattern matching and built-in matchers
 
   -- they take the arguments in a different order
-  branchesBuiltinTerm P.ChooseList _ 
-    (TyArg a : TyArg tyR : TermArg lst : TermArg caseNil : TermArg caseCons : excess) = 
+  branchesBuiltinTerm
+    P.ChooseList
+    _
+    (TyArg a : TyArg tyR : TermArg lst : TermArg caseNil : TermArg caseCons : excess) =
       continueWithListMatch a tyR lst caseNil caseCons excess
-  branchesBuiltinTerm P.ChooseUnit _ (tyR : unit : rest) = 
+  branchesBuiltinTerm P.ChooseUnit _ (tyR : unit : rest) =
     continueWith "Unit_match" (unit : tyR : rest)
-  branchesBuiltinTerm P.ChooseData _ 
+  branchesBuiltinTerm
+    P.ChooseData
+    _
     (tyR : dat : TermArg caseC : TermArg caseM : TermArg caseL : TermArg caseI : TermArg caseB : excess) =
       continueWithDataMatch dat tyR caseC caseM caseL caseI caseB excess
-
   -- built-in matchers
 
   branchesBuiltinTerm P.FstPair _ [tyA@(TyArg a), tyB@(TyArg b), tuple] =
-    continueWith "Tuple2_match"
-      [ tyA, tyB, tuple, tyA
-      , TermArg $ Lam (Ann "x") a $ Lam (Ann "y") b $ App (Bound (Ann "x") 1) [] ]
+    continueWith
+      "Tuple2_match"
+      [ tyA,
+        tyB,
+        tuple,
+        tyA,
+        TermArg $ Lam (Ann "x") a $ Lam (Ann "y") b $ App (Bound (Ann "x") 1) []
+      ]
   branchesBuiltinTerm P.SndPair _ [tyA@(TyArg a), tyB@(TyArg b), tuple] =
-    continueWith "Tuple2_match"
-      [ tyA, tyB, tuple, tyB
-      , TermArg $ Lam (Ann "x") a $ Lam (Ann "y") b $ App (Bound (Ann "y") 0) [] ]
-
+    continueWith
+      "Tuple2_match"
+      [ tyA,
+        tyB,
+        tuple,
+        tyB,
+        TermArg $ Lam (Ann "x") a $ Lam (Ann "y") b $ App (Bound (Ann "y") 0) []
+      ]
   branchesBuiltinTerm P.HeadList _ [TyArg a, TermArg lst] =
     continueWithListMatch a a lst errorTerm (App (Bound (Ann "x") 1) []) []
   branchesBuiltinTerm P.TailList _ [TyArg a, TermArg lst] =
     continueWithListMatch a (listOf a) lst errorTerm (App (Bound (Ann "xs") 0) []) []
   branchesBuiltinTerm P.NullList _ [TyArg a, TermArg lst] =
-    continueWithListMatch a (builtin PIRTypeBool) lst
-      (K $ PIRConstBool True) (K $ PIRConstBool False) []  
-
+    continueWithListMatch
+      a
+      (builtin PIRTypeBool)
+      lst
+      (K $ PIRConstBool True)
+      (K $ PIRConstBool False)
+      []
   branchesBuiltinTerm P.UnConstrData _ [d] =
-    continueWithDataMatch 
-      d (TyArg (builtin (PIRTypePair (Just PIRTypeInteger) (Just PIRTypeData))))
-      (App (Free $ TermSig "Tuple2") [TermArg $ App (Bound (Ann "i") 1) [], TermArg $ App (Bound (Ann "ds") 0) []]) 
-      errorTerm errorTerm errorTerm errorTerm []
+    continueWithDataMatch
+      d
+      (TyArg (builtin (PIRTypePair (Just PIRTypeInteger) (Just PIRTypeData))))
+      (App (Free $ TermSig "Tuple2") [TermArg $ App (Bound (Ann "i") 1) [], TermArg $ App (Bound (Ann "ds") 0) []])
+      errorTerm
+      errorTerm
+      errorTerm
+      errorTerm
+      []
   branchesBuiltinTerm P.UnMapData _ [d] =
-    continueWithDataMatch 
-      d (TyArg (listOf (builtin (PIRTypePair (Just PIRTypeData) (Just PIRTypeData)))))
-      errorTerm (App (Bound (Ann "es") 0) []) errorTerm errorTerm errorTerm []
+    continueWithDataMatch
+      d
+      (TyArg (listOf (builtin (PIRTypePair (Just PIRTypeData) (Just PIRTypeData)))))
+      errorTerm
+      (App (Bound (Ann "es") 0) [])
+      errorTerm
+      errorTerm
+      errorTerm
+      []
   branchesBuiltinTerm P.UnListData _ [d] =
-    continueWithDataMatch 
-      d (TyArg (listOf (builtin PIRTypeData)))
-      errorTerm errorTerm (App (Bound (Ann "ds") 0) []) errorTerm errorTerm []
+    continueWithDataMatch
+      d
+      (TyArg (listOf (builtin PIRTypeData)))
+      errorTerm
+      errorTerm
+      (App (Bound (Ann "ds") 0) [])
+      errorTerm
+      errorTerm
+      []
   branchesBuiltinTerm P.UnIData _ [d] =
-    continueWithDataMatch 
-      d (TyArg (builtin PIRTypeInteger))
-      errorTerm errorTerm errorTerm (App (Bound (Ann "i") 0) []) errorTerm []
+    continueWithDataMatch
+      d
+      (TyArg (builtin PIRTypeInteger))
+      errorTerm
+      errorTerm
+      errorTerm
+      (App (Bound (Ann "i") 0) [])
+      errorTerm
+      []
   branchesBuiltinTerm P.UnBData _ [d] =
-    continueWithDataMatch 
-      d (TyArg (builtin PIRTypeByteString))
-      errorTerm errorTerm errorTerm errorTerm (App (Bound (Ann "b") 0) []) []
-
-  branchesBuiltinTerm _rest _translator _args = 
+    continueWithDataMatch
+      d
+      (TyArg (builtin PIRTypeByteString))
+      errorTerm
+      errorTerm
+      errorTerm
+      errorTerm
+      (App (Bound (Ann "b") 0) [])
+      []
+  branchesBuiltinTerm _rest _translator _args =
     pure Nothing
 
 -- | Indicates that the next step in the evaluation of that
 -- built-in is the given function with the given arguments.
 -- There's quite some boilerplate around it, hence this utility.
-continueWith :: 
+continueWith ::
   (ToSMT meta, Applicative m) =>
-  Text -> [ArgMeta lang meta] ->
+  Text ->
+  [ArgMeta lang meta] ->
   m (Maybe [Branch lang meta])
 continueWith destr args = do
   let destr' = Name destr Nothing
-      tm     = App (Free $ TermSig destr') args
-  pure $ Just [ Branch { additionalInfo = mempty, newTerm = tm }]
+      tm = App (Free $ TermSig destr') args
+  pure $ Just [Branch {additionalInfo = mempty, newTerm = tm}]
 
 -- | Indicates that the next step is an application of
 -- the List destructor. Note that this function does *not*
 -- include any check for well-scopedness, so be careful!
 continueWithListMatch ::
   (ToSMT meta, Applicative m, lang ~ PlutusIR) =>
-  TypeMeta lang meta -> TypeMeta lang meta -> TermMeta lang meta ->
-  TermMeta lang meta -> TermMeta lang meta ->
-  [ArgMeta lang meta] -> m (Maybe [Branch lang meta])
-continueWithListMatch tyA tyR lst caseNil caseCons excess = 
-  continueWith "Nil_match" 
-    [ TyArg tyA, TermArg lst, TyArg tyR 
-    , TermArg $ caseNil `appN` excess
-    , TermArg $ Lam (Ann "x") tyA $ Lam (Ann "xs") (listOf tyA) $ caseCons `appN` excess ]
+  TypeMeta lang meta ->
+  TypeMeta lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  [ArgMeta lang meta] ->
+  m (Maybe [Branch lang meta])
+continueWithListMatch tyA tyR lst caseNil caseCons excess =
+  continueWith
+    "Nil_match"
+    [ TyArg tyA,
+      TermArg lst,
+      TyArg tyR,
+      TermArg $ caseNil `appN` excess,
+      TermArg $ Lam (Ann "x") tyA $ Lam (Ann "xs") (listOf tyA) $ caseCons `appN` excess
+    ]
 
 -- | Indicates that the next step is an application of
 -- the Data destructor. Note that this function does *not*
 -- include any check for well-scopedness, so be careful!
 continueWithDataMatch ::
   (ToSMT meta, Applicative m, lang ~ PlutusIR) =>
-  ArgMeta lang meta -> ArgMeta lang meta ->
-  TermMeta lang meta -> TermMeta lang meta -> TermMeta lang meta -> TermMeta lang meta -> TermMeta lang meta ->
-  [ArgMeta lang meta] -> m (Maybe [Branch lang meta])
+  ArgMeta lang meta ->
+  ArgMeta lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  [ArgMeta lang meta] ->
+  m (Maybe [Branch lang meta])
 continueWithDataMatch dat tyR caseC caseM caseL caseI caseB excess =
-  continueWith "Data_match" 
-    [ dat, tyR
-    , TermArg $ Lam (Ann "i") (builtin PIRTypeInteger)  $ Lam (Ann "ds") (listOf (builtin PIRTypeData)) caseC `appN` excess
-    , TermArg $ Lam (Ann "es") (listOf (builtin (PIRTypePair (Just PIRTypeData) (Just PIRTypeData)))) $ caseM `appN` excess
-    , TermArg $ Lam (Ann "ds") (listOf (builtin PIRTypeData)) $ caseL `appN` excess
-    , TermArg $ Lam (Ann "i") (builtin PIRTypeInteger) $ caseI `appN` excess
-    , TermArg $ Lam (Ann "b") (builtin PIRTypeByteString) $ caseB `appN` excess ]
+  continueWith
+    "Data_match"
+    [ dat,
+      tyR,
+      TermArg $ Lam (Ann "i") (builtin PIRTypeInteger) $ Lam (Ann "ds") (listOf (builtin PIRTypeData)) caseC `appN` excess,
+      TermArg $ Lam (Ann "es") (listOf (builtin (PIRTypePair (Just PIRTypeData) (Just PIRTypeData)))) $ caseM `appN` excess,
+      TermArg $ Lam (Ann "ds") (listOf (builtin PIRTypeData)) $ caseL `appN` excess,
+      TermArg $ Lam (Ann "i") (builtin PIRTypeInteger) $ caseI `appN` excess,
+      TermArg $ Lam (Ann "b") (builtin PIRTypeByteString) $ caseB `appN` excess
+    ]
 
 errorTerm :: AnnTerm ty ann (SystemF.VarMeta meta ann (TermBase lang))
 errorTerm = App (Free Bottom) []
 
-listOf :: AnnType ann (SystemF.VarMeta meta ann (TypeBase lang))
-       -> AnnType ann (SystemF.VarMeta meta ann (TypeBase lang))
+listOf ::
+  AnnType ann (SystemF.VarMeta meta ann (TypeBase lang)) ->
+  AnnType ann (SystemF.VarMeta meta ann (TypeBase lang))
 listOf x = TyApp (Free $ TySig "List") [x]
 
-tuple2Of :: AnnType ann (SystemF.VarMeta meta ann (TypeBase lang)) 
-         -> AnnType ann (SystemF.VarMeta meta ann (TypeBase lang))
-         -> AnnType ann (SystemF.VarMeta meta ann (TypeBase lang))
+tuple2Of ::
+  AnnType ann (SystemF.VarMeta meta ann (TypeBase lang)) ->
+  AnnType ann (SystemF.VarMeta meta ann (TypeBase lang)) ->
+  AnnType ann (SystemF.VarMeta meta ann (TypeBase lang))
 tuple2Of x y = TyApp (Free $ TySig "Tuple2") [x, y]
 
 builtin :: PIRBuiltinType -> AnnType ann (SystemF.VarMeta meta ann (TypeBase PlutusIR))

--- a/src/Language/Pirouette/PlutusIR/Typing.hs
+++ b/src/Language/Pirouette/PlutusIR/Typing.hs
@@ -12,8 +12,8 @@
 -- the only export of this module is that instance.
 module Language.Pirouette.PlutusIR.Typing () where
 
-import Language.Pirouette.PlutusIR.Syntax
 import Data.String (fromString)
+import Language.Pirouette.PlutusIR.Syntax
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import qualified PlutusCore as P

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -1,14 +1,14 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Provides the quasiquoters to be able to write @lang@ programs
 --  directly into Haskell source files. Using the functions
@@ -28,7 +28,7 @@ import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Term.TypeChecker (typeCheckDecls, typeCheckFunDef)
 import Text.Megaparsec
 
-prog :: forall lang . (LanguageParser lang, LanguageBuiltinTypes lang, Language lang) => QuasiQuoter
+prog :: forall lang. (LanguageParser lang, LanguageBuiltinTypes lang, Language lang) => QuasiQuoter
 prog = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
   (decls, DFunDef main@(FunDef _ mainTm _)) <- trQ (uncurry trProgram p0)
@@ -36,19 +36,19 @@ prog = quoter $ \str -> do
   _ <- maybeQ (typeCheckFunDef decls "main" main)
   [e|(decls, mainTm)|]
 
-progNoTC :: forall lang . (LanguageParser lang, Language lang) => QuasiQuoter
+progNoTC :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
 progNoTC = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
   (decls, DFunDef (FunDef _ mainTm _)) <- trQ (uncurry trProgram p0)
   [e|(decls, mainTm)|]
 
-term :: forall lang . (LanguageParser lang, Language lang) => QuasiQuoter
+term :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
 term = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseTerm @lang) <* eof) str
   p1 <- trQ (trTerm [] [] p0)
   [e|p1|]
 
-ty :: forall lang . (LanguageParser lang, Language lang) => QuasiQuoter
+ty :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
 ty = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseType @lang) <* eof) str
   p1 <- trQ (trType [] p0)

--- a/src/Language/Pirouette/QuasiQuoter/Syntax.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Syntax.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ConstraintKinds #-}
 
 -- | Simple parser for a simple language aimed at helping us
 -- writing terms for testing pirouette a with a little less work.
@@ -38,13 +38,13 @@ import Data.Foldable
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Void
+import Language.Haskell.TH.Syntax (Lift)
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Transformations.Utils (monoNameSep)
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
-import Language.Haskell.TH.Syntax (Lift)
 
 -- ** Class for parsing language builtins
 

--- a/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
+++ b/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
@@ -28,8 +28,8 @@ trProgram ::
   TrM (M.Map (Namespace, Name) (Definition lang), Definition lang)
 trProgram env main@FunDecl {} =
   let decls = forM (M.toList env) $ \case
-                (s, Left td) -> trDataDecl s td
-                (s, Right f) -> (\r -> [((TermNamespace, fromString s), r)]) <$> trFunDecl f
+        (s, Left td) -> trDataDecl s td
+        (s, Right f) -> (\r -> [((TermNamespace, fromString s), r)]) <$> trFunDecl f
    in (,) <$> (decls >>= toDecls . concat) <*> trFunDecl main
   where
     toDecls :: [((Namespace, Name), Definition lang)] -> TrM (Decls lang)

--- a/src/ListT/Weighted.hs
+++ b/src/ListT/Weighted.hs
@@ -8,7 +8,7 @@
 -- | A re-implementation of @https://hackage.haskell.org/package/weighted-search@
 -- as a monad transformer.
 module ListT.Weighted
-  ( WeightedListT(..),
+  ( WeightedListT (..),
     WeightedList,
     MonadWeightedList (..),
     (<|>),

--- a/src/Pirouette.hs
+++ b/src/Pirouette.hs
@@ -1,7 +1,7 @@
 module Pirouette (module X) where
 
 import Pirouette.Symbolic.Prover.Runner as X
-  ( assertIncorrectnessLogic,
+  ( IncorrectnessParams (..),
+    assertIncorrectnessLogic,
     replIncorrectnessLogic,
-    IncorrectnessParams(..)
   )

--- a/src/Pirouette/Monad.hs
+++ b/src/Pirouette/Monad.hs
@@ -80,7 +80,7 @@ prtDefOfAnyNamespace n = do
   let tm = Map.lookup (TermNamespace, n) defs
       ty = Map.lookup (TypeNamespace, n) defs
   case (tm, ty) of
-    (Just _, Just _)  -> prtError $ PEUndefined n
+    (Just _, Just _) -> prtError $ PEUndefined n
     (Just t, Nothing) -> pure t
     (Nothing, Just t) -> pure t
     _ -> prtError $ PEUndefined n

--- a/src/Pirouette/SMT/Base.hs
+++ b/src/Pirouette/SMT/Base.hs
@@ -4,8 +4,8 @@ module Pirouette.SMT.Base where
 
 import Control.Monad.IO.Class
 import Data.Void
-import qualified PureSMT
 import Pirouette.Term.Syntax
+import qualified PureSMT
 
 -- | Captures the languages that can be translated to SMTLIB; namelly,
 -- we need to be able to translate each individual base syntactical category.

--- a/src/Pirouette/SMT/Constraints.hs
+++ b/src/Pirouette/SMT/Constraints.hs
@@ -10,13 +10,13 @@ module Pirouette.SMT.Constraints where
 import Data.Either
 import Data.List (intersperse)
 import Data.Map (Map)
+import qualified Data.Set as S
 import Pirouette.Monad
 import Pirouette.SMT.Base
-import qualified PureSMT
 import Pirouette.SMT.FromTerm
 import Pirouette.Term.Syntax
 import Prettyprinter hiding (Pretty (..))
-import qualified Data.Set as S
+import qualified PureSMT
 
 -- TODO: this module should probably be refactored somewhere;
 -- I'm not entirely onboard with the 'translateData' funct as it is;

--- a/src/Pirouette/SMT/FromTerm.hs
+++ b/src/Pirouette/SMT/FromTerm.hs
@@ -20,9 +20,9 @@ import qualified Data.Set as S
 -- import Debug.Trace (trace)
 import Pirouette.Monad
 import Pirouette.SMT.Base
-import qualified PureSMT
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as Raw
+import qualified PureSMT
 
 -- useful during debugging
 traceMe :: String -> a -> a

--- a/src/Pirouette/SMT/Monadic.hs
+++ b/src/Pirouette/SMT/Monadic.hs
@@ -7,8 +7,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Pirouette.SMT.Monadic
   ( SolverT (..),
@@ -46,10 +46,10 @@ import ListT.Weighted (MonadWeightedList)
 import Pirouette.Monad
 import Pirouette.SMT.Base as Base
 import Pirouette.SMT.Constraints
-import qualified PureSMT
 import Pirouette.SMT.FromTerm
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as R
+import qualified PureSMT
 
 -- OLD CODE
 
@@ -120,21 +120,22 @@ declareDatatype typeName (Datatype _ typeVariables _ cstrs) = do
 -- | Declare a set of datatypes (all at once) in the current solver session.
 declareDatatypes ::
   (LanguageSMT lang, MonadIO m) => [(Name, TypeDef lang)] -> ExceptT String (SolverT m) [Name]
-declareDatatypes [] = 
+declareDatatypes [] =
   -- we need to handle this especially because SMTLIB doesn't like an empty set of types
   pure []
 declareDatatypes dts = do
   solver <- ask
-  (dts', _) <- runWriterT $ forM dts $ \(typeName, Datatype _ typeVariables _ cstrs) -> do
-    cstrs' <- mapM (constructorFromPIR typeVariables) cstrs
-    pure (toSmtName typeName, map (toSmtName . fst) typeVariables, cstrs')
+  (dts', _) <- runWriterT $
+    forM dts $ \(typeName, Datatype _ typeVariables _ cstrs) -> do
+      cstrs' <- mapM (constructorFromPIR typeVariables) cstrs
+      pure (toSmtName typeName, map (toSmtName . fst) typeVariables, cstrs')
   liftIO $ PureSMT.declareDatatypes solver dts'
   return $ concat [typeName : map fst cstrs | (typeName, Datatype _ _ _ cstrs) <- dts]
 
--- |Returns whether or not a function @f@ can be declared as an uninterpreted function and,
--- if it can, return the type of its arguments and result.
--- A function can be declared if its type can be translate to SmtLib, an uninterpreted function
--- has no body after all, so no need to worry about it.
+-- | Returns whether or not a function @f@ can be declared as an uninterpreted function and,
+--  if it can, return the type of its arguments and result.
+--  A function can be declared if its type can be translate to SmtLib, an uninterpreted function
+--  has no body after all, so no need to worry about it.
 supportedUninterpretedFunction ::
   (LanguageSMT lang) => FunDef lang -> Maybe ([PureSMT.SExpr], PureSMT.SExpr)
 supportedUninterpretedFunction FunDef {funTy} = toMaybe $ do
@@ -142,10 +143,10 @@ supportedUninterpretedFunction FunDef {funTy} = toMaybe $ do
   (args', _) <- runWriterT $ mapM translateType args
   (result', _) <- runWriterT $ translateType result
   return (args', result')
- where
-   toMaybe = either (const Nothing) Just . runExcept
+  where
+    toMaybe = either (const Nothing) Just . runExcept
 
--- |Declares a function with a given name, type of arguments and type of result.
+-- | Declares a function with a given name, type of arguments and type of result.
 declareRawFun ::
   (MonadIO m) => Name -> ([PureSMT.SExpr], PureSMT.SExpr) -> SolverT m ()
 declareRawFun n (args, res) = do

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -225,8 +225,9 @@ weightedParFilter f (ListT.Weight n w) =
 weightedParFilter f (ListT.Action (Identity w)) = weightedParFilter f w
 weightedParFilter f (ListT.Yield a w) =
   let (keep, rest) =
-        withStrategy (parTuple2 rpar rpar)
-        (f a , weightedParFilter f w)
+        withStrategy
+          (parTuple2 rpar rpar)
+          (f a, weightedParFilter f w)
    in if keep then ListT.Yield a rest else rest
 
 -- | Learn a new constraint and add it as a conjunct to the set of constraints of
@@ -370,7 +371,7 @@ symEvalOneStep t@(R.App hd args) = case hd of
 -- in here. If we do really need the monad, we can only paralellize the prune and pruneAndValidate
 -- functions, if not, we could paralellize everything.
 symEvalParallel ::
-  forall lang .
+  forall lang.
   (SymEvalConstr lang) =>
   [TermMeta lang SymVar] ->
   SymEval lang ([TermMeta lang SymVar], Any)

--- a/src/Pirouette/Symbolic/Eval/Helpers.hs
+++ b/src/Pirouette/Symbolic/Eval/Helpers.hs
@@ -6,69 +6,74 @@ import Pirouette.SMT.Constraints
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 
-ifThenElseBranching :: 
+ifThenElseBranching ::
   (Applicative f, LanguageSMT lang, Show meta) =>
-  (TermMeta lang meta -> Bool) -> TermMeta lang meta ->
-  (TermMeta lang meta -> Bool) -> TermMeta lang meta -> 
+  (TermMeta lang meta -> Bool) ->
+  TermMeta lang meta ->
+  (TermMeta lang meta -> Bool) ->
+  TermMeta lang meta ->
   (BuiltinTerms lang -> Bool) ->
-  TermMeta lang meta -> TermMeta lang meta -> TermMeta lang meta -> [ArgMeta lang meta] ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  [ArgMeta lang meta] ->
   f (Maybe [Branch lang meta])
 ifThenElseBranching isTrue trueTm isFalse falseTm isEq c t e excess =
-    let t' = t `SystF.appN` excess
-        e' = e `SystF.appN` excess
-      in case c of
-          _ | isTrue c -> pure $ Just [Branch (And []) t]
-          _ | isFalse c -> pure $ Just [Branch (And []) e]
-          SystF.App (SystF.Free (Builtin eq)) [SystF.TermArg x, SystF.TermArg y]
-            -- try to generate the best type of constraint
-            -- from the available equality ones
-            | isEq eq,
-              Just x1 <- termIsMeta x,
-              Just y1 <- termIsMeta y ->
-              pure $
-                Just
-                  [ -- either they are equal
-                    Branch (And [VarEq x1 y1]) t',
-                    -- or they are not
-                    Branch (And [NonInlinableSymbolNotEq x y]) e'
-                  ]
-            | isEq eq,
-              Just x1 <- termIsMeta x,
-              isStuckBuiltin y ->
-              pure $
-                Just
-                  [ -- either they are equal
-                    Branch (And [Assign x1 y]) t',
-                    -- or they are not
-                    Branch (And [NonInlinableSymbolNotEq x y]) e'
-                  ]
-            | isEq eq,
-              isStuckBuiltin x,
-              Just y1 <- termIsMeta y ->
-              pure $
-                Just
-                  [ -- either they are equal
-                    Branch (And [Assign y1 x]) t',
-                    -- or they are not
-                    Branch (And [NonInlinableSymbolNotEq y x]) e'
-                  ]
-            | isEq eq,
-              isStuckBuiltin x,
-              isStuckBuiltin y ->
-              pure $
-                Just
-                  [ -- either they are equal
-                    Branch (And [NonInlinableSymbolEq x y]) t',
-                    -- or they are not
-                    Branch (And [NonInlinableSymbolNotEq x y]) e'
-                  ]
-          _
-            | Just v <- termIsMeta c ->
-              pure $
-                Just
-                  [ -- c is True => t is executed
-                    Branch (And [Assign v trueTm]) t',
-                    -- c is False => e is executed
-                    Branch (And [Assign v falseTm]) e'
-                  ]
-          _ -> pure Nothing
+  let t' = t `SystF.appN` excess
+      e' = e `SystF.appN` excess
+   in case c of
+        _ | isTrue c -> pure $ Just [Branch (And []) t]
+        _ | isFalse c -> pure $ Just [Branch (And []) e]
+        SystF.App (SystF.Free (Builtin eq)) [SystF.TermArg x, SystF.TermArg y]
+          -- try to generate the best type of constraint
+          -- from the available equality ones
+          | isEq eq,
+            Just x1 <- termIsMeta x,
+            Just y1 <- termIsMeta y ->
+            pure $
+              Just
+                [ -- either they are equal
+                  Branch (And [VarEq x1 y1]) t',
+                  -- or they are not
+                  Branch (And [NonInlinableSymbolNotEq x y]) e'
+                ]
+          | isEq eq,
+            Just x1 <- termIsMeta x,
+            isStuckBuiltin y ->
+            pure $
+              Just
+                [ -- either they are equal
+                  Branch (And [Assign x1 y]) t',
+                  -- or they are not
+                  Branch (And [NonInlinableSymbolNotEq x y]) e'
+                ]
+          | isEq eq,
+            isStuckBuiltin x,
+            Just y1 <- termIsMeta y ->
+            pure $
+              Just
+                [ -- either they are equal
+                  Branch (And [Assign y1 x]) t',
+                  -- or they are not
+                  Branch (And [NonInlinableSymbolNotEq y x]) e'
+                ]
+          | isEq eq,
+            isStuckBuiltin x,
+            isStuckBuiltin y ->
+            pure $
+              Just
+                [ -- either they are equal
+                  Branch (And [NonInlinableSymbolEq x y]) t',
+                  -- or they are not
+                  Branch (And [NonInlinableSymbolNotEq x y]) e'
+                ]
+        _
+          | Just v <- termIsMeta c ->
+            pure $
+              Just
+                [ -- c is True => t is executed
+                  Branch (And [Assign v trueTm]) t',
+                  -- c is False => e is executed
+                  Branch (And [Assign v falseTm]) e'
+                ]
+        _ -> pure Nothing

--- a/src/Pirouette/Symbolic/Eval/SMT.hs
+++ b/src/Pirouette/Symbolic/Eval/SMT.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -20,6 +20,7 @@ module Pirouette.Symbolic.Eval.SMT where
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
+import Data.Bifunctor (bimap)
 import qualified Data.List as List
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -29,9 +30,8 @@ import Pirouette.SMT.FromTerm
 import qualified Pirouette.SMT.Monadic as SMT
 import Pirouette.Symbolic.Eval.Types
 import Pirouette.Term.Syntax
+import Prettyprinter (align, enclose, vsep, (<+>))
 import qualified PureSMT
-import Data.Bifunctor (bimap)
-import Prettyprinter (enclose, align, (<+>), vsep)
 
 -- | Contains the shared context of a session with the solver. Datatypes will
 -- be declared first, then the uninterpreted functions. Definitions will
@@ -69,16 +69,16 @@ data CheckPropertyProblem lang = CheckPropertyProblem
     cpropDefs :: PrtOrderedDefs lang
   }
 
--- |The result of a 'CheckPropertyProblem' is one of the following options:
+-- | The result of a 'CheckPropertyProblem' is one of the following options:
 data PruneResult
-  -- |The assumptions are inconsistent (TODO: what does it mean? example!)
-  = PruneInconsistentAssumptions
-  -- |The SMT was able to prove that the implication holds in this branch
-  | PruneImplicationHolds
-  -- |The SMT found a counter-example to the implication
-  | PruneCounterFound Model
-  -- |The SMT is uncertain whether the implication holds or not
-  | PruneUnknown
+  = -- | The assumptions are inconsistent (TODO: what does it mean? example!)
+    PruneInconsistentAssumptions
+  | -- | The SMT was able to prove that the implication holds in this branch
+    PruneImplicationHolds
+  | -- | The SMT found a counter-example to the implication
+    PruneCounterFound Model
+  | -- | The SMT is uncertain whether the implication holds or not
+    PruneUnknown
   deriving (Eq, Show)
 
 data CheckPathProblem lang = CheckPathProblem
@@ -86,7 +86,7 @@ data CheckPathProblem lang = CheckPathProblem
     cpathDefs :: PrtOrderedDefs lang
   }
 
--- |Models returned by the SMT solver
+-- | Models returned by the SMT solver
 newtype Model = Model [(PureSMT.SExpr, PureSMT.Value)]
   deriving (Eq, Show)
 
@@ -110,7 +110,7 @@ hackSolver s = flip runReaderT s . SMT.unSolverT
 hackSolverPrt :: PureSMT.Solver -> PrtOrderedDefs lang -> HackSolver lang a -> IO a
 hackSolverPrt s defs = flip runReaderT defs . flip runReaderT s . SMT.unSolverT
 
--- |Instance necessary to call the 'PureSMT.solve' function.
+-- | Instance necessary to call the 'PureSMT.solve' function.
 instance (SMT.LanguageSMT lang) => PureSMT.Solve lang where
   type Ctx lang = SolverSharedCtx lang
   type Problem lang = SolverProblem lang

--- a/src/Pirouette/Symbolic/Prover.hs
+++ b/src/Pirouette/Symbolic/Prover.hs
@@ -10,15 +10,15 @@ import Control.Monad.State
 import Control.Monad.Writer
 import qualified Data.Text as T
 import Debug.Trace
-import Pirouette.Monad (termIsWHNFOrMeta, PirouetteDepOrder)
+import Pirouette.Monad (PirouetteDepOrder, termIsWHNFOrMeta)
 import Pirouette.SMT.Base (LanguageSMT (isStuckBuiltin))
 import Pirouette.SMT.Constraints
-import PureSMT (SExpr (..))
 import Pirouette.SMT.FromTerm
 import Pirouette.Symbolic.Eval
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as R
-import Prettyprinter hiding (pretty, Pretty)
+import Prettyprinter hiding (Pretty, pretty)
+import PureSMT (SExpr (..))
 
 -- | A problem represents a triple that should be checked.
 -- It should be the case that assuming 'problemAssume',
@@ -58,7 +58,7 @@ type SymTerm lang = TermMeta lang SymVar
 rESULTNAME :: Name
 rESULTNAME = "__result"
 
--- |Executes the problem returning /all/ paths (up to some stopping condition).
+-- | Executes the problem returning /all/ paths (up to some stopping condition).
 prove ::
   (SymEvalConstr lang, PirouetteDepOrder lang m) =>
   StoppingCondition ->
@@ -66,17 +66,17 @@ prove ::
   m [Path lang (EvaluationWitness lang)]
 prove shouldStop problem = symeval shouldStop $ proveRaw problem
 
--- |Prove without any stopping condition.
+-- | Prove without any stopping condition.
 proveUnbounded ::
   (SymEvalConstr lang, PirouetteDepOrder lang m) =>
   Problem lang ->
   m [Path lang (EvaluationWitness lang)]
 proveUnbounded = prove (const False)
 
--- |Executes the problem while the stopping condition is valid until
--- the supplied predicate returns @True@. A return value of @Nothing@
--- means that on all paths that we looked at they were either verified or
--- they reached the stopping condition.
+-- | Executes the problem while the stopping condition is valid until
+--  the supplied predicate returns @True@. A return value of @Nothing@
+--  means that on all paths that we looked at they were either verified or
+--  they reached the stopping condition.
 proveAny ::
   (SymEvalConstr lang, PirouetteDepOrder lang m) =>
   StoppingCondition ->
@@ -177,8 +177,9 @@ worker resultVar bodyTerm assumeTerm proveTerm = do
     _ -> do
       -- one step of evaluation on each,
       -- but going into matches first
-      ([bodyTerm', assumeTerm', proveTerm'], somethingWasEval) <- prune $
-        symEvalParallel [bodyTerm, assumeTerm, proveTerm]
+      ([bodyTerm', assumeTerm', proveTerm'], somethingWasEval) <-
+        prune $
+          symEvalParallel [bodyTerm, assumeTerm, proveTerm]
       -- debugPutStr "ONE STEP"
       -- debugPrint (pretty bodyTerm')
       -- debugPrint (pretty assumeTerm')

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -8,6 +8,7 @@ import Control.Monad.Reader
 import Pirouette.Monad
 import Pirouette.Symbolic.Eval
 import Pirouette.Symbolic.Prover
+import Pirouette.Term.Syntax (pretty)
 import Pirouette.Term.Syntax.Base
 import Pirouette.Term.Syntax.SystemF (tyFunArgs)
 import Pirouette.Term.TypeChecker
@@ -16,7 +17,6 @@ import Pirouette.Transformations.Defunctionalization
 import Pirouette.Transformations.Monomorphization
 import System.Console.ANSI
 import qualified Test.Tasty.HUnit as Test
-import Pirouette.Term.Syntax (pretty)
 
 data AssumeProve lang = Term lang :==>: Term lang
   deriving (Eq, Show)

--- a/src/Pirouette/Term/Syntax.hs
+++ b/src/Pirouette/Term/Syntax.hs
@@ -190,7 +190,7 @@ safeIdx l = go l . fromIntegral
     go :: [a] -> Integer -> Maybe a
     go [] _ = Nothing
     go (x : _) 0 = Just x
-    go (_ : xs) n = go xs (n -1)
+    go (_ : xs) n = go xs (n - 1)
 
 unsafeIdx :: (Integral i) => String -> [a] -> i -> a
 unsafeIdx lbl l = fromMaybe (error $ "unsafeIdx: out-of-bounds; " ++ lbl) . safeIdx l

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -346,22 +346,25 @@ class (LanguageConstrs lang) => LanguageBuiltins lang where
   type Constants lang :: *
 
   -- | Definitions required for built-in types
-  builtinTypeDefinitions :: 
-    [(Name, TypeDef lang)]    -- ^ types which are already defined
-    -> [(Name, TypeDef lang)] -- ^ additional definitions supporting those
+  builtinTypeDefinitions ::
+    -- | types which are already defined
+    [(Name, TypeDef lang)] ->
+    -- | additional definitions supporting those
+    [(Name, TypeDef lang)]
   builtinTypeDefinitions _ = []
 
 builtinTypeDecls :: (LanguageBuiltins lang) => Decls lang -> Decls lang
-builtinTypeDecls m = 
+builtinTypeDecls m =
   let defs = flip mapMaybe (Map.toList m) $ \((_, nm), def) -> case def of
-               DTypeDef td -> Just (nm, td)
-               _ -> Nothing
+        DTypeDef td -> Just (nm, td)
+        _ -> Nothing
       newTypeDefs = builtinTypeDefinitions defs
-  in Map.fromList $ do
-    (nm, td@Datatype { destructor, constructors }) <- newTypeDefs
-    [ ((TypeNamespace, nm), DTypeDef td), ((TermNamespace, destructor), DDestructor nm) ]
-      ++ [ ((TermNamespace, constructorName), DConstructor i nm )
-         | (i, (constructorName, _)) <- zip [0 ..] constructors ]
+   in Map.fromList $ do
+        (nm, td@Datatype {destructor, constructors}) <- newTypeDefs
+        [((TypeNamespace, nm), DTypeDef td), ((TermNamespace, destructor), DDestructor nm)]
+          ++ [ ((TermNamespace, constructorName), DConstructor i nm)
+               | (i, (constructorName, _)) <- zip [0 ..] constructors
+             ]
 
 -- | Auxiliary constraint for pretty-printing terms of a given language.
 type LanguagePretty lang =

--- a/src/Pirouette/Term/Syntax/Pretty.hs
+++ b/src/Pirouette/Term/Syntax/Pretty.hs
@@ -93,5 +93,5 @@ instance Pretty Namespace where
 instance (LanguagePretty lang) => Pretty (Decls lang) where
   pretty = align . vsep . map prettyDef . Map.toList
     where
-      prettyDef ((namespace, name), def) = 
+      prettyDef ((namespace, name), def) =
         vsep [pretty namespace <+> pretty name <+> "|->", indent 2 (pretty def)]

--- a/src/Pirouette/Term/Syntax/SystemF.hs
+++ b/src/Pirouette/Term/Syntax/SystemF.hs
@@ -74,7 +74,7 @@ data Kind = KStar | KTo Kind Kind
 -- > kindDrop 3 (* -> (* -> *) -> * -> *) == *
 kindDrop :: Int -> Kind -> Kind
 kindDrop 0 k = k
-kindDrop n (KTo _ k) = kindDrop (n -1) k
+kindDrop n (KTo _ k) = kindDrop (n - 1) k
 kindDrop _ _ = error "kindDrop: KStar has no arguments to drop"
 
 -- ** Types
@@ -242,7 +242,7 @@ getHeadAbs t = ([], t)
 
 getNHeadAbs :: Int -> AnnTerm ty ann v -> ([(ann, Kind)], AnnTerm ty ann v)
 getNHeadAbs 0 t = ([], t)
-getNHeadAbs n (Abs (Ann v) k t) = first ((v, k) :) $ getNHeadAbs (n -1) t
+getNHeadAbs n (Abs (Ann v) k t) = first ((v, k) :) $ getNHeadAbs (n - 1) t
 getNHeadAbs _ _ = error "getNHeadAbs: Not enough type-abstractions"
 
 getHeadLams :: AnnTerm ty ann v -> ([(ann, ty)], AnnTerm ty ann v)
@@ -251,7 +251,7 @@ getHeadLams t = ([], t)
 
 getNHeadLams :: Int -> AnnTerm ty ann v -> ([(ann, ty)], AnnTerm ty ann v)
 getNHeadLams 0 t = ([], t)
-getNHeadLams n (Lam (Ann v) ty t) = first ((v, ty) :) $ getNHeadLams (n -1) t
+getNHeadLams n (Lam (Ann v) ty t) = first ((v, ty) :) $ getNHeadLams (n - 1) t
 getNHeadLams _ _ = error "getNHeadLams: Not enough lambdas"
 
 withLams :: [(ann, ty)] -> AnnTerm ty ann v -> AnnTerm ty ann v

--- a/src/Pirouette/Term/Transformations.hs
+++ b/src/Pirouette/Term/Transformations.hs
@@ -11,13 +11,13 @@ import Control.Monad.Except
 import Data.Data
 import Data.Functor
 import Data.Generics.Uniplate.Data
+import Data.List (elemIndex)
 import Data.String (fromString)
 import Pirouette.Monad
 import Pirouette.Monad.Maybe
 import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.Subst
 import qualified Pirouette.Term.Syntax.SystemF as SystF
-import Data.List (elemIndex)
 
 -- | Put excessive arguments of a a destructor in the branches.
 --  Because we have n-ary applications, whenever we translate something like:
@@ -85,8 +85,8 @@ removeExcessiveDestArgs = rewriteM (runMaybeT . go)
 
     tyDrop :: Int -> TypeMeta lang meta -> TypeMeta lang meta
     tyDrop 0 t = t
-    tyDrop n (SystF.TyFun _ b) = tyDrop (n -1) b
-    tyDrop n (SystF.TyAll _ _ t) = tyDrop (n -1) t
+    tyDrop n (SystF.TyFun _ b) = tyDrop (n - 1) b
+    tyDrop n (SystF.TyAll _ _ t) = tyDrop (n - 1) t
     tyDrop _ _ = error "Ill-typed program: not enough type parameters to drop"
 
 -- | Because TLA+ really doesn't allow for shadowed bound names, we need to rename them
@@ -251,7 +251,7 @@ chooseHeadCase t ty args fstArg =
     geneXs n =
       map
         (\i -> SystF.TermArg $ SystF.termPure (SystF.Bound (fromString $ "x" ++ show i) (toInteger $ n - 1 - i)))
-        [0 .. n -1]
+        [0 .. n - 1]
 
     -- Replace the argument "INPUT" by a dummy version of it, which is bound at index 0.
     transitionArgs :: String -> Int -> SystF.Arg ty (Term lang)

--- a/src/Pirouette/Term/TypeChecker.hs
+++ b/src/Pirouette/Term/TypeChecker.hs
@@ -373,8 +373,7 @@ instance Pretty ErrorPathElement where
   pretty (TermPathAppTermArg n) = "arg" <+> pretty n
   pretty TermPathAppResult = "app result"
 
-instance Pretty NameUnknownReason
-  where
+instance Pretty NameUnknownReason where
   pretty (TypeUnknown nm) = "type" <+> pretty nm
   pretty (ConstructorIndexUnknown ix) = "constructor" <+> pretty ix
   pretty NameLookupFailed = "lookup"

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | This module implements a pool of external processes, each running an
 -- SMT solver.
-module PureSMT (module X, Solve(..), solve) where
+module PureSMT (module X, Solve (..), solve) where
 
-import PureSMT.Process as X
-import PureSMT.SExpr as X
 import Control.Concurrent.MVar
 import Control.Concurrent.QSem
-import System.IO.Unsafe (unsafePerformIO)
 import Control.Monad
 import GHC.Conc (numCapabilities)
+import PureSMT.Process as X
+import PureSMT.SExpr as X
+import System.IO.Unsafe (unsafePerformIO)
 
 -- | This class provides an interface to communicate with an individual
 -- SMT solver, while the `solve` function provides access to the pool.
@@ -24,16 +24,17 @@ import GHC.Conc (numCapabilities)
 -- be called by the user. To provide an instance of 'Solve', you can use the functions
 -- in "PureSMT.Process" and "PureSMT.SExpr" to interact with a 'Solver' in a monadic fashion.
 class Solve domain where
-  -- |Specifies what is the common domain that is supposed to be shared amongst all calls to
-  -- the SMT solver
+  -- | Specifies what is the common domain that is supposed to be shared amongst all calls to
+  --  the SMT solver
   type Ctx domain :: *
-  -- |Specifies a GADT for the problems that we can solve for this domain.
+
+  -- | Specifies a GADT for the problems that we can solve for this domain.
   type Problem domain :: * -> *
 
-  -- |How to initialize a solver with the given context;
+  -- | How to initialize a solver with the given context;
   initSolver :: Ctx domain -> Solver -> IO ()
 
-  -- |Solves a problem, producing an associated result with it
+  -- | Solves a problem, producing an associated result with it
   solveProblem :: Problem domain result -> Solver -> IO result
 
 -- | Evaluates a 'Problem' with an SMT solver chosen from a global pool of
@@ -43,9 +44,8 @@ class Solve domain where
 -- multiple pools of SMT solvers might be created for the same value of
 -- @Ctx domain@ if @solve@ is called from different modules, or if GHC
 -- optimizations fail to apply CSE over calls to solve in the same module.
---
 {-# NOINLINE solve #-}
-solve :: forall domain res . Solve domain => Ctx domain -> Problem domain res -> res
+solve :: forall domain res. Solve domain => Ctx domain -> Problem domain res -> res
 solve ctx = unsafePerformIO $ do
   -- Launch all our worker processes similar to how we did it in TypedProcess2.hs; but now
   -- we end up with a list of MVars, which we will protect in another MVar.
@@ -65,7 +65,7 @@ solve ctx = unsafePerformIO $ do
     pushMStack ms allProcs
     return r
 
-launchAll :: forall domain . Solve domain => Ctx domain -> IO [MVar X.Solver]
+launchAll :: forall domain. Solve domain => Ctx domain -> IO [MVar X.Solver]
 launchAll ctx = replicateM numCapabilities $ do
   s <- X.launchSolverWithFinalizer "cvc4 --lang=smt2 --incremental --fmf-fun" debug0
   initSolver @domain ctx s
@@ -76,15 +76,15 @@ launchAll ctx = replicateM numCapabilities $ do
 
 -- * Async Stacks
 
--- |An 'MStack a' is an 'MVar' having a list of 'a's,
--- which can be popped off the list and pushed back onto it.
--- Popping off an 'MStack' that has no available 'a's just blocks until one becomes available.
+-- | An 'MStack a' is an 'MVar' having a list of 'a's,
+--  which can be popped off the list and pushed back onto it.
+--  Popping off an 'MStack' that has no available 'a's just blocks until one becomes available.
 type MStack a =
-    -- Invariants:
-    -- * The qsem has no more resources than the length of the list in the MVar
-    -- * For every element added to the list in the MVar, one resource
-    -- is then added in the qsem (although not atomically).
-    (QSem, MVar [a])
+  -- Invariants:
+  -- The qsem has no more resources than the length of the list in the MVar
+  -- For every element added to the list in the MVar, one resource
+  -- is then added in the qsem (although not atomically).
+  (QSem, MVar [a])
 
 newMStack :: [a] -> IO (MStack a)
 newMStack xs = (,) <$> newQSem (length xs) <*> newMVar xs
@@ -97,5 +97,6 @@ pushMStack a (sem, q) = do
 popMStack :: MStack a -> IO a
 popMStack (sem, q) = do
   waitQSem sem
-  modifyMVar q $ \case []     -> error "invariant disrespected; MStack should not be empty if QSem gives passage"
-                       (x:xs) -> pure (xs, x)
+  modifyMVar q $ \case
+    [] -> error "invariant disrespected; MStack should not be empty if QSem gives passage"
+    (x : xs) -> pure (xs, x)

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -6,10 +6,10 @@ import Data.Char (isDigit, isSpace)
 import Data.List (intersperse)
 import Data.Ratio (denominator, numerator, (%))
 import qualified Data.Text
-import Numeric (showFFloat, showHex, readHex)
+import Numeric (readHex, showFFloat, showHex)
+import Text.Read (readMaybe)
 import Prelude hiding (abs, and, concat, const, div, mod, not, or)
 import qualified Prelude as P
-import Text.Read (readMaybe)
 
 -- | Results of checking for satisfiability.
 data Result
@@ -170,7 +170,7 @@ ppSExpr = go 0
         e : more
           | n <= 0 -> Nothing
           | otherwise -> case e of
-            Atom x -> (showString x :) <$> small (n -1) more
+            Atom x -> (showString x :) <$> small (n - 1) more
             _ -> Nothing
 
     go :: Int -> SExpr -> ShowS

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -42,8 +42,9 @@ run_ormolu() {
   ## which requires to set our locale for Ormolu to be happy.
   export LC_ALL=C.UTF-8
   if $ci; then
-    ormolu --mode check $(find ./src -name '*.hs')
+    ormolu --mode check $(find ./src -name '*.hs') | tee "./${proj}-ormolu.out"
     ormolu_res=$?
+    echo "run_ormolu:$ormolu_res" >> "./${proj}-ormolu.res"
   else
     ormolu --mode inplace $(find ./src -name '*.hs')
     ormolu_res=$?
@@ -84,13 +85,11 @@ if [[ "$cabal_build_ok" -ne "0" ]]; then
   exit 1
 fi
 
-## Disable ormolu for the time being; re-enable back before merging into main.
-##
-## run_ormolu "$p"
-## if [[ "$?" -ne "0" ]]; then
-##   echo "[FAILURE] 'ormolu --check' failed for $p; check the respective artifact."
-##   ormolu_ok=false
-## fi
+run_ormolu "pirouette"
+if [[ "$?" -ne "0" ]]; then
+  echo "[FAILURE] 'ormolu --check' failed; check the respective artifact."
+  ormolu_ok=false
+fi
 
 run_cabal_test "pirouette"
 if [[ "$?" -ne "0" ]]; then


### PR DESCRIPTION
This PR brings in a lot of changes that were produced by `ormolu`; the important changes are w.r.t. hooking up ormolu to our CI:

- https://github.com/tweag/pirouette/pull/119/files#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948L68
- https://github.com/tweag/pirouette/pull/119/files#diff-4df71b389eaed17aa1d651bc8d40d4f67356af9eb04af052c7c5483c0c9f56d1

Closes #105 

I advise people to set up a commit hook to run ormolu for you; you can do so by creating an executable file named `.git/hooks/pre-commit` with the following contents:

```bash
#!/usr/bin/env bash
set -e

# command adapted from https://github.com/JLLeitschuh/ktlint-gradle  task addKtlintFormatGitPreCommitHook
filesToFormat="$(git --no-pager diff --name-status --no-color --cached | \
  awk '($1 == "M" || $1 == "A") && $2 ~ /\.hs/ { print $2} $1 ~ /R/ && $3 ~ /\.hs/ { print $3 } ')"

echo "files to format $filesToFormat"
for sourceFilePath in $filesToFormat
do
  ormolu --mode inplace "$(pwd)/$sourceFilePath"
  git add $sourceFilePath
done;
```

I'll add that to the readme and to the repo on a separate PR used to update the readmes.
