### PR TITLE
Monomorphize Everything

### DIFF
--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -54,6 +54,7 @@ library
       Pirouette.Transformations.Prenex
       Pirouette.Transformations.Term
       Pirouette.Transformations.Utils
+      Pirouette.Utils
       PureSMT
       PureSMT.Process
       PureSMT.SExpr

--- a/src/Language/Pirouette/QuasiQuoter/Syntax.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Syntax.hs
@@ -40,7 +40,7 @@ import Data.Void
 import Language.Haskell.TH.Syntax (Lift)
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
-import Pirouette.Transformations.Utils (monoNameSep)
+import Pirouette.Transformations.Monomorphization (monoNameSep)
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L

--- a/src/Pirouette/Transformations/Contextualize.hs
+++ b/src/Pirouette/Transformations/Contextualize.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TupleSections #-}
-
 module Pirouette.Transformations.Contextualize where
 
 import qualified Data.Map as M
@@ -8,6 +6,7 @@ import qualified Data.Text as T
 import Pirouette.Monad
 import Pirouette.Term.Syntax as S
 import Pirouette.Term.Syntax.SystemF as SystF
+import Pirouette.Utils
 
 -- | Make all the 'Name's in the term with empty uniques
 -- refer to those in the context.
@@ -33,8 +32,8 @@ contextualizeDef :: (PirouetteReadDefs lang m) => Definition lang -> m (Definiti
 contextualizeDef (DFunDef (FunDef r term ty)) = DFunDef <$> (FunDef r <$> contextualizeTerm term <*> contextualizeType ty)
 contextualizeDef (DConstructor i n) = return (DConstructor i n)
 contextualizeDef (DDestructor n) = return (DDestructor n)
-contextualizeDef (DTypeDef (Datatype k vars dest cons)) =
-  DTypeDef <$> (Datatype k vars dest <$> mapM (secondM contextualizeType) cons)
+contextualizeDef (DTypeDef (Datatype k vars dest0 cons)) =
+  DTypeDef <$> (Datatype k vars dest0 <$> mapM (secondM contextualizeType) cons)
 
 contextualizeDecls :: (PirouetteReadDefs lang m) => Decls lang -> m (Decls lang)
 contextualizeDecls = fmap M.fromList . mapM (secondM contextualizeDef) . M.toList
@@ -109,6 +108,3 @@ removeFromScope ::
   Map.Map (Namespace, Name) (Definition lang)
 removeFromScope inScope space nm =
   Map.delete (space, nm) inScope
-
-secondM :: (Monad m) => (b -> m b') -> (a, b) -> m (a, b')
-secondM f (a, b) = (a,) <$> f b

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -30,8 +30,10 @@ import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.Base as B
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Transformations.EtaExpand
-import Pirouette.Transformations.Monomorphization (findPolyHOFDefs, hofsClosure)
 import Pirouette.Transformations.Utils
+
+defunctionalize :: (Language lang, LanguageBuiltinTypes lang) => PrtUnorderedDefs lang -> PrtUnorderedDefs lang
+defunctionalize defs0 = undefined
 
 -- Defunctionalization assumes lots of things! Namelly:
 --
@@ -39,6 +41,7 @@ import Pirouette.Transformations.Utils
 -- 2. everything has been fully eta-expanded
 -- 3. ??? still discovering
 
+{-
 defunctionalize :: (Language lang, LanguageBuiltinTypes lang) => PrtUnorderedDefs lang -> PrtUnorderedDefs lang
 defunctionalize defs0 =
   case defunctionalizeAssumptions defs0 of
@@ -142,7 +145,7 @@ defunDtors defs = transformBi f defs
       | Just UnDestMeta {..} <- runReader (runMaybeT (unDest term)) defs,
         Datatype {..} <- runReader (prtTypeDefOf undestTypeName) defs =
         let tyArgs' = map rewriteFunType undestTypeArgs
-            returnTy = rewriteFunType undestReturnType
+            _returnTy = rewriteFunType undestReturnType
             instantiatedCtors = map ((`SystF.tyInstantiateN` tyArgs') . snd) constructors
             branches = zipWith (handleBranches undestCasesExtra) instantiatedCtors undestCases
          in dest $
@@ -429,10 +432,10 @@ rewriteHofType = go 0
         (dom', posApply) =
           case dom of
             SystF.TyFun {} -> (closureType dom, Just $ DefunHofArgInfo dom)
-            ty | hasFuns ty -> (rewriteFunType ty, Just DefunHofArgNested)
+            ty | SystF.tyHasFuns ty -> (rewriteFunType ty, Just DefunHofArgNested)
             _ -> (dom, Nothing)
     go _ ty@SystF.TyApp {}
-      | hasFuns ty = (rewriteFunType ty, [])
+      | SystF.tyHasFuns ty = (rewriteFunType ty, [])
       | otherwise = (ty, [])
     go pos (SystF.TyAll ann k ty) = SystF.TyAll ann k *** (Nothing :) $ go (pos + 1) ty
     go _pos SystF.TyLam {} = error "unexpected arg type" -- TODO mention the type
@@ -491,3 +494,4 @@ funTyStr ty =
   error $
     "unexpected arg type during defunctionalization:\n"
       <> renderSingleLineStr (pretty ty)
+-}

--- a/src/Pirouette/Transformations/Monomorphization.hs
+++ b/src/Pirouette/Transformations/Monomorphization.hs
@@ -10,122 +10,60 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Pirouette.Transformations.Monomorphization
-  ( -- * Actual functionality
-    monomorphize,
+module Pirouette.Transformations.Monomorphization where
 
-    -- * Exported for testing
-    hofsClosure,
-    findPolyHOFDefs,
-    specFunApp,
-    specTyApp,
-    executeSpecRequest,
-    SpecRequest (..),
-  )
-where
-
+import Control.Arrow (first)
+import Control.Monad.Reader
+import Control.Monad.State.Strict
 import Control.Monad.Writer.Strict
-import Data.Data
+import Data.Default
 import Data.Generics.Uniplate.Data
 import Data.List (isPrefixOf)
 import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Set as S
+import qualified Data.Text as T
 import Pirouette.Monad
 import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.Subst
 import qualified Pirouette.Term.Syntax.SystemF as SystF
-import Pirouette.Transformations.Utils
+import Pirouette.Term.TransitiveDeps
+import Pirouette.Utils
 
 -- * Monomorphization
 
---
--- tl;dr: `monomorphize` exported from this module turns (in Haskell syntax)
---
--- > foldl :: (b -> a -> b) -> b -> [a] -> b
--- > foldl f z []     = z
--- > foldl f z (x:xs) = foldl f (f z x) xs
--- >
--- > any :: [Bool] -> Bool
--- > any xs = foldl or False xs
---
--- into, imagining '@' is a valid part of a name:
---
--- > foldl@Bool@Bool :: (Bool -> Bool -> Bool) -> Bool -> [Bool] -> Bool
--- > foldl@Bool@Bool f z []     = z
--- > foldl@Bool@Bool f z (x:xs) = foldl@Bool@Bool f (f z x) xs
--- >
--- > any :: [Bool] -> Bool
--- > any xs = foldl@Bool@Bool or False xs
---
--- This module implements a _partial_ monomorphization,
--- substituting type variables appearing in higher-order functional contexts with the specific types.
--- That is,
---
--- > foo :: (a -> a -> a) -> b -> b
--- > bar :: _
--- > bar = foo (\(l :: Bool) (r :: Bool) -> l `or` r) "test"
---
--- results in
---
--- > foo@Bool :: (Bool -> Bool -> Bool) -> b -> b
--- > bar :: _
--- > bar = foo@Bool ...
---
--- and _not_ in `foo@Bool@String`: we don't specialize `b` since it doesn't appear in a higher-order context.
---
--- Polymorphic data types like `Maybe` or
---
--- > data Monoid a where
--- >   MkMonoid :: (a -> a -> a) -> a -> Monoid a
---
--- are handled similarly.
---
---
--- -- * Motivation
---
--- This is just about as much as needed to prepare a System Fω program for symbolic evaluation with an SMT solver.
--- Indeed, current SMTLIB doesn't support higher-order functions, hence we need to defunctionalize.
---
--- It seemingly isn't possible to defunctionalize polymoprhic higher-order functions in System Fω
--- (as the imaginary polymorphic `apply` function is not typeable),
--- so we need to monomorphize everything higher-order before defunctionalization.
--- And, since SMTLIB does support polymorphism, we can leave type variables not occuring in a higher-order context,
--- potentially reducing the number of extra specialized terms.
---
--- -- * Shortcomings
---
--- The tl;dr example is actually a bit of wishful thinking: right now, only the first type variable gets monomorphized.
--- The example is what the module will eventually do, but full monomorphization on all tyvars is TODO for now.
+{-
+TODO: I can see how the name-fixing function that uses '!' and how the option of
+whether we should or should not monomorphize all polymorphic definitions could be made into
+options:
 
--- | The ultimate monomorphization, orchestrating the rest of the functions in this module.
---
--- Monomorphization goes as follows:
---
--- 1. The higher-order polymorphic definitions are collected (via 'findPolyHOFDefs'):
---    * all the functions having functional arguments of polymorphic type,
---    * all the types having at least one constructor having a polymorphic HOF field.
--- 2. The transitive closure of functions mentioning the names of things from step (1) is built (via 'hofDefs').
--- 3. a. All mentions of names from (2) applied to concrete types only (where no type variables are present)
---       are replaced with a specialized name, so @foldl @Bool @Bool f x y@ becomes @foldl_Bool_Bool f x y@
---       (via 'specFunApp' and 'specTyApp').
---    b. The definitions corresponding to the names found during step (a) get generated:
---       so, if step (a) replaced @fold @Bool @Bool@ with @fold_Bool_Bool@ somewhere, then this step
---       actually generates the definition of @fold_Bool_Bool@ based on the "template" @fold@.
--- 4. Since step (3b) might introduce more names from (2) applied to concrete types,
---    the whole step (3) is repeated until the fixpoint
---    (which presumably might not exist for arbitrary System Fω, but shall exist for the subset of programs we care about).
--- 5. Having done that, all the higher-order definitions from (2) are subject to @prune@.
-monomorphize ::
-  forall lang.
-  (Language lang) =>
-  PrtUnorderedDefs lang ->
-  PrtUnorderedDefs lang
+data MonomorphizeOpts = MonomorphizeOpts
+  { -- | Monomorphizes only definitions that contain a polymorphic higher-order function.
+    -- Simple polymophic datatypes like @Maybe@ or functions like @id@ won't be monomorphized.
+    monoHOFOnly :: Bool,
+    fixName :: ... -> Name,
+  }
+-}
+
+-- | Given a set of definitions in prenex form (i.e., all 'SystF.TyAll' appear in the front and
+-- you can rely on "Pirouette.Transformations.Prenex" to get there), will yield a new set
+-- of definitions that contains no 'SystF.TyAll' nor datatypes of kind other than *.
+monomorphize :: forall lang. (Language lang) => PrtUnorderedDefs lang -> PrtUnorderedDefs lang
 monomorphize defs0 = prune $ go mempty defs0
   where
-    hofDefsRoots = findPolyHOFDefs $ prtUODecls defs0
-    hofDefs = hofsClosure (prtUODecls defs0) hofDefsRoots
+    defsToMono = selectMonoDefs defs0
 
+    -- This fixpoint is necessary since we might encounter things such as:
+    --
+    -- > length :: [a] -> Int
+    -- > f :: [a] -> Int
+    -- > f x = ... (length x) ...
+    -- > main = f [3] + f "abc"
+    --
+    -- On a first iteration, we'll learn that we should specialize 'f' twice:
+    -- once for @a ~ Integer@ and once for @a ~ Char@. Now, however we'll have
+    -- calls to @length@ which are applied to different type-variables, hence,
+    -- we need to run again.
     go :: S.Set (SpecRequest lang) -> PrtUnorderedDefs lang -> PrtUnorderedDefs lang
     go prevOrders defs
       | M.null newDefs && defs == defs' = defs'
@@ -133,18 +71,57 @@ monomorphize defs0 = prune $ go mempty defs0
       where
         (defs', specOrders) =
           runWriter $
-            transformBiM (specFunApp hofDefs :: SpecFunApp lang) defs
-              >>= transformBiM (specTyApp hofDefs :: SpecTyApp lang)
+            transformBiM (specFunApp defsToMono :: SpecFunApp lang) defs
+              >>= transformBiM (specTyApp defsToMono :: SpecTyApp lang)
         newOrders = filter (`S.notMember` prevOrders) specOrders
         newDefs = foldMap executeSpecRequest newOrders
 
     prune :: PrtUnorderedDefs lang -> PrtUnorderedDefs lang
-    prune defs = defs {prtUODecls = M.filterWithKey (\n _ -> n `M.notMember` hofDefs) $ prtUODecls defs}
+    prune defs = defs {prtUODecls = M.filterWithKey (\n _ -> snd n `M.notMember` defsToMono) $ prtUODecls defs}
+
+-- | Return a set of definitions that either satisfy 'shouldMono' or have one
+--  of its transitive dependencies satisfy 'shouldMono'. In other words, picks
+--  all definitions that should be monomorphized.
+selectMonoDefs :: forall lang. (Language lang) => PrtUnorderedDefs lang -> M.Map Name (FunOrTypeDef lang)
+selectMonoDefs decls0@PrtUnorderedDefs {..} =
+  let defsList = mapMaybe (secondM isFunOrTypeDef) $ M.toList prtUODecls
+      -- Makes a first selection of definitions: all of those satisfying 'shouldMono'
+      selectedDefs0 = filter (shouldMono . snd) defsList
+      selectedNames0 = map (namespaceToArg . fst) selectedDefs0
+      -- Now get all names that depend on anything from selectedNames0
+      selectedDefs = flip runReader decls0 $
+        flip evalStateT def $
+          flip mapMaybeM defsList $ \((space, nm), d) -> do
+            depsOfNM <- transitiveDepsOfCached space nm
+            return $
+              if (`S.member` depsOfNM) `any` selectedNames0
+                then Just (nm, d)
+                else Nothing
+   in M.fromList $ map (first snd) selectedDefs0 -- ++ selectedDefs
+
+type FunOrTypeDef lang = SystF.Arg (TypeDef lang) (FunDef lang)
+
+-- | Returns whether we should monomorphize this function or type.
+shouldMono :: FunOrTypeDef lang -> Bool
+shouldMono (SystF.TermArg FunDef {..}) = isPolyType funTy
+shouldMono (SystF.TyArg Datatype {..}) = not (null typeVariables)
+
+isPolyType :: SystF.AnnType ann ty -> Bool
+isPolyType SystF.TyAll {} = True
+isPolyType _ = False
+
+isFunOrTypeDef :: Definition lang -> Maybe (FunOrTypeDef lang)
+isFunOrTypeDef (DTypeDef tydef) = Just (SystF.TyArg tydef)
+isFunOrTypeDef (DFunDef fdef) = Just (SystF.TermArg fdef)
+isFunOrTypeDef _ = Nothing
+
+-- * Specializer
 
 -- | Describes a definition (a function or a type) that needs to be specialized with the given type arguments list.
 data SpecRequest lang = SpecRequest
-  { origDef :: HofDef lang,
-    specArgs :: [Type lang]
+  { srName :: Name,
+    srOrigDef :: FunOrTypeDef lang,
+    srArgs :: [Type lang]
   }
   deriving (Show, Eq, Ord)
 
@@ -152,24 +129,84 @@ type SpecFunApp lang = forall m. MonadWriter [SpecRequest lang] m => Term lang -
 
 type SpecTyApp lang = forall m. MonadWriter [SpecRequest lang] m => Type lang -> m (Type lang)
 
+-- | Specializes a function application of the form:
+--
+--  > hof @Integer @Bool x y z
+--
+-- at call site, where @hof@ has been identified as
+-- 1. either a higher-order function itself,
+-- 2. or invoking a polymorphic higher-order function, perhaps, transitively;
+-- and its type argument contains no bound-variables: in other words,
+-- we can substitute that call with @hof\@Integer\@Bool@ while creating a monomorphic
+-- definition for @hof@.
+--
+-- We only specialize type arguments that appear /before/ the first term-argument.
+--
+-- This function only does the substitution _at call site_ and emits a 'SpecRequest' denoting that the corresponding
+-- higher-order _definition_ needs to be specialized (which will be handled later by 'executeSpecRequest').
+specFunApp ::
+  forall lang.
+  (LanguageBuiltins lang) =>
+  M.Map Name (FunOrTypeDef lang) ->
+  SpecFunApp lang
+specFunApp toMono (SystF.App (SystF.Free (TermSig name)) args)
+  -- We compare the entire name, not just the nameString part: x0 /= x1.
+  | Just someDef <- name `M.lookup` toMono,
+    -- Now we ensure that there is something to specialize and that the type arguments we've
+    -- gathered are specializable arguments (ie, no bound type-variables)
+    let tyArgs = map (fromJust . SystF.fromTyArg) $ takeWhile SystF.isTyArg args,
+    not (null tyArgs),
+    all isSpecArg tyArgs = do
+    let (specArgs, remainingArgs) = SystF.splitArgs (length tyArgs) args
+        speccedName = genSpecName specArgs name
+    tell $ pure $ SpecRequest name someDef specArgs
+    pure $ SystF.Free (TermSig speccedName) `SystF.App` remainingArgs
+specFunApp _ x = pure x
+
+-- | Specializes a type application of the form
+--
+--  > HOFType @Integer
+--
+--  where @HOFType a@ has at least one constructor having a higher-order argument mentioning @a@,
+--  perhaps, transitively.
+--  For example, both these definitions would be specialized:
+--
+--  > data Semigroup a = MkSemigroup (a -> a -> a)
+--  > data Monoid a = MkMonoid (Semigroup a) a
+--
+--  See the docs for 'specFunApp' for more details.
+specTyApp ::
+  (LanguageBuiltins lang) =>
+  M.Map Name (FunOrTypeDef lang) ->
+  SpecTyApp lang
+specTyApp toMono (SystF.TyApp (SystF.Free (TySig name)) tyArgs)
+  | Just someDef <- name `M.lookup` toMono,
+    not (null tyArgs),
+    all isSpecArg tyArgs = do
+    let (specArgs, remainingArgs) = splitAt (length tyArgs) tyArgs
+        speccedName = genSpecName specArgs name
+    tell $ pure $ SpecRequest name someDef specArgs
+    pure $ SystF.Free (TySig speccedName) `SystF.TyApp` remainingArgs
+specTyApp _ x = pure x
+
 -- | Takes a description of what needs to be specialized
 -- (a function or a type definition along with specialization args)
 -- and produces the specialized definitions.
 executeSpecRequest :: (Language lang) => SpecRequest lang -> Decls lang
-executeSpecRequest SpecRequest {origDef = HofDef {..}, ..} = M.fromList $
-  case hofDefBody of
-    HDBFun FunDef {..} ->
+executeSpecRequest SpecRequest {..} = M.fromList $
+  case srOrigDef of
+    SystF.TermArg FunDef {..} ->
       let newDef =
             DFunction
               funIsRec
-              (funBody `SystF.appN` map SystF.TyArg specArgs)
-              (funTy `SystF.tyInstantiateN` specArgs)
-       in [((TermNamespace, fixName hofDefName), newDef)]
-    HDBType Datatype {..} ->
-      let tyName = fixName hofDefName
+              (funBody `SystF.appN` map SystF.TyArg srArgs)
+              (funTy `SystF.tyInstantiateN` srArgs)
+       in [((TermNamespace, fixName srName), newDef)]
+    SystF.TyArg Datatype {..} ->
+      let tyName = fixName srName
           dtorName = fixName destructor
           ctors =
-            [ (fixName ctorName, fixType $ ctorTy `SystF.tyInstantiateN` specArgs)
+            [ (fixName ctorName, fixType $ ctorTy `SystF.tyInstantiateN` srArgs)
               | (ctorName, ctorTy) <- constructors
             ]
           newDef =
@@ -188,8 +225,8 @@ executeSpecRequest SpecRequest {origDef = HofDef {..}, ..} = M.fromList $
                  | i <- [0 ..]
                ]
   where
-    fixName = genSpecName specArgs
-    specArgsLen = length specArgs
+    fixName = genSpecName srArgs
+    specArgsLen = length srArgs
 
     -- When specializing constructor types, we need to substitute occurences of
     -- the un-specialized type with the fixed name. For instance, if we're specializing
@@ -203,62 +240,9 @@ executeSpecRequest SpecRequest {origDef = HofDef {..}, ..} = M.fromList $
     --
     fixType = rewrite $ \case
       SystF.TyApp (SystF.Free (TySig n)) xs -> do
-        guard (n == hofDefName && specArgs `isPrefixOf` xs)
+        guard (n == srName && srArgs `isPrefixOf` xs)
         return $ SystF.Free (TySig $ fixName n) `SystF.TyApp` drop specArgsLen xs
       _ -> Nothing
-
--- | Specializes a function application of the form:
---
---  > hof @Integer @Bool x y z
---
--- at call site, where @hof@ has been identified as
--- 1. either a higher-order function itself,
--- 2. or invoking a polymorphic higher-order function, perhaps, transitively;
--- and its type argument contains no bound-variables: in other words,
--- we can substitute that call with @hof\@Integer\@Bool@ while creating a monomorphic
--- definition for @hof@.
---
--- We only specialize type arguments that appear /before/ the first term-argument.
---
--- This function only does the substitution _at call site_ and emits a 'SpecRequest' denoting that the corresponding
--- higher-order _definition_ needs to be specialized (which will be handled later by 'executeSpecRequest').
-specFunApp :: forall lang. (LanguageBuiltins lang) => HOFDefs lang -> SpecFunApp lang
-specFunApp hofDefs (SystF.App (SystF.Free (TermSig name)) args)
-  -- We compare the entire name, not just the nameString part: x0 /= x1.
-  | Just someDef <- (TermNamespace, name) `M.lookup` hofDefs,
-    -- Now we ensure that there is something to specialize and that the type arguments we've
-    -- gathered are specializable arguments (ie, no bound type-variables)
-    let tyArgs = map (fromJust . SystF.fromTyArg) $ takeWhile SystF.isTyArg args,
-    not (null tyArgs),
-    all isSpecArg tyArgs = do
-    let (specArgs, remainingArgs) = splitArgs (length tyArgs) args
-        speccedName = genSpecName specArgs name
-    tell $ pure $ SpecRequest someDef specArgs
-    pure $ SystF.Free (TermSig speccedName) `SystF.App` remainingArgs
-specFunApp _ x = pure x
-
--- | Specializes a type application of the form
---
---  > HOFType @Integer
---
---  where @HOFType a@ has at least one constructor having a higher-order argument mentioning @a@,
---  perhaps, transitively.
---  For example, both these definitions would be specialized:
---
---  > data Semigroup a = MkSemigroup (a -> a -> a)
---  > data Monoid a = MkMonoid (Semigroup a) a
---
---  See the docs for 'specFunApp' for more details.
-specTyApp :: (LanguageBuiltins lang) => HOFDefs lang -> SpecTyApp lang
-specTyApp hofDefs (SystF.TyApp (SystF.Free (TySig name)) tyArgs)
-  | Just someDef <- (TypeNamespace, name) `M.lookup` hofDefs,
-    not (null tyArgs),
-    all isSpecArg tyArgs = do
-    let (specArgs, remainingArgs) = splitAt (length tyArgs) tyArgs
-        speccedName = genSpecName specArgs name
-    tell $ pure $ SpecRequest someDef specArgs
-    pure $ SystF.Free (TySig speccedName) `SystF.TyApp` remainingArgs
-specTyApp _ x = pure x
 
 -- A type argument is fully specialized if it has no bound variables
 isSpecArg :: forall lang. LanguageBuiltins lang => Type lang -> Bool
@@ -267,6 +251,32 @@ isSpecArg arg = null bounds
     bounds :: [TyVar lang]
     bounds = filter (isJust . isBound) $ universeBi arg
 
+-- | This is the character used to separate the type arguments and the term or type name
+--  when monomorphizing. Because we need to be able to test monomorphization, this
+--  is also recognized by the "Language.Pirouette.Example" as a valid part of an identifier
+monoNameSep :: Char
+monoNameSep = '!'
+
+genSpecName :: (LanguageBuiltins lang) => [Type lang] -> Name -> Name
+genSpecName args name = Name (nameString name <> msep <> argsToStr args) Nothing
+  where
+    msep = T.pack [monoNameSep]
+
+argsToStr :: (LanguageBuiltins lang) => [Type lang] -> T.Text
+argsToStr = T.intercalate msep . map f
+  where
+    msep = T.pack [monoNameSep]
+
+    f (SystF.Free n `SystF.TyApp` args) =
+      tyBaseString n <> if null args then mempty else "<" <> argsToStr args <> ">"
+    f (SystF.TyFun a b) = f a <> "_" <> f b
+    f arg = error $ "unexpected specializing arg" <> show arg
+
+tyBaseString :: LanguageBuiltins lang => TypeBase lang -> T.Text
+tyBaseString (TyBuiltin bt) = T.pack $ show bt
+tyBaseString (TySig na) = nameString na
+
+{-
 -- Returns the definitions containing (polymorphic) higher-order functions,
 -- be it functions or types.
 --
@@ -282,10 +292,6 @@ findPolyFuns ::
   [((space, Name), Definition lang)] ->
   [((space, Name), HofDef lang)]
 findPolyFuns predi = flip findFuns (\f -> isPolyType (funTy f) && predi f)
-
-isPolyType :: SystF.AnnType ann ty -> Bool
-isPolyType SystF.TyAll {} = True
-isPolyType _ = False
 
 -- | Finds the transitive closure of functions invoking higher-order things.
 --
@@ -310,3 +316,5 @@ hofsClosure decls = go
         hasHofName entity =
           not (null [() | TySig name <- universeBi entity :: [TypeBase lang], (TypeNamespace, name) `M.member` hofs])
             || not (null [() | TermSig name <- universeBi entity :: [TermBase lang], (TermNamespace, name) `M.member` hofs])
+
+-}

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -22,17 +22,7 @@ import Prettyprinter hiding (Pretty, pretty)
 traceDefsId :: (LanguagePretty lang) => PrtUnorderedDefs lang -> PrtUnorderedDefs lang
 traceDefsId defs = renderSingleLineStr (pretty $ prtUODecls defs) `trace` defs
 
-data HofDefBody lang
-  = HDBType (TypeDef lang)
-  | HDBFun (FunDef lang)
-  deriving (Show, Eq, Ord)
-
-data HofDef lang = HofDef
-  { hofDefName :: Name,
-    hofDefBody :: HofDefBody lang
-  }
-  deriving (Show, Eq, Ord)
-
+{-
 type HOFDefs lang = M.Map (Namespace, Name) (HofDef lang)
 
 findFuns ::
@@ -77,32 +67,7 @@ findHOFDefs funPred tyPred declsPairs =
     funPred' :: FunDef lang -> Bool
     funPred' fun = funPred fun && hasHOFuns (funTy fun)
     tyPred' name typeDef = tyPred name typeDef && (hasHOFuns . snd) `any` constructors typeDef
-
--- | Returns whether a type has higher-order functions anywhere, directly
--- or indirectly. For instance, the type:
---
--- > Integer -> Maybe (Bool -> Bool) -> X
---
--- Has higher-order functions present nested in 'Maybe'. This current function
--- could be much better given it will also return some false-positives. For instance,
---
--- > Integer -> Const Bool (Bool -> Bool) -> X
---
--- Doesn't really have higher order functions because @Const a b = a@, but we
--- are not worrying about that now.
-hasHOFuns :: (Data ann, Data ty) => AnnType ann ty -> Bool
--- (_ -> _) -> _ ...
-hasHOFuns (TyFun TyFun {} _) = True
-hasHOFuns (TyFun a b) = hasHOFuns a || hasHOFuns b
-hasHOFuns (TyApp _ args) = hasFuns `any` args
-hasHOFuns (TyLam _ _ at) = hasHOFuns at
-hasHOFuns (TyAll _ _ at) = hasHOFuns at
-
-hasFuns :: (Data ann, Data ty) => AnnType ann ty -> Bool
-hasFuns (TyFun _ _) = True
-hasFuns (TyApp _ args) = hasFuns `any` args
-hasFuns (TyLam _ _ at) = hasFuns at
-hasFuns (TyAll _ _ at) = hasFuns at
+-}
 
 -- @Arg Kind (Type lang)@ could've been used here instead,
 -- but having a distinct type seems to be a bit nicer, at least for now for hole-driven development reasons.
@@ -117,42 +82,7 @@ flattenType (dom `TyFun` cod) = first (FlatTermArg dom :) $ flattenType cod
 flattenType (TyAll _ k ty) = first (FlatTyArg k :) $ flattenType ty
 flattenType TyLam {} = error "unnormalized type"
 
--- * @splitArgs n args@ splits @args@ into the first @n@ type arguments and everything else.
-
---
--- For instance, @splitArgs 2 [Arg a, TyArg A, TyArg B, Arg b, TyArg C]@
--- yields @([A, B], [Arg a, Arg b, TyArg C])@.
-splitArgs :: Int -> [SystF.Arg ty v] -> ([ty], [SystF.Arg ty v])
-splitArgs 0 args = ([], args)
-splitArgs n (TyArg tyArg : args) = first (tyArg :) $ splitArgs (n - 1) args
-splitArgs n (arg : args) = second (arg :) $ splitArgs n args
-splitArgs _ [] = error "Less args than poly args count"
-
--- | This is the character used to separate the type arguments and the term or type name
---  when monomorphizing. Because we need to be able to test monomorphization, this
---  is also recognized by the "Language.Pirouette.Example" as a valid part of an identifier
-monoNameSep :: Char
-monoNameSep = '!'
-
-genSpecName :: (LanguageBuiltins lang) => [Type lang] -> Name -> Name
-genSpecName args name = Name (nameString name <> msep <> argsToStr args) Nothing
-  where
-    msep = T.pack [monoNameSep]
-
-argsToStr :: (LanguageBuiltins lang) => [Type lang] -> T.Text
-argsToStr = T.intercalate msep . map f
-  where
-    msep = T.pack [monoNameSep]
-
-    f (SystF.Free n `TyApp` args) =
-      tyBaseString n <> if null args then mempty else "<" <> argsToStr args <> ">"
-    f (SystF.TyFun a b) = f a <> "_" <> f b
-    f arg = error $ "unexpected specializing arg" <> show arg
-
-tyBaseString :: LanguageBuiltins lang => TypeBase lang -> T.Text
-tyBaseString (TyBuiltin bt) = T.pack $ show bt
-tyBaseString (TySig na) = nameString na
-
+{-
 -- This really belongs to a Pretty module, but we need them here for nicer debugging anyway for now.
 instance (Pretty (BuiltinTypes lang), Pretty (FunDef lang)) => Pretty (HofDefBody lang) where
   pretty (HDBType defn) = "<typ>" <+> pretty defn
@@ -163,3 +93,4 @@ instance (Pretty (BuiltinTypes lang), Pretty (FunDef lang)) => Pretty (HofDef la
 
 instance (Pretty (BuiltinTypes lang), Pretty (FunDef lang)) => Pretty (HOFDefs lang) where
   pretty = align . vsep . map (\(n, d) -> pretty n <+> pretty d) . M.toList
+-}

--- a/src/Pirouette/Utils.hs
+++ b/src/Pirouette/Utils.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE TupleSections #-}
+
+module Pirouette.Utils where
+
+import Data.Maybe
+
+secondM :: (Functor m) => (b -> m b') -> (a, b) -> m (a, b')
+secondM f (a, b) = (a,) <$> f b
+
+mapMaybeM :: (Monad m) => (a -> m (Maybe b)) -> [a] -> m [b]
+mapMaybeM f = fmap catMaybes . mapM f


### PR DESCRIPTION
Simplifies the monomorphizer, which should help the defunctionalizer later by not having to deal with those nasty `Just @(Bool -> Bool)` cases: those will have been replaced by `Just!BoolToBool` and will be of type:

```Just!BoolToBool : (Bool -> Bool) -> Maybe (Bool -> Bool)```

Hence, it's obviously a higher-order constructor for the defunctionalizer!

Still incomplete: understand and decide how to deal with constructors of types that should be defunctionalized.