### PR TITLE
Fix mono matches (1)

### DIFF
--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -133,12 +133,12 @@ defunDtors defs = transformBi f defs
       where
         (branches, prefix) = reverse *** reverse $ span SystF.isArg $ reverse args
         tyArgErr tyArg = error $ show name <> ": unexpected TyArg " <> renderSingleLineStr (pretty tyArg)
-        prefix' = fixPrefixType <$> prefix
+        prefix' = closurifyTyArg <$> prefix
         branches' = SystF.argElim tyArgErr (SystF.TermArg . rewriteHofBody) <$> branches
     f x = x
 
-    fixPrefixType arg@SystF.TermArg {} = arg
-    fixPrefixType (SystF.TyArg theArg) =
+    closurifyTyArg arg@SystF.TermArg {} = arg
+    closurifyTyArg (SystF.TyArg theArg) =
       SystF.TyArg $ case theArg of
         SystF.TyFun {} -> closureType theArg
         _ -> theArg

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -12,7 +12,7 @@
 
 module Pirouette.Transformations.Defunctionalization (defunctionalize) where
 
-import Control.Arrow ((***), first)
+import Control.Arrow (first, (***))
 import Control.Monad.RWS.Strict
 import Control.Monad.Writer.Strict
 import Data.Generics.Uniplate.Data
@@ -89,6 +89,15 @@ defunctionalizeAssumptions defs = either error (const ()) . traverseDefs (\n d -
 
 -- * Defunctionalization of types
 
+-- | Identify types that contain contructors that receive functions as
+-- an argument. As an example, take:
+--
+-- > data Monoid (a : Type) = Mon : (a -> a -> a) -> a -> Monoid a
+-- > data Maybe (a : Type) = Just : a -> Maybe a | Nothing : Maybe a
+--
+-- The call to 'defunTypes' will pick @Mon@ as a target for defunctionalization,
+-- and will 'tell' an appropriate new declaration for @Monoid@. It will
+-- not pick @Just@, however.
 defunTypes ::
   (LanguagePretty lang, LanguageBuiltins lang) =>
   PrtUnorderedDefs lang ->

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -148,9 +148,14 @@ defunDtors defs = transformBi f defs
         branches' = SystF.argElim tyArgErr (SystF.TermArg . rewriteHofBody . rewriteNestedLamArgs) <$> branches
     f x = x
 
+    -- Rewrite the branches of a destructor that have a nested higher order function
+    -- but deliberatly do not rewrite those that are already functions, that will
+    -- be handled by vanilla defunctionalization
     rewriteNestedLamArgs :: Term lang -> Term lang
-    rewriteNestedLamArgs (SystF.Lam ann ty t) =
+    rewriteNestedLamArgs (SystF.Lam ann ty@SystF.TyApp {} t) =
       SystF.Lam ann (rewriteFunType ty) (rewriteNestedLamArgs t)
+    rewriteNestedLamArgs (SystF.Lam ann ty t) =
+      SystF.Lam ann ty (rewriteNestedLamArgs t)
     rewriteNestedLamArgs t = t
 
     -- Replaces the functional type arguments to the type itself with the corresponding closure types.

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -99,6 +99,10 @@ defunctionalizeAssumptions defs = either error (const ()) . traverseDefs (\n d -
 -- The call to 'defunTypes' will pick @Mon@ as a target for defunctionalization,
 -- and will 'tell' an appropriate new declaration for @Monoid@. It will
 -- not pick @Just@, however.
+--
+-- TODO: This has to be more involved; we need to generate the proper calls
+-- for nested things at once, in this step, for the rest of the engine
+-- to understand... my previous hacks met their deadend
 defunTypes ::
   (LanguagePretty lang, LanguageBuiltins lang) =>
   PrtUnorderedDefs lang ->

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -146,6 +146,7 @@ argsToStr = T.intercalate msep . map f
 
     f (SystF.Free n `TyApp` args) =
       tyBaseString n <> if null args then mempty else "<" <> argsToStr args <> ">"
+    f (SystF.TyFun a b) = f a <> "_" <> f b
     f arg = error $ "unexpected specializing arg" <> show arg
 
 tyBaseString :: LanguageBuiltins lang => TypeBase lang -> T.Text

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -79,12 +79,31 @@ findHOFDefs funPred tyPred declsPairs =
     funPred' fun = funPred fun && hasHOFuns (funTy fun)
     tyPred' name typeDef = tyPred name typeDef && (hasHOFuns . snd) `any` constructors typeDef
 
+-- | Returns whether a type has higher-order functions anywhere, directly
+-- or indirectly. For instance, the type:
+--
+-- > Integer -> Maybe (Bool -> Bool) -> X
+--
+-- Has higher-order functions present nested in 'Maybe'. This current function
+-- could be much better given it will also return some false-positives. For instance,
+--
+-- > Integer -> Const Bool (Bool -> Bool) -> X
+--
+-- Doesn't really have higher order functions because @Const a b = a@, but we
+-- are not worrying about that now.
 hasHOFuns :: (Data ann, Data ty) => AnnType ann ty -> Bool
-hasHOFuns ty = isHOFTy `any` [f | f@TyFun {} <- universe ty]
+-- (_ -> _) -> _ ...
+hasHOFuns (TyFun TyFun {} _) = True
+hasHOFuns (TyFun a b) = hasHOFuns a || hasHOFuns b
+hasHOFuns (TyApp _ args) = hasFuns `any` args
+hasHOFuns (TyLam _ _ at) = hasHOFuns at
+hasHOFuns (TyAll _ _ at) = hasHOFuns at
 
-isHOFTy :: AnnType ann ty -> Bool
-isHOFTy (TyFun TyFun {} _) = True
-isHOFTy _ = False
+hasFuns :: (Data ann, Data ty) => AnnType ann ty -> Bool
+hasFuns (TyFun _ _) = True
+hasFuns (TyApp _ args) = hasFuns `any` args
+hasFuns (TyLam _ _ at) = hasFuns at
+hasFuns (TyAll _ _ at) = hasFuns at
 
 -- @Arg Kind (Type lang)@ could've been used here instead,
 -- but having a distinct type seems to be a bit nicer, at least for now for hole-driven development reasons.

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -10,7 +10,6 @@ module Pirouette.Transformations.Utils where
 
 import Control.Arrow (first, second)
 import Data.Data
-import Data.Generics.Uniplate.Data
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Debug.Trace

--- a/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
@@ -187,13 +187,12 @@ defuncTestsPoly =
   ]
   where
     monoDefunc :: PrtUnorderedDefs Ex -> PrtUnorderedDefs Ex
-    monoDefunc = {- defunctionalize . -} monomorphize
+    monoDefunc = defunctionalize . monomorphize
 
     runTest :: PrtUnorderedDefs Ex -> Assertion
     runTest decls0 =
       case monoDefunc decls0 of
         PrtUnorderedDefs decls -> do
-          print (pretty decls)
           case typeCheckDecls decls of
             Left err -> print (pretty decls) >> assertFailure (show $ pretty err)
             Right _ -> return ()

--- a/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
@@ -88,6 +88,8 @@ tests =
             @?= sort
               [ (TypeNamespace, "Monoid"),
                 (TypeNamespace, "Indirect"),
+                (TermNamespace, "Ind"),
+                (TermNamespace, "match_Indirect"),
                 (TermNamespace, "Mon"),
                 (TermNamespace, "fold"),
                 (TermNamespace, "match_Monoid")


### PR DESCRIPTION
I ended up just replacing any functional type argument to the matcher with the corresponding closure type — those are to be defunctionalized in the match branches anyway.

This doesn't fix all the problems with the ADTs having higher-order fields though. Right now we get the following on the test case:
```
term Just |->
  Constructor 0 Maybe
term Nothing |->
  Constructor 1 Maybe
term main |->
  Integer
  match_Maybe @Closure!!TyInteger_TyInteger
      val
      @Integer
      (λ f : Closure!!TyInteger_TyInteger . _Apply!!TyInteger_TyInteger 0#f 42)
      0
term match_Maybe |->
  Destructor Maybe
term val |->
  Maybe Integer -> Integer
  Just @(Integer -> Integer) (λ x : Integer . b/add 0#x 1)
type Maybe |->
  Type data a:*
            match_Maybe
            Just : ∀ a : * . 0#a -> (Maybe 0#a)
            Nothing : ∀ a : * . Maybe 0#a
```
thus we also need to defunctionalize the things around `val` — the ctor and the type itself.

So far I think it's safe to just blindly replace anything of the form `TyCon TyFun{}` (where `TyCon :: * -> ...`) with `TyCon ClosureType` (where `ClosureType` corresponds to the `TyFun`), and similarly with constructors of such `TyCon`s.

I'd be happy to continue hacking on this tomorrow, especially if you agree this is a reasonable thing to do.

Also, our pretty-printer does something funny here, printing `Maybe Integer -> Integer`. A mental note to self to investigate.