### PR TITLE
Monomoprhization and namespaces interaction bug

### DIFF
--- a/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
@@ -68,14 +68,20 @@ withSampleUDefs m = runReader m sampleUDefs
 tests :: [TestTree]
 tests =
   [ -- We expect that 'Monoid' is a higher-order definition and is picked by findPolyHOFDefs
-    testCase "findPolyHOFDefs picks 'Monoid'" $
-      assertBool "not there" $ (TypeNamespace, "Monoid") `M.member` findPolyHOFDefs (prtUODecls sampleUDefs),
+    testCase "findPolyHOFDefs picks 'Monoid' and friends" $ do
+      let res = findPolyHOFDefs (prtUODecls sampleUDefs)
+      assertBool "Monoid not there" $ (TypeNamespace, "Monoid") `M.member` res,
     -- In order to get the transitive closure of all the definitions that use ho-defs,
     -- we rely on 'hofsClosure'.
     testCase "hofsClosure picks the expected defs" $
       let ds = prtUODecls sampleUDefs
-       in sort (map snd (M.keys (hofsClosure ds (findPolyHOFDefs ds))))
-            @?= sort ["Mon", "Monoid", "fold", "match_Monoid"],
+       in sort (M.keys (hofsClosure ds (findPolyHOFDefs ds)))
+            @?= sort
+              [ (TypeNamespace, "Monoid"),
+                (TermNamespace, "Mon"),
+                (TermNamespace, "fold"),
+                (TermNamespace, "match_Monoid")
+              ],
     -- Now we make sure that the function specialization requests are working as we expect:
     testGroup
       "specFunApp"


### PR DESCRIPTION
The introduction of namespaces left out [one small detail on an auxiliary function](https://github.com/tweag/pirouette/commit/892da4fec6a932ba40a911a9c23bd4e7f5469af3#diff-88570a062606267f7e9d939af6469964c269bbd461b8a317cb47e79e2ad8269fR56), where it uses `TypeNamespace` for the names of the destructor and constructors, whereas it should use `TermNamespace` for those.