### PR TITLE
Update interface and `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ transformations (monomorphization, defunctionalization, prenex, etc...) defined
 and relies on the `-XQuasiQuotes` extension to be able to easily write
 properties in the target language.
 
-There is one analisys currently built into pirouette, which symbolic evaluates terms up to
+There is one analysis currently built into pirouette, which symbolically evaluates terms up to
 a certain bound while looking for counterexamples based on [incorrectness][incorrectness]
 or Hoare triples.
 

--- a/README.md
+++ b/README.md
@@ -2,30 +2,35 @@
 
 _Pirouette is a research prototype under active development_
 
-* [Use case: Example](#example-language)
-* [Use case: Plutus Smart Contracts](#plutus-smart-contracts)
-* [Limitations](#limitations)
+* [Bounded Symbolic Evaluation](#bounded-symbolic-evaluation)
+  - [Use case: Example](#example-language)
+  - [Use case: Plutus Smart Contracts](#plutus-smart-contracts)
+  - [Limitations](#limitations)
 * [Building, Installing and Hacking](#building-installing-and-hacking)
 * [Contributing](#contributing)
 * [License](#license)
 
 Pirouette is a framework for constructing different static
 analysis tools for [System F][systemf]-based languages. It has a number of
-transformations (monomorphization, defunctionalization, prenex, etc...) implemented
-and relies on the `-XQuasiQuotes` extension to be able to easily write
-properties in the target language.
+transformations (monomorphization, defunctionalization, prenex, etc...) implemented,
+which can be composed in different ways to cater for different goals.
 
-There is one analysis currently built into pirouette, which symbolically evaluates terms up to
-a certain bound while looking for counterexamples based on [incorrectness][incorrectness]
-or Hoare triples.
+# Bounded Symbolic Evaluation
+
+There is one analysis currently built into pirouette, which symbolically evaluates terms
+while looking for counterexamples based on a mixture of [incorrectness][incorrectness] and Hoare triples.
+Say we have a function `t :: Ins -> Outs`, we can check that for all `i :: Ints` up to a certain
+size, `P (t i) i` implies `Q (t i) i`, where `P` and `Q` are the user-defined predicates we
+interested in enforcing. We invite the interested reader to our [blog-post][tweag-blogpost] for more 
+details on these reasoning techniques.
 
 [systemf]: https://en.wikipedia.org/wiki/System_F
 [incorrectness]: https://dl.acm.org/doi/pdf/10.1145/3371078
 [tweag-blogpost]: TODO
 
-# Use Cases
+## Use Cases
 
-## Example Language
+### Example Language
 
 The `Language.Pirouette.Example` defines the `Ex` language: pirouette's example language.
 We refer the interested reader to this module for guidelines on using pirouette over
@@ -40,48 +45,39 @@ addone x = x + 1
 
 And we wish to check the incorrectness triple `[x > 0] addone x [result > 0]`, that
 is: if `addone x > 0`, then `x > 0`. We obviously expect a counterexample with `x = 0`.
-We can use pirouette to find that assignment:
+Because pirouette conveniently uses the `-XQuasiQuotes` extension, we can 
+quickly use it find that assignment:
 
 ```haskell
 params :: IncorrectnessParams Ex
 params = IncorrectnessParams
-          [term| \x:Integer . x + 1 |] -- A function term to symbolically evaluate
+          [term| \x:Integer . x + 1 |] -- A function term to symbolically evaluate, this is our t above
           [ty| Integer |] -- type of the result of the function term above
-          -- Conditions to check, they take the result and the inputs of the function term 
+          -- Conditions to check, they take the result and the inputs of the function term,
+          -- these are our P and Q above
           ([term| \(res:Integer) (x:Integer) . 0 < res |]
             :==>: [term| \(res:Integer) (x:Integer) . 0 < x |])
 ```
 
-Now we can run `replIncorrectnessLogic1 10 params` in a repl and we should see:
+Now we can run `replIncorrectnessLogicSingl 10 params` in a repl and we should see:
 ```
 💸 COUNTEREXAMPLE FOUND
 { __result ↦ 1
   x ↦ 0 }
 ```
 
-## Plutus Smart Contracts
+### Plutus Smart Contracts
 
 [Plutus] is a subset of Haskell used to
-write smart contracts for Cardano blockchain, which utilizes the _Extended UTxO_
-[[1](https://iohk.io/en/research/library/papers/the-extended-utxo-model/),
-[2](https://iohk.io/en/research/library/papers/native-custom-tokens-in-the-extended-utxo-model/)]
-model to represent its accounts. Pirouette has a prototype interface to interacting with
+write smart contracts for Cardano blockchain.
+Pirouette has a prototype interface to interacting with
 plutus through `Language.Pirouette.PlutusIR`, but further work is necessary to
 seamlessly interact with validator scripts.
 
 An example of using pirouette to load and check an incorrectness triple over a `.pir` file
 can be found [here](tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs).
 
-## Building, Installing and Hacking
-
-The recommended way of building pirouette is through [Nix](https://nixos.org/guides/install-nix.html).
-Enter the Nix shell with `nix-shell` then run `cabal build` at the
-root of the repository. It is important that you *set up your nix cache* according to the
-[instructions in the plutus repository](https://github.com/input-output-hk/plutus#iohk-binary-cache)
-to avoid building GHC when you start the nix shell.
-
-You might want to consider `direnv` and [`nix-direnv`](https://github.com/nix-community/nix-direnv)
-instead of running `nix-shell` directly.
+[Plutus]: https://plutus.readthedocs.io/en/latest/
 
 ## Limitations
 
@@ -92,15 +88,34 @@ it also carries the limitations of a model checker: exploration of the state spa
 and it is not a substitute for a formal
 proof of correctness.
 
-## Contributing
+# Building, Installing and Hacking
 
-Did you find a bug while using `pirouette`? Please [report it](https://github.com/tweag/pirouette/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md). Would you like to help fix a bug or add a feature?
+The recommended way of building pirouette is through [Nix](https://nixos.org/guides/install-nix.html).
+Enter the Nix shell with `nix-shell` then run `cabal build` at the
+root of the repository. It is important that you *set up your nix cache* according to the
+[instructions in the plutus repository](https://github.com/input-output-hk/plutus#iohk-binary-cache)
+to avoid building GHC when you start the nix shell.
+
+You might want to consider `direnv` and [`nix-direnv`](https://github.com/nix-community/nix-direnv)
+instead of running `nix-shell` directly.
+
+## Pre-commit Hooks and CI
+
+Our CI runs `ormolu` and `cabal test`. In order to help avoid CI failures due to 
+formatting problems, we recommend that you install the 
+[pre-commit hook for running ormolu](tests/ormolu-pre-commit-hook.sh).
+To do so, simply copy (or link) the script into `.git/hooks/pre-commit`.
+
+# Contributing
+
+Did you find a bug while using `pirouette`? 
+Please [report it](https://github.com/tweag/pirouette/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md). 
+Would you like to help fix a bug or add a feature?
 We welcome pull requests! Check the [issue](https://github.com/tweag/pirouette/issues) page for inspiration.
 
-## License
+# License
 
 See [LICENSE](LICENSE).
 
 Copyright © 2021–present Tweag I/O
 
-[Plutus]: https://plutus.readthedocs.io/en/latest/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ or Hoare triples.
 [incorrectness]: https://dl.acm.org/doi/pdf/10.1145/3371078
 [tweag-blogpost]: TODO
 
-# Use Case: Example
+# Use Cases
+
+## Example Language
 
 The `Language.Pirouette.Example` defines the `Ex` language: pirouette's example language.
 We refer the interested reader to check the respective module for guidelines on using pirouette over
@@ -57,7 +59,7 @@ Now we can run `replIncorrectnessLogic1 10 params` in a repl and we should see:
   x ↦ 0 }
 ```
 
-# Use Case: Plutus Smart Contracts
+## Plutus Smart Contracts
 
 [Plutus] is a subset of Haskell used to
 write smart contracts for Cardano blockchain, which utilizes the _Extended UTxO_

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 _Pirouette is a research prototype under active development_
 
-* [Plutus Smart Contracts](#plutus-smart-contracts-and-transition-systems)
 * [Building, Installing and Hacking](#building-installing-and-hacking)
-* [Usage](#usage)
+* [Use case: Example](#example-language)
+* [Use case: Plutus Smart Contracts](#plutus-smart-contracts)
 * [Limitations](#limitations)
 * [Contributing](#contributing)
 * [License](#license)
+
+Pirouette is a toolbox for building language-agnostic analisys tools. Its core language
+is System F with datatypes
+
+----
 
 Pirouette is a semi-automatic code extraction tool. It extracts a
 [TLA+](https://lamport.azurewebsites.net/tla/tla.html) specification

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ is: if `addone x > 0`, then `x > 0`. We obviously expect a counterexample with `
 We can use pirouette to find that assignment:
 
 ```haskell
-parms :: IncorrectnessParams Ex
-parms = IncorrectnessParams
-          [term| \x:Integer . x + 1 |] -- Term to symbolically evaluate
-          [ty| Integer |] -- type of the term above
-          -- Conditions to check
+params :: IncorrectnessParams Ex
+params = IncorrectnessParams
+          [term| \x:Integer . x + 1 |] -- A function term to symbolically evaluate
+          [ty| Integer |] -- type of the result of the function term above
+          -- Conditions to check, they take the result and the inputs of the function term 
           ([term| \(res:Integer) (x:Integer) . 0 < res |]
             :==>: [term| \(res:Integer) (x:Integer) . 0 < x |])
 ```
@@ -70,7 +70,7 @@ plutus through `Language.Pirouette.PlutusIR`, but further work is necessary to
 seamlessly interact with validator scripts.
 
 An example of using pirouette to load and check an incorrectness triple over a `.pir` file
-can be found in [here](tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs).
+can be found [here](tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs).
 
 ## Building, Installing and Hacking
 
@@ -87,9 +87,9 @@ instead of running `nix-shell` directly.
 
 In its current form, `pirouette` itself is still a research prototype
 and, hence, it has plenty of limitations. The overall approach of pirouette's
-symbolic engine is an intersetion of bounded model checking and symbolic executon, hence,
-it also carries the limitations of a model checker: it can be slow
-space can be slow and a model checker is not a substitute for a formal
+symbolic engine is an intersection of bounded model checking and symbolic execution, hence,
+it also carries the limitations of a model checker: exploration of the state space can be slow
+and it is not a substitute for a formal
 proof of correctness.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ _Pirouette is a research prototype under active development_
 * [Contributing](#contributing)
 * [License](#license)
 
-Pirouette is being built as framework for constructing different static
-analisys tools for [System F][systemf] based languages. It has a number of
-transformations (monomorphization, defunctionalization, prenex, etc...) defined
+Pirouette is a framework for constructing different static
+analysis tools for [System F][systemf]-based languages. It has a number of
+transformations (monomorphization, defunctionalization, prenex, etc...) implemented
 and relies on the `-XQuasiQuotes` extension to be able to easily write
 properties in the target language.
 
@@ -28,7 +28,7 @@ or Hoare triples.
 ## Example Language
 
 The `Language.Pirouette.Example` defines the `Ex` language: pirouette's example language.
-We refer the interested reader to check the respective module for guidelines on using pirouette over
+We refer the interested reader to this module for guidelines on using pirouette over
 your own language.
 
 Now, say we have the simple program:
@@ -85,8 +85,8 @@ instead of running `nix-shell` directly.
 
 ## Limitations
 
-In its current form, `pirouette` itself is still a research prototype
-and, hence, it has plenty of limitations. The overall approach of pirouette's
+In its current form, `pirouette` itself is still a research prototype,
+hence, it has plenty of limitations. The overall approach of pirouette's
 symbolic engine is an intersection of bounded model checking and symbolic execution, hence,
 it also carries the limitations of a model checker: exploration of the state space can be slow
 and it is not a substitute for a formal

--- a/src/Language/Pirouette/Example/IsUnity.hs
+++ b/src/Language/Pirouette/Example/IsUnity.hs
@@ -3,35 +3,37 @@
 module Language.Pirouette.Example.IsUnity where
 
 import Language.Pirouette.Example
+import Pirouette.Monad
 import Pirouette.Symbolic.Prover.Runner
-import Pirouette.Term.Syntax.Base
 import qualified Test.Tasty.HUnit as Test
 
 checkWrong :: Test.Assertion
 checkWrong =
   assertIncorrectnessLogic
+    15
+    definitions
     IncorrectnessParams
-      { ipDefinitions = definitions,
-        ipTarget = [term| \(tx : TxInfo) . validator tx |], -- validator
+      { ipTarget = [term| \(tx : TxInfo) . validator tx |], -- validator
+        ipTargetType = [ty| Bool |],
         ipCondition =
           [term| \(result : Bool) (tx : TxInfo) . result |] -- incorrectness triple
-            :==>: [term| \(result : Bool) (tx : TxInfo) . correct_validator tx |],
-        ipMaxCstrs = 15
+            :==>: [term| \(result : Bool) (tx : TxInfo) . correct_validator tx |]
       }
 
 checkOk :: Test.Assertion
 checkOk =
   assertIncorrectnessLogic
+    20
+    definitions
     IncorrectnessParams
-      { ipDefinitions = definitions,
-        ipTarget = [term| \(tx : TxInfo) . correct_validator tx |], -- validator
+      { ipTarget = [term| \(tx : TxInfo) . correct_validator tx |], -- validator
+        ipTargetType = [ty| Bool |],
         ipCondition =
           [term| \(result : Bool) (tx : TxInfo) . result |] -- incorrectness triple
-            :==>: [term| \(result : Bool) (tx : TxInfo) . correct_validator tx |],
-        ipMaxCstrs = 20
+            :==>: [term| \(result : Bool) (tx : TxInfo) . correct_validator tx |]
       }
 
-definitions :: Program Ex
+definitions :: PrtUnorderedDefs Ex
 definitions =
   [prog|
 fun and : Bool -> Bool -> Bool

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -1,14 +1,14 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Provides the quasiquoters to be able to write @lang@ programs
 --  directly into Haskell source files. Using the functions
@@ -28,27 +28,27 @@ import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Term.TypeChecker (typeCheckDecls, typeCheckFunDef)
 import Text.Megaparsec
 
-prog :: forall lang . (LanguageParser lang, LanguageBuiltinTypes lang, Language lang) => QuasiQuoter
+prog :: forall lang. (LanguageParser lang, LanguageBuiltinTypes lang, Language lang) => QuasiQuoter
 prog = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
   (decls, DFunDef main@(FunDef _ mainTm _)) <- trQ (uncurry trProgram p0)
   _ <- maybeQ (typeCheckDecls decls)
   _ <- maybeQ (typeCheckFunDef decls "main" main)
-  [e|(decls, mainTm)|]
+  [e|(PrtUnorderedDefs decls mainTm)|]
 
-progNoTC :: forall lang . (LanguageParser lang, Language lang) => QuasiQuoter
+progNoTC :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
 progNoTC = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
   (decls, DFunDef (FunDef _ mainTm _)) <- trQ (uncurry trProgram p0)
-  [e|(decls, mainTm)|]
+  [e|(PrtUnorderedDefs decls mainTm)|]
 
-term :: forall lang . (LanguageParser lang, Language lang) => QuasiQuoter
+term :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
 term = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseTerm @lang) <* eof) str
   p1 <- trQ (trTerm [] [] p0)
   [e|p1|]
 
-ty :: forall lang . (LanguageParser lang, Language lang) => QuasiQuoter
+ty :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
 ty = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseType @lang) <* eof) str
   p1 <- trQ (trType [] p0)

--- a/src/Pirouette.hs
+++ b/src/Pirouette.hs
@@ -1,7 +1,8 @@
 module Pirouette (module X) where
 
 import Pirouette.Symbolic.Prover.Runner as X
-  ( assertIncorrectnessLogic,
+  ( IncorrectnessParams (..),
+    IncorrectnessResult,
+    assertIncorrectnessLogic,
     replIncorrectnessLogic,
-    IncorrectnessParams(..)
   )

--- a/src/Pirouette.hs
+++ b/src/Pirouette.hs
@@ -1,8 +1,10 @@
 module Pirouette (module X) where
 
 import Pirouette.Symbolic.Prover.Runner as X
-  ( IncorrectnessParams (..),
+  ( AssumeProve (..),
+    IncorrectnessParams (..),
     IncorrectnessResult,
     assertIncorrectnessLogic,
     replIncorrectnessLogic,
+    replIncorrectnessLogic1,
   )

--- a/src/Pirouette.hs
+++ b/src/Pirouette.hs
@@ -6,5 +6,5 @@ import Pirouette.Symbolic.Prover.Runner as X
     IncorrectnessResult,
     assertIncorrectnessLogic,
     replIncorrectnessLogic,
-    replIncorrectnessLogic1,
+    replIncorrectnessLogicSingl,
   )

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -63,7 +63,7 @@ runIncorrectnessLogic maxCstrs prog parms =
 -- | Prepares a 'IncorrectnessParams' into a 'Problem', to be passed to
 --  some worker function. Chances are that you are looking for
 --  'runIncorrectnessLogic' instead, unless you want a specific analysis.
---  If that's the case, the arguments to worker that you want will
+--  If that's not the case, the arguments to worker that you want will
 --  likely be 'prove', 'proveUnbounded' or 'proveAny' from "Pirouette.Symbolic.Prove"
 execIncorrectnessLogic ::
   (Language lang, LanguageBuiltinTypes lang, Monad m) =>

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -31,7 +31,7 @@ data IncorrectnessParams lang = IncorrectnessParams
 
 -- | The result type of 'runIncorrectnessLogic', returning the first (if any)
 --  path that is a counterexample to the supplied 'IncorrectnessParams'.
---  If you would like finer grained control, look at 'execIncorrectnessLogic.
+--  If you would like finer grained control, look at 'execIncorrectnessLogic'.
 type IncorrectnessResult lang = Maybe (Path lang (EvaluationWitness lang))
 
 runIncorrectnessLogic1 ::

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -118,13 +118,13 @@ replIncorrectnessLogic ::
 replIncorrectnessLogic maxCstrs defs params =
   printIRResult maxCstrs $ runIncorrectnessLogic maxCstrs defs params
 
-replIncorrectnessLogic1 ::
+replIncorrectnessLogicSingl ::
   (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
   Int ->
   IncorrectnessParams lang ->
   IO ()
-replIncorrectnessLogic1 maxCstrs params =
-  printIRResult maxCstrs $ runIncorrectnessLogic1 maxCstrs params
+replIncorrectnessLogicSingl maxCstrs params =
+  printIRResult maxCstrs $ runIncorrectnessLogicSingl maxCstrs params
 
 -- | Assert a test failure (Tasty HUnit integration) when the result of the
 -- incorrectness logic execution reveals an error or a counterexample.

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -1,57 +1,80 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Pirouette.Symbolic.Prover.Runner where
 
+import Control.Monad.Identity
 import Control.Monad.Reader
 import Pirouette.Monad
 import Pirouette.Symbolic.Eval
 import Pirouette.Symbolic.Prover
+import Pirouette.Term.Syntax (pretty)
 import Pirouette.Term.Syntax.Base
-import Pirouette.Term.Syntax.SystemF (tyFunArgs)
-import Pirouette.Term.TypeChecker
 import Pirouette.Transformations
+import Pirouette.Transformations.Contextualize
 import Pirouette.Transformations.Defunctionalization
 import Pirouette.Transformations.Monomorphization
 import System.Console.ANSI
 import qualified Test.Tasty.HUnit as Test
-import Pirouette.Term.Syntax (pretty)
 
 data AssumeProve lang = Term lang :==>: Term lang
   deriving (Eq, Show)
 
-type IncorrectnessResult lang = Maybe (Path lang (EvaluationWitness lang))
-
 -- | Parameters for an incorrectness logic run
 data IncorrectnessParams lang = IncorrectnessParams
-  { ipDefinitions :: Program lang,
-    ipTarget :: Term lang,
-    ipCondition :: AssumeProve lang,
-    ipMaxCstrs :: Int
+  { ipTarget :: Term lang,
+    ipTargetType :: Type lang,
+    ipCondition :: AssumeProve lang
   }
+
+-- | The result type of 'runIncorrectnessLogic', returning the first (if any)
+--  path that is a counterexample to the supplied 'IncorrectnessParams'.
+--  If you would like finer grained control, look at 'execIncorrectnessLogic.
+type IncorrectnessResult lang = Maybe (Path lang (EvaluationWitness lang))
 
 runIncorrectnessLogic ::
   (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  Int ->
+  PrtUnorderedDefs lang ->
   IncorrectnessParams lang ->
   IncorrectnessResult lang
-runIncorrectnessLogic
-  (IncorrectnessParams definitions target (post :==>: pre) maxCstrs) = do
-    let shouldStop = \st -> sestConstructors st > maxCstrs
-    let prog0 = uncurry PrtUnorderedDefs definitions
-    let prog1 = monomorphize prog0
-    let decls = defunctionalize prog1
-    let orderedDecls = elimEvenOddMutRec decls
-    let Right (Just (_, resultTy)) =
-          fmap (fmap tyFunArgs) $
-            flip runReaderT ((prtDecls orderedDecls, []), [DeclPath "validator"]) $
-              typeInferTerm target
-    flip runReader orderedDecls $ do
-      proveAny shouldStop isCounterExample (Problem resultTy target post pre)
-    where
-      isCounterExample Path {pathResult = CounterExample _ _, pathStatus = s}
-        | s /= OutOfFuel = True
-      isCounterExample _ = False
+runIncorrectnessLogic maxCstrs prog parms =
+  runIdentity $ execIncorrectnessLogic (proveAny shouldStop isCounter) prog parms
+  where
+    -- The stopping condition is defined as a limit on the number of unfolded constructors per branch;
+    shouldStop st = sestConstructors st > maxCstrs
+
+    isCounter Path {pathResult = CounterExample _ _, pathStatus = s}
+      | s /= OutOfFuel = True
+    isCounter _ = False
+
+-- | Prepares a 'IncorrectnessParams' into a 'Problem', to be passed to
+--  some worker function. Chances are that you are looking for
+--  'runIncorrectnessLogic' instead, unless you want a specific analysis.
+--  If that's the case, the arguments to worker that you want will
+--  likely be 'prove', 'proveUnbounded' or 'proveAny' from "Pirouette.Symbolic.Prove"
+execIncorrectnessLogic ::
+  (Language lang, LanguageBuiltinTypes lang, Monad m) =>
+  -- | Worker to run on the processed definitions
+  (Problem lang -> ReaderT (PrtOrderedDefs lang) m res) ->
+  PrtUnorderedDefs lang ->
+  IncorrectnessParams lang ->
+  m res
+execIncorrectnessLogic toDo prog (IncorrectnessParams fn ty (assume :==>: toProve)) = do
+  -- First, we apply a series of transformations to our program that will enable
+  -- us to translate it to SMTLIB later on
+  let orderedDecls =
+        elimEvenOddMutRec
+          . defunctionalize
+          . monomorphize
+          $ prog
+  -- Now we can contextualize the necessary terms and run the worker
+  flip runReaderT orderedDecls $ do
+    ty' <- contextualizeType ty
+    fn' <- contextualizeTerm fn
+    assume' <- contextualizeTerm assume
+    toProve' <- contextualizeTerm toProve
+    toDo (Problem ty' fn' assume' toProve')
 
 printIRResult ::
   Int ->
@@ -76,16 +99,20 @@ assertIRResult _ = return ()
 -- pretty-print the result
 replIncorrectnessLogic ::
   (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  Int ->
+  PrtUnorderedDefs lang ->
   IncorrectnessParams lang ->
   IO ()
-replIncorrectnessLogic params@IncorrectnessParams {..} =
-  printIRResult ipMaxCstrs (runIncorrectnessLogic params)
+replIncorrectnessLogic maxCstrs defs params =
+  printIRResult maxCstrs $ runIncorrectnessLogic maxCstrs defs params
 
 -- | Assert a test failure (Tasty HUnit integration) when the result of the
 -- incorrectness logic execution reveals an error or a counterexample.
 assertIncorrectnessLogic ::
   (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  Int ->
+  PrtUnorderedDefs lang ->
   IncorrectnessParams lang ->
   Test.Assertion
-assertIncorrectnessLogic params =
-  assertIRResult (runIncorrectnessLogic params)
+assertIncorrectnessLogic maxCstr defs params =
+  assertIRResult (runIncorrectnessLogic maxCstr defs params)

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -5,11 +5,13 @@ module Pirouette.Symbolic.Prover.Runner where
 
 import Control.Monad.Identity
 import Control.Monad.Reader
+import qualified Data.Map as M
 import Pirouette.Monad
 import Pirouette.Symbolic.Eval
 import Pirouette.Symbolic.Prover
 import Pirouette.Term.Syntax (pretty)
 import Pirouette.Term.Syntax.Base
+import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Transformations
 import Pirouette.Transformations.Contextualize
 import Pirouette.Transformations.Defunctionalization
@@ -31,6 +33,14 @@ data IncorrectnessParams lang = IncorrectnessParams
 --  path that is a counterexample to the supplied 'IncorrectnessParams'.
 --  If you would like finer grained control, look at 'execIncorrectnessLogic.
 type IncorrectnessResult lang = Maybe (Path lang (EvaluationWitness lang))
+
+runIncorrectnessLogic1 ::
+  (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  Int ->
+  IncorrectnessParams lang ->
+  IncorrectnessResult lang
+runIncorrectnessLogic1 maxCstrs =
+  runIncorrectnessLogic maxCstrs (PrtUnorderedDefs M.empty $ SystF.termPure $ SystF.Free Bottom)
 
 runIncorrectnessLogic ::
   (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
@@ -105,6 +115,14 @@ replIncorrectnessLogic ::
   IO ()
 replIncorrectnessLogic maxCstrs defs params =
   printIRResult maxCstrs $ runIncorrectnessLogic maxCstrs defs params
+
+replIncorrectnessLogic1 ::
+  (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  Int ->
+  IncorrectnessParams lang ->
+  IO ()
+replIncorrectnessLogic1 maxCstrs params =
+  printIRResult maxCstrs $ runIncorrectnessLogic1 maxCstrs params
 
 -- | Assert a test failure (Tasty HUnit integration) when the result of the
 -- incorrectness logic execution reveals an error or a counterexample.

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -34,12 +34,14 @@ data IncorrectnessParams lang = IncorrectnessParams
 --  If you would like finer grained control, look at 'execIncorrectnessLogic'.
 type IncorrectnessResult lang = Maybe (Path lang (EvaluationWitness lang))
 
-runIncorrectnessLogic1 ::
+-- | Runs an incorrectness logic check for a single term, i.e., receives no
+-- environment of definitions.
+runIncorrectnessLogicSingl ::
   (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
   Int ->
   IncorrectnessParams lang ->
   IncorrectnessResult lang
-runIncorrectnessLogic1 maxCstrs =
+runIncorrectnessLogicSingl maxCstrs =
   runIncorrectnessLogic maxCstrs (PrtUnorderedDefs M.empty $ SystF.termPure $ SystF.Free Bottom)
 
 runIncorrectnessLogic ::

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -321,9 +321,6 @@ data Namespace = TermNamespace | TypeNamespace
 -- | A program will be translated into a number of term and type declarations.
 type Decls lang = Map (Namespace, Name) (Definition lang)
 
--- | A program consists in a set of declarations and a main term.
-type Program lang = (Decls lang, Term lang)
-
 -- * Language Builtins
 
 type EqOrdShowDataTypeable a = (Eq a, Ord a, Show a, Data a, Typeable a)
@@ -346,22 +343,25 @@ class (LanguageConstrs lang) => LanguageBuiltins lang where
   type Constants lang :: *
 
   -- | Definitions required for built-in types
-  builtinTypeDefinitions :: 
-    [(Name, TypeDef lang)]    -- ^ types which are already defined
-    -> [(Name, TypeDef lang)] -- ^ additional definitions supporting those
+  builtinTypeDefinitions ::
+    -- | types which are already defined
+    [(Name, TypeDef lang)] ->
+    -- | additional definitions supporting those
+    [(Name, TypeDef lang)]
   builtinTypeDefinitions _ = []
 
 builtinTypeDecls :: (LanguageBuiltins lang) => Decls lang -> Decls lang
-builtinTypeDecls m = 
+builtinTypeDecls m =
   let defs = flip mapMaybe (Map.toList m) $ \((_, nm), def) -> case def of
-               DTypeDef td -> Just (nm, td)
-               _ -> Nothing
+        DTypeDef td -> Just (nm, td)
+        _ -> Nothing
       newTypeDefs = builtinTypeDefinitions defs
-  in Map.fromList $ do
-    (nm, td@Datatype { destructor, constructors }) <- newTypeDefs
-    [ ((TypeNamespace, nm), DTypeDef td), ((TermNamespace, destructor), DDestructor nm) ]
-      ++ [ ((TermNamespace, constructorName), DConstructor i nm )
-         | (i, (constructorName, _)) <- zip [0 ..] constructors ]
+   in Map.fromList $ do
+        (nm, td@Datatype {destructor, constructors}) <- newTypeDefs
+        [((TypeNamespace, nm), DTypeDef td), ((TermNamespace, destructor), DDestructor nm)]
+          ++ [ ((TermNamespace, constructorName), DConstructor i nm)
+               | (i, (constructorName, _)) <- zip [0 ..] constructors
+             ]
 
 -- | Auxiliary constraint for pretty-printing terms of a given language.
 type LanguagePretty lang =

--- a/tests/ormolu-pre-commit-hook.sh
+++ b/tests/ormolu-pre-commit-hook.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# command adapted from https://github.com/JLLeitschuh/ktlint-gradle  task addKtlintFormatGitPreCommitHook
+filesToFormat="$(git --no-pager diff --name-status --no-color --cached | \
+  awk '($1 == "M" || $1 == "A") && $2 ~ /\.hs/ { print $2} $1 ~ /R/ && $3 ~ /\.hs/ { print $3 } ')"
+
+echo "files to format $filesToFormat"
+for sourceFilePath in $filesToFormat
+do
+  ormolu --mode inplace "$(pwd)/$sourceFilePath"
+  git add $sourceFilePath
+done;

--- a/tests/unit/Language/Pirouette/ExampleSpec.hs
+++ b/tests/unit/Language/Pirouette/ExampleSpec.hs
@@ -3,6 +3,7 @@
 module Language.Pirouette.ExampleSpec (tests) where
 
 import Language.Pirouette.Example
+import Pirouette.Monad (PrtUnorderedDefs (..))
 import Pirouette.Term.Syntax.Base
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -13,7 +14,7 @@ canParseTerm _ = return ()
 canParseType :: Type Ex -> Assertion
 canParseType _ = return ()
 
-canParseProgram :: Program Ex -> Assertion
+canParseProgram :: PrtUnorderedDefs Ex -> Assertion
 canParseProgram _ = return ()
 
 tests :: [TestTree]
@@ -26,10 +27,10 @@ tests =
       canParseType [ty| Integer -> (all a : Type . Integer) |]
       canParseType [ty| all a : Type . a -> all b : Type . a -> Integer |]
       canParseType [ty| all a : Type . a -> all b : (Type -> Type) . Integer -> b a -> Integer |],
-     testCase "Type binders with or without parenthesis" $ do
-          let t1 = [ty| \(x : Type) (y : Type) (z : Type) . F x y |]
-              t2 = [ty| \(x : Type) . \(y : Type) . \(z : Type) . F x y |]
-           in (t1 :: Type Ex) @?= t2 ,
+    testCase "Type binders with or without parenthesis" $ do
+      let t1 = [ty| \(x : Type) (y : Type) (z : Type) . F x y |]
+          t2 = [ty| \(x : Type) . \(y : Type) . \(z : Type) . F x y |]
+       in (t1 :: Type Ex) @?= t2,
     testGroup
       "Can parse terms"
       [ testCase "Example 1" $

--- a/tests/unit/Language/Pirouette/PlutusIR/Common.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/Common.hs
@@ -1,35 +1,45 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Language.Pirouette.PlutusIR.Common where
 
+import Control.Monad.Except
 import Control.Monad.IO.Class
 import qualified Data.ByteString as BS
 import qualified Data.Text.IO as T
 import qualified Flat
 import GHC.Float (rationalToDouble)
+import Language.Pirouette.PlutusIR.Syntax
+import Language.Pirouette.PlutusIR.ToTerm
+import Pirouette.Monad
 import qualified PlutusCore as P
 import qualified PlutusCore.Flat as P
-import PlutusIR.Core.Type (Program)
+import qualified PlutusIR.Core.Type as PIR (Program)
 import qualified PlutusIR.Parser as PIR
 
-openAndParsePIR ::
-  FilePath ->
-  IO (Program P.TyName P.Name P.DefaultUni P.DefaultFun PIR.SourcePos)
-openAndParsePIR fileName = do
-  !content <- T.readFile fileName
-  case PIR.parse (PIR.program @P.DefaultUni @P.DefaultFun) fileName content of
-    Left err -> print err >> error "Couldn't parse"
-    Right p -> return p
-
-openAndDecodeFlat ::
-  (MonadIO m) =>
-  FilePath ->
-  m (Either String (Program P.TyName P.Name P.DefaultUni P.DefaultFun ()))
-openAndDecodeFlat fileName = do
-  content <- liftIO $ BS.readFile fileName
-  return . either (Left . show) Right $ pirDecoder content
+openAndParsePIR :: FilePath -> IO (PrtUnorderedDefs PlutusIR)
+openAndParsePIR fileName = openAndDecodeWith T.readFile pirParser fileName
   where
-    pirDecoder :: BS.ByteString -> Flat.Decoded (Program P.TyName P.Name P.DefaultUni P.DefaultFun ())
+    pirParser = PIR.parse (PIR.program @P.DefaultUni @P.DefaultFun) fileName
+
+openAndDecodeFlat :: FilePath -> IO (PrtUnorderedDefs PlutusIR)
+openAndDecodeFlat = openAndDecodeWith BS.readFile pirDecoder
+  where
+    pirDecoder :: BS.ByteString -> Flat.Decoded (PIR.Program P.TyName P.Name P.DefaultUni P.DefaultFun ())
     pirDecoder = Flat.unflat
+
+openAndDecodeWith ::
+  (Show err, Show loc) =>
+  (FilePath -> IO content) ->
+  (content -> Either err (PIR.Program P.TyName P.Name P.DefaultUni P.DefaultFun loc)) ->
+  FilePath ->
+  IO (PrtUnorderedDefs PlutusIR)
+openAndDecodeWith read decoder fileName = do
+  !content <- read fileName
+  case decoder content of
+    Left err -> print err >> error "Coult not decode"
+    Right pirProgram ->
+      let Right (main, decls) = runExcept $ trProgram pirProgram
+       in return $ PrtUnorderedDefs decls main

--- a/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs
@@ -4,74 +4,60 @@
 
 module Language.Pirouette.PlutusIR.SymEvalSpec where
 
-import Control.Monad.Except ( runExcept )
-import Control.Monad.Reader ( ReaderT(runReaderT) )
+import Control.Monad.Except (runExcept)
+import Control.Monad.Reader (ReaderT (runReaderT))
 import qualified Data.Map as M
 import Language.Pirouette.PlutusIR
+import Language.Pirouette.PlutusIR.Common (openAndParsePIR)
 import Language.Pirouette.PlutusIR.Syntax
 import Language.Pirouette.PlutusIR.ToTerm
+import Pirouette
 import Pirouette.Monad
+import Pirouette.Symbolic.Eval
 import Pirouette.Symbolic.EvalUtils
 import Pirouette.Symbolic.Prover
+import Pirouette.Symbolic.Prover.Runner
 import Pirouette.Term.Syntax
-import Pirouette.Transformations (elimEvenOddMutRec)
-import Pirouette.Transformations.Contextualize
-import Pirouette.Transformations.Defunctionalization
-import Pirouette.Transformations.Monomorphization
 import PlutusCore (DefaultUni (..))
 import qualified PlutusCore as P
 import qualified PlutusCore.Pretty as P
 import qualified PlutusIR.Core.Type as PIR
-
-import Language.Pirouette.PlutusIR.Common (openAndParsePIR)
-
 import Test.Tasty
-import Test.Tasty.HUnit
 import Test.Tasty.ExpectedFailure (expectFail)
+import Test.Tasty.HUnit
 
 execFromPIRFile ::
-  (Problem PlutusIR -> ReaderT (PrtOrderedDefs PlutusIR) IO a) ->
-  FilePath -> (Type PlutusIR, Term PlutusIR) ->
-  (Term PlutusIR, Term PlutusIR) ->
-  IO a
-execFromPIRFile toDo path (tyRes, fn) (assume, toProve) = do
+  FilePath -> IncorrectnessParams PlutusIR -> IO [Path PlutusIR (EvaluationWitness PlutusIR)]
+execFromPIRFile path problem = do
   pir <- openAndParsePIR path
-  exec toDo (pir, tyRes, fn) (assume, toProve)
-
-exec ::
-  (PIRConstraint tyname name P.DefaultFun, Show loc) =>
-  (Problem PlutusIR -> ReaderT (PrtOrderedDefs PlutusIR) IO a) ->
-  (PIR.Program tyname name DefaultUni P.DefaultFun loc, Type PlutusIR, Term PlutusIR) ->
-  (Term PlutusIR, Term PlutusIR) ->
-  IO a
-exec toDo (pirProgram, tyRes, fn) (assume, toProve) = do
-  let Right (main, decls) = runExcept $ trProgram pirProgram
-  let orderedDecls = elimEvenOddMutRec $ PrtUnorderedDefs decls main
-  flip runReaderT orderedDecls $ do
-    tyRes' <- contextualizeType tyRes
-    fn' <- contextualizeTerm fn
-    assume' <- contextualizeTerm assume
-    toProve' <- contextualizeTerm toProve
-    toDo (Problem tyRes' fn' assume' toProve')
+  execIncorrectnessLogic proveUnbounded pir problem
 
 tests :: [TestTree]
 tests =
   [ testGroup
       "simple triples"
       [ testCase "[input > 0] add 1 [result > 0] counter" $
-          execFromPIRFile proveUnbounded 
+          execFromPIRFile
             "tests/unit/resources/fromPlutusIRSpec-01.pir"
-            ( [pirTy| Integer |], [pir| \(x : Integer) . addone x |])
-            ( [pir| \(result : Integer) (x : Integer) . 0 < result |],
-              [pir| \(result : Integer) (x : Integer) . 0 < x |]
+            ( IncorrectnessParams
+                { ipTarget = [pir| \(x : Integer) . addone x |],
+                  ipTargetType = [pirTy| Integer |],
+                  ipCondition =
+                    [pir| \(result : Integer) (x : Integer) . 0 < result |]
+                      :==>: [pir| \(result : Integer) (x : Integer) . 0 < x |]
+                }
             )
-            `pathSatisfies` (isSingleton .&. all isCounter)
-      , testCase "[input > 0] add 1 [result > 1] verified" $
-          execFromPIRFile proveUnbounded 
+            `pathSatisfies` (isSingleton .&. all isCounter),
+        testCase "[input > 0] add 1 [result > 1] verified" $
+          execFromPIRFile
             "tests/unit/resources/fromPlutusIRSpec-01.pir"
-            ( [pirTy| Integer |], [pir| \(x : Integer) . addone x |])
-            ( [pir| \(result : Integer) (x : Integer) . 1 < result |],
-              [pir| \(result : Integer) (x : Integer) . 0 < x |]
+            ( IncorrectnessParams
+                { ipTarget = [pir| \(x : Integer) . addone x |],
+                  ipTargetType = [pirTy| Integer |],
+                  ipCondition =
+                    [pir| \(result : Integer) (x : Integer) . 1 < result |]
+                      :==>: [pir| \(result : Integer) (x : Integer) . 0 < x |]
+                }
             )
             `pathSatisfies` (isSingleton .&. all isVerified)
       ]

--- a/tests/unit/Language/Pirouette/PlutusIR/SyntaxSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/SyntaxSpec.hs
@@ -5,13 +5,15 @@
 module Language.Pirouette.PlutusIR.SyntaxSpec where
 
 import Control.Monad.Except
-import Data.Map (keys)
 import Data.Foldable (toList)
+import Data.Map (keys)
 import GHC.Float (rationalToDouble)
 import Language.Pirouette.PlutusIR
-import Pirouette.Term.TypeChecker
-import Pirouette.Term.Syntax.Pretty
+import Language.Pirouette.PlutusIR.Common
+import Pirouette.Monad
 import Pirouette.Term.Syntax.Base hiding (Program)
+import Pirouette.Term.Syntax.Pretty
+import Pirouette.Term.TypeChecker
 import qualified PlutusCore as P
 import qualified PlutusCore.Pretty as P
 import PlutusIR.Core.Type (Program)
@@ -19,19 +21,20 @@ import qualified PlutusIR.Parser as PIR
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Language.Pirouette.PlutusIR.Common
-
 goldenFiles :: [(String, FilePath)]
-goldenFiles = [("Split", "tests/unit/resources/split.flat")
-              ,("Auction", "tests/unit/resources/auction.flat")]
+goldenFiles =
+  [ ("Split", "tests/unit/resources/split.flat"),
+    ("Auction", "tests/unit/resources/auction.flat")
+  ]
 
 canParseTerm :: Term PlutusIR -> Assertion
 canParseTerm _ = return ()
 
 tests :: [TestTree]
 tests =
-  [ testGroup "Read, translate and typecheck programs" $ flip map goldenFiles $ \(n, fpath) ->
-       testCase n (assertTrProgramOk fpath),
+  [ testGroup "Read, translate and typecheck programs" $
+      flip map goldenFiles $ \(n, fpath) ->
+        testCase n (assertTrProgramOk fpath),
     testCase "Can parse terms" $ do
       canParseTerm [pir| \(x : Integer) . x + 1 |]
       canParseTerm [pir| \(bs : ByteString) . b/appendByteString bs bs |]
@@ -39,14 +42,11 @@ tests =
 
 assertTrProgramOk :: FilePath -> Assertion
 assertTrProgramOk flatFilePath = do
-  Right pir <- openAndDecodeFlat flatFilePath
-  case runExcept (trProgram pir) of
-    Left err -> assertFailure $ "Translate program: " ++ show err
-    Right (_, decls) -> do
-      -- writeFile "decls.pirouette" (show $ pretty decls)
-      let allDecls = builtinTypeDecls decls <> decls
-      -- print $ pretty allDecls
-      case typeCheckDecls allDecls of
-        Left err -> assertFailure $ "Typecheck program: " ++ show (pretty err)
-        Right _ -> return ()
+  PrtUnorderedDefs decls _ <- openAndDecodeFlat flatFilePath
+  -- writeFile "decls.pirouette" (show $ pretty decls)
+  let allDecls = builtinTypeDecls decls <> decls
+  -- print $ pretty allDecls
+  case typeCheckDecls allDecls of
+    Left err -> assertFailure $ "Typecheck program: " ++ show (pretty err)
+    Right _ -> return ()
   return ()

--- a/tests/unit/Language/Pirouette/PlutusIR/ToTermSpec.hs
+++ b/tests/unit/Language/Pirouette/PlutusIR/ToTermSpec.hs
@@ -7,6 +7,7 @@ import Control.Monad.Reader
 import qualified Data.Map as M
 import Data.Maybe (fromJust)
 import Debug.Trace
+import Language.Pirouette.PlutusIR.Common
 import Language.Pirouette.PlutusIR.ToTerm
 import Pirouette.Monad
 import Pirouette.Term.Syntax
@@ -14,41 +15,38 @@ import Pirouette.Term.Transformations
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Language.Pirouette.PlutusIR.Common
-
 tests :: [TestTree]
-tests = (:[]) $ withResource acquire (const $ return ()) $ \progAct ->
-  testGroup
-    "With resource: tests/unit/resources/fromPlutusIRSpec-01.pir"
-    [ testCase "Translates the PIR program without errors" $ do
-        -- We force a pattern match on at least one declaration, which
-        -- means that translation had to happen at this point.
-        _ : _ <- M.toList <$> progAct
-        return (),
-      -- Test that two declarations are present
-      testCase "Decls contain 'long' and 'short' terms" $ do
-        decls <- progAct
-        let longN = head $ filter ((== "long") . nameString . snd) $ M.keys decls
-        let shortN = head $ filter ((== "short") . nameString . snd) $ M.keys decls
-        case (,) <$> M.lookup longN decls <*> M.lookup shortN decls of
-          Just _ -> return ()
-          Nothing -> assertFailure "long/short not declared",
-      -- Test that expanding one declaration yields the other declaration
-      testCase "expandDefs produces NF terms" $ do
-        decls <- progAct
-        let longN = head $ filter ((== "long") . nameString . snd) $ M.keys decls
-        let shortN = head $ filter ((== "short") . nameString . snd) $ M.keys decls
-        let (DFunction _ long _) = fromJust $ M.lookup longN decls
-        let (DFunction _ short _) = fromJust $ M.lookup shortN decls
-        runReader (expandDefs long) (mocked decls) @?= short
-    ]
+tests = (: []) $
+  withResource acquire (const $ return ()) $ \progAct ->
+    testGroup
+      "With resource: tests/unit/resources/fromPlutusIRSpec-01.pir"
+      [ testCase "Translates the PIR program without errors" $ do
+          -- We force a pattern match on at least one declaration, which
+          -- means that translation had to happen at this point.
+          _ : _ <- M.toList <$> progAct
+          return (),
+        -- Test that two declarations are present
+        testCase "Decls contain 'long' and 'short' terms" $ do
+          decls <- progAct
+          let longN = head $ filter ((== "long") . nameString . snd) $ M.keys decls
+          let shortN = head $ filter ((== "short") . nameString . snd) $ M.keys decls
+          case (,) <$> M.lookup longN decls <*> M.lookup shortN decls of
+            Just _ -> return ()
+            Nothing -> assertFailure "long/short not declared",
+        -- Test that expanding one declaration yields the other declaration
+        testCase "expandDefs produces NF terms" $ do
+          decls <- progAct
+          let longN = head $ filter ((== "long") . nameString . snd) $ M.keys decls
+          let shortN = head $ filter ((== "short") . nameString . snd) $ M.keys decls
+          let (DFunction _ long _) = fromJust $ M.lookup longN decls
+          let (DFunction _ short _) = fromJust $ M.lookup shortN decls
+          runReader (expandDefs long) (mocked decls) @?= short
+      ]
   where
     mocked = flip PrtUnorderedDefs undefined
     acquire = do
-      pir <- openAndParsePIR "tests/unit/resources/fromPlutusIRSpec-01.pir"
-      case runExcept (trProgramDecls pir) of
-        Left err -> fail $ show err
-        Right decls -> return decls
+      PrtUnorderedDefs decls _ <- openAndParsePIR "tests/unit/resources/fromPlutusIRSpec-01.pir"
+      return decls
 
 -- TODO: Check that Datatype decls have the typeVariables redeclared on
 -- constructors

--- a/tests/unit/Pirouette/Symbolic/ProveSpec.hs
+++ b/tests/unit/Pirouette/Symbolic/ProveSpec.hs
@@ -12,29 +12,28 @@ import Data.Maybe (isJust)
 import Language.Pirouette.Example
 import qualified Language.Pirouette.Example.IsUnity as IsUnity
 import Pirouette.Monad
-import qualified PureSMT
 import Pirouette.Symbolic.Eval
-import Pirouette.Symbolic.Prover
 import Pirouette.Symbolic.EvalUtils
+import Pirouette.Symbolic.Prover
 import Pirouette.Term.Syntax
 import Pirouette.Transformations (elimEvenOddMutRec)
 import Pirouette.Transformations.Defunctionalization
 import Pirouette.Transformations.Monomorphization
+import qualified PureSMT
 import Test.Tasty
 import Test.Tasty.HUnit
 
 exec ::
   (Problem Ex -> ReaderT (PrtOrderedDefs Ex) IO a) ->
-  (Program Ex, Type Ex, Term Ex) ->
+  (PrtUnorderedDefs Ex, Type Ex, Term Ex) ->
   (Term Ex, Term Ex) ->
   IO a
-exec toDo (program, tyRes, fn) (assume, toProve) = do
-  let decls = uncurry PrtUnorderedDefs program
+exec toDo (decls, tyRes, fn) (assume, toProve) = do
   let orderedDecls = elimEvenOddMutRec decls
   flip runReaderT orderedDecls $
     toDo (Problem tyRes fn assume toProve)
 
-add1 :: (Program Ex, Type Ex, Term Ex)
+add1 :: (PrtUnorderedDefs Ex, Type Ex, Term Ex)
 add1 =
   ( [prog|
 fun add1 : Integer -> Integer
@@ -64,7 +63,7 @@ input0Output1 =
     [term| \(result : Integer) (x : Integer) . greaterThan0 x |]
   )
 
-maybes :: Program Ex
+maybes :: PrtUnorderedDefs Ex
 maybes =
   [prog|
 data MaybeInt
@@ -193,7 +192,7 @@ fun main : Integer = 42
 --
 -- Now we have that SEM1 is equivalent to SEM3
 
-conditionals1 :: (Program Ex, Type Ex, Term Ex)
+conditionals1 :: (PrtUnorderedDefs Ex, Type Ex, Term Ex)
 conditionals1 =
   ( [prog|
 data Delta = D : Integer -> Integer -> Delta
@@ -254,7 +253,7 @@ ohearnTest =
 
 -- We didn't have much success with builtins integers; let me try the same with peano naturals:
 
-conditionals1Peano :: (Program Ex, Type Ex, Term Ex)
+conditionals1Peano :: (PrtUnorderedDefs Ex, Type Ex, Term Ex)
 conditionals1Peano =
   ( [prog|
 data Nat = Z : Nat | S : Nat -> Nat
@@ -361,8 +360,7 @@ tests =
 
 -- * IsUnity example
 
-
-isUnity :: (Program Ex, Type Ex, Term Ex)
+isUnity :: (PrtUnorderedDefs Ex, Type Ex, Term Ex)
 isUnity =
   ( IsUnity.definitions,
     [ty|Bool|],
@@ -383,11 +381,10 @@ condIsUnity =
 
 execFull ::
   (Problem Ex -> ReaderT (PrtOrderedDefs Ex) IO a) ->
-  (Program Ex, Type Ex, Term Ex) ->
+  (PrtUnorderedDefs Ex, Type Ex, Term Ex) ->
   (Term Ex, Term Ex) ->
   IO a
-execFull toDo (program, tyRes, fn) (assume, toProve) = do
-  let prog0 = uncurry PrtUnorderedDefs program
+execFull toDo (prog0, tyRes, fn) (assume, toProve) = do
   -- liftIO $ writeFile "prog0" (show $ pretty $ prtUODecls prog0)
   let prog1 = monomorphize prog0
   -- liftIO $ writeFile "prog1" (show $ pretty $ prtUODecls prog1)

--- a/tests/unit/Pirouette/Term/TransformationsSpec.hs
+++ b/tests/unit/Pirouette/Term/TransformationsSpec.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Pirouette.Term.TransformationsSpec (tests) where
 
@@ -16,16 +16,17 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 withUnorderedDecls ::
-  Program Ex ->
+  PrtUnorderedDefs Ex ->
   (forall m. PirouetteReadDefs Ex m => m Assertion) ->
   Assertion
-withUnorderedDecls (decls, main) m =
-  case runReaderT m (PrtUnorderedDefs decls main) of
+withUnorderedDecls prog m =
+  case runReaderT m prog of
     Left err -> assertFailure err
-    Right t  -> t
+    Right t -> t
 
-sampleProgram :: Program Ex
-sampleProgram = [prog|
+samplePrtUnorderedDefs :: PrtUnorderedDefs Ex
+samplePrtUnorderedDefs =
+  [prog|
 data Maybe (a : Type)
   = Nothing : Maybe a
   | Just : a -> Maybe a
@@ -45,9 +46,10 @@ fun main : Integer = 42
 |]
 
 tests :: [TestTree]
-tests = [
-  testCase "destrNF" $ withUnorderedDecls sampleProgram $ do
-      destrNF_f1 <- prtTermDefOf "f1" >>= destrNF
-      expected <- prtTermDefOf "destrNF_f1"
-      return $ destrNF_f1 @?= expected
+tests =
+  [ testCase "destrNF" $
+      withUnorderedDecls samplePrtUnorderedDefs $ do
+        destrNF_f1 <- prtTermDefOf "f1" >>= destrNF
+        expected <- prtTermDefOf "destrNF_f1"
+        return $ destrNF_f1 @?= expected
   ]

--- a/tests/unit/Pirouette/Transformations/EtaExpandSpec.hs
+++ b/tests/unit/Pirouette/Transformations/EtaExpandSpec.hs
@@ -1,10 +1,10 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE BangPatterns #-}
 
 module Pirouette.Transformations.EtaExpandSpec (tests) where
 
@@ -17,13 +17,13 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 withUnorderedDecls ::
-  Program Ex ->
+  PrtUnorderedDefs Ex ->
   (forall m. PirouetteReadDefs Ex m => m Assertion) ->
   Assertion
-withUnorderedDecls (decls, main) m = runReader m (PrtUnorderedDefs decls main)
+withUnorderedDecls = flip runReader
 
-sampleProgram :: Program Ex
-sampleProgram =
+samplePrtUnorderedDefs :: PrtUnorderedDefs Ex
+samplePrtUnorderedDefs =
   [prog|
 data Maybe (a : Type)
   = Nothing : Maybe a
@@ -45,7 +45,7 @@ fun main : Integer = 42
 |]
 
 isEtaEq :: Term Ex -> Term Ex -> Assertion
-isEtaEq t u = withUnorderedDecls sampleProgram $ do
+isEtaEq t u = withUnorderedDecls samplePrtUnorderedDefs $ do
   res <- etaExpandTerm t
   return $ unless (res == u) (assertFailure $ msg res)
   where

--- a/tests/unit/Pirouette/Transformations/PrenexSpec.hs
+++ b/tests/unit/Pirouette/Transformations/PrenexSpec.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Pirouette.Transformations.PrenexSpec (tests) where
 
@@ -14,55 +14,56 @@ import Pirouette.Monad
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Transformations.Monomorphization
+import Pirouette.Transformations.Prenex
 import Pirouette.Transformations.Utils
 import Test.Tasty
 import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
-import Pirouette.Transformations.Prenex
 
-beforePrenex1, afterPrenex1 :: Program Ex
+beforePrenex1, afterPrenex1 :: PrtUnorderedDefs Ex
 (beforePrenex1, afterPrenex1) =
-  ([prog|
+  ( [prog|
 fun example : all a : Type . a -> all b : Type . b -> a
   = /\ a : Type . \(x : a) . /\ b : Type . \(y : b) . x
 
 fun main : Integer = example @Integer 3 @Integer 4
-|], [prog|
+|],
+    [prog|
 fun example : all a : Type . all b : Type . a -> b -> a
   = /\ a : Type . /\ b : Type . \(x : a) (y : b) . x
 
 fun main : Integer = example @Integer @Integer 3 4
-|])
+|]
+  )
 
-beforePrenex2, afterPrenex2 :: Program Ex
+beforePrenex2, afterPrenex2 :: PrtUnorderedDefs Ex
 (beforePrenex2, afterPrenex2) =
-  ([prog|
+  ( [prog|
 fun f : all a : Type . a -> all b : Type . b -> a
   = /\ a : Type . \(x : a) . /\ b : Type . \(y : b) . x
 fun g : all a : Type . all b : Type . a -> b -> all c : Type . c -> a
   = /\ a : Type . /\ b : Type . \(x : a) (y : b) . /\ c : Type . \(z : c) . x
 
 fun main : Integer = f @Integer 3 @Integer (g @Integer @Integer 4 5 @Integer 6)
-|], [prog|
+|],
+    [prog|
 fun f : all a : Type . all b : Type . a -> b -> a
   = /\ a : Type . /\ b : Type . \(x : a) . \(y : b) . x
 fun g : all a : Type . all b : Type . all c : Type . a -> b -> c -> a
   = /\ a : Type . /\ b : Type . /\ c : Type . \(x : a) (y : b) . \(z : c) . x
 
 fun main : Integer = f @Integer @Integer 3 (g @Integer @Integer @Integer 4 5 6)
-|])
-
-uDefs :: Program Ex -> PrtUnorderedDefs Ex
-uDefs = uncurry PrtUnorderedDefs
+|]
+  )
 
 tests :: [TestTree]
 tests =
   [ testCase "prenex example #1" $
-      prenex (uDefs beforePrenex1) @=? uDefs afterPrenex1,
+      prenex beforePrenex1 @=? afterPrenex1,
     testCase "prenex example #1, unchanged" $
-      prenex (uDefs afterPrenex1) @=? uDefs afterPrenex1,
+      prenex afterPrenex1 @=? afterPrenex1,
     testCase "prenex example #1" $
-      prenex (uDefs beforePrenex2) @=? uDefs afterPrenex2,
+      prenex beforePrenex2 @=? afterPrenex2,
     testCase "prenex example #2, unchanged" $
-      prenex (uDefs afterPrenex2) @=? uDefs afterPrenex2
+      prenex afterPrenex2 @=? afterPrenex2
   ]


### PR DESCRIPTION
This PR addresses #87 and updates the interface in `Pirouette.Symbolic.Prover.Runner` so we can use it in all our tests, regardless of whether they are tests for the `Ex` or `PlutusIR` language. Here's two examples:

```haskell
parms :: IncorrectnessParams Ex
parms = IncorrectnessParams
          [term| \x:Integer . x + 1 |] -- Term to symbolically evaluate
          [ty| Integer |] -- type of the term above
          -- Conditions to check
          ([term| \(res:Integer) (x:Integer) . 0 < res |]
            :==>: [term| \(res:Integer) (x:Integer) . 0 < x |])

-- replIncorrecntessLogic1 receives no definitions, it's used to check a single term.
replIncorrectnessLogic1 10 params
```

Or, for plutus, taken from the `tests/unit/Language/Pirouette/PlutusIR/SymEvalSpec.hs`:
```haskell
          execFromPIRFile
            "tests/unit/resources/fromPlutusIRSpec-01.pir"
            ( IncorrectnessParams
                { ipTarget = [pir| \(x : Integer) . addone x |],
                  ipTargetType = [pirTy| Integer |],
                  ipCondition =
                    [pir| \(result : Integer) (x : Integer) . 0 < result |]
                      :==>: [pir| \(result : Integer) (x : Integer) . 0 < x |]
                }
            )
```