### PR TITLE
Simplify Defunctionalization

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,8 @@ packages:
 -- We never, ever, want this.
 write-ghc-environment-files: never
 
+library-profiling: True
+
 -- Always build tests and benchmarks.
 tests: true
 benchmarks: true

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -4,31 +4,8 @@
   # Bring in our pinned nixpkgs, but also brings in iohk's modiied nixpkgs
   # which contains the precious ghc810420210212 needed for compiling plutus.
   rawpkgs ? import sources.nixpkgs {},
-  haskellNix ? import sources.haskellNix {},
-  iohkpkgs ? import
-    haskellNix.sources.nixpkgs-unstable
-    haskellNix.nixpkgsArgs
 }:
-let
-  # The only difficulty we face is making sure to build the haskell-language-server
-  # with the same version of GHC that is used for plutus; doing so, however,
-  # requires patching ghcide, a dependency of haskell-language-server.
-  #
-  # To do that, we create a hackage-package and specify a patch
-  # inside its 'modules' key:
-  custom-hls =
-    with
-    (iohkpkgs.haskell-nix.hackage-package {
-      compiler-nix-name = "ghc810420210212";
-      name = "haskell-language-server";
-      version = "1.7.0.0";
-      modules = [{
-        packages.ghcide.patches = [ patches/ghcide_partial_iface.patch ];
-        packages.ghcide.flags.ghc-patched-unboxed-bytecode = true;
-      }];
-    }).components.exes;
-    [haskell-language-server haskell-language-server-wrapper];
-in { 
+{ 
   # We will split our dependencies into those deps that are needed for
   # building and testing; and those that are needed for development
   # the purpose is to keep CI happier and make it as fast as possible.
@@ -46,17 +23,15 @@ in {
         # haskell development tools pulled from regular nixpkgs
         hpack
         ormolu
+        haskellPackages.cabal-install
         haskellPackages.happy
+        haskell.compiler.ghc8107
         cvc4 # required to run pirouette once its built
-     ] ++ [
-        # iohk-specific stuff that we require
-        iohkpkgs.haskell-nix.internal-cabal-install
-        iohkpkgs.haskell-nix.compiler.ghc810420210212
      ] ++ lib.optional (stdenv.isLinux) systemd.dev;
 
-  # Besides what's needed for building, we also want our instance of the
-  # the haskell-language-server
-  dev-deps = [ custom-hls ];
+  dev-deps = with rawpkgs; [
+        haskellPackages.haskell-language-server
+      ];
 
   # Export the raw nixpkgs to be accessible to whoever imports this.
   nixPkgsProxy = rawpkgs;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,16 +1,4 @@
 {
-    "haskellNix": {
-        "branch": "master",
-        "description": "Alternative Haskell Infrastructure for Nixpkgs",
-        "homepage": "https://input-output-hk.github.io/haskell.nix",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "4ee7270856a6ba4617c7e51a6c619f365faad894",
-        "sha256": "022xg02wmr5dj3y2qgn3c2sfg97w41avbl7nwyml6cvqin9qskhl",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/4ee7270856a6ba4617c7e51a6c619f365faad894.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/package.yaml
+++ b/package.yaml
@@ -41,7 +41,6 @@ library:
     -Wall
     -Wno-orphans
     -fplugin=StackTrace.Plugin
-    -threaded
 
 tests:
   spec:
@@ -52,3 +51,17 @@ tests:
       - pirouette
     ghc-options:
       -threaded
+
+## executables:
+##   spec-prof:
+##     main: Spec.hs
+##     source-dirs:
+##       - tests/unit
+##     dependencies:
+##       - pirouette
+##     ghc-options:
+##       -threaded
+##       -fprof-auto
+##       -fexternal-interpreter
+##       "-with-rtsopts=-N -p -s -h"
+

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -64,7 +64,7 @@ library
       Paths_pirouette
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wno-orphans -fplugin=StackTrace.Plugin -threaded
+  ghc-options: -Wall -Wno-orphans -fplugin=StackTrace.Plugin
   build-depends:
       QuickCheck
     , ansi-terminal

--- a/src/Language/Pirouette/Example.hs
+++ b/src/Language/Pirouette/Example.hs
@@ -235,6 +235,10 @@ pattern SConstant s = SystF.App (SystF.Free (Constant (ConstString s))) []
 -- In particular, with respect to @if@ statements in our case. Check the respective
 -- class documentation for more details.
 instance LanguageSymEval Ex where
+  -- Our example language has Bool as a builtin type and terms of type Bool are
+  -- translated to SMT's builtin Bool type, no casting needed whatsoever.
+  isTrue = id
+
   -- translate arithmetic operations applied to constants
   branchesBuiltinTerm op _translator [SystF.TermArg (IConstant x), SystF.TermArg (IConstant y)]
     | exTermIsArithOp op =
@@ -256,11 +260,11 @@ instance LanguageSymEval Ex where
       let isEq TermEq = True
           isEq TermStrEq = True
           isEq _ = False
-          isTrue BTrue = True
-          isTrue _ = False
+          isTrue0 BTrue = True
+          isTrue0 _ = False
           isFalse BFalse = True
           isFalse _ = False
-       in ifThenElseBranching isTrue BTrue isFalse BFalse isEq c t e excess
+       in ifThenElseBranching isTrue0 BTrue isFalse BFalse isEq c t e excess
   branchesBuiltinTerm _ _ _ = pure Nothing
 
 -- * QuasiQuoters

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -28,26 +28,26 @@ import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Term.TypeChecker (typeCheckDecls)
 import Text.Megaparsec
 
-prog :: forall lang. (LanguageParser lang, LanguageBuiltinTypes lang, Language lang) => QuasiQuoter
+prog :: forall lang. (LanguageParser lang, LanguageBuiltinTypes lang, LanguagePretty lang) => QuasiQuoter
 prog = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
   decls <- trQ (trProgram p0)
   _ <- maybeQ (typeCheckDecls decls)
   [e|(PrtUnorderedDefs decls)|]
 
-progNoTC :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
+progNoTC :: forall lang. (LanguageParser lang, LanguagePretty lang) => QuasiQuoter
 progNoTC = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
   decls <- trQ (trProgram p0)
   [e|(PrtUnorderedDefs decls)|]
 
-term :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
+term :: forall lang. (LanguageParser lang, LanguagePretty lang) => QuasiQuoter
 term = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseTerm @lang) <* eof) str
   p1 <- trQ (trTerm [] [] p0)
   [e|p1|]
 
-ty :: forall lang. (LanguageParser lang, Language lang) => QuasiQuoter
+ty :: forall lang. (LanguageParser lang, LanguagePretty lang) => QuasiQuoter
 ty = quoter $ \str -> do
   p0 <- parseQ (spaceConsumer *> lexeme (parseType @lang) <* eof) str
   p1 <- trQ (trType [] p0)

--- a/src/Language/Pirouette/QuasiQuoter/Syntax.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Syntax.hs
@@ -83,7 +83,7 @@ class (LanguageLift lang, LanguageBuiltins lang) => LanguageParser lang where
 
 -- ** Syntactical Categories
 
-data DataDecl lang = DataDecl [(String, SystF.Kind)] [(String, Ty lang)]
+data DataDecl lang = DataDecl [(String, SystF.Kind)] [(String, Ty lang)] (Maybe String)
 
 deriving instance (Show (BuiltinTypes lang)) => Show (DataDecl lang)
 
@@ -145,7 +145,8 @@ parseDataDecl = label "Data declaration" $ do
   cons <-
     (try (symbol "=") >> ((,) <$> typeName @lang <*> (parseTyOf >> parseType)) `sepBy1` symbol "|")
       <|> return []
-  return (i, DataDecl vars cons)
+  dest <- optional (symbol "destructor" >> try (ident @lang) <|> typeName @lang)
+  return (i, DataDecl vars cons dest)
 
 -- | Parses functon declarations:
 --
@@ -292,7 +293,7 @@ ident = label "identifier" $ do
   where
     reserved :: S.Set String
     reserved =
-      S.fromList ["abs", "all", "data", "if", "then", "else", "fun", "bottom"]
+      S.fromList ["abs", "all", "data", "destructor", "if", "then", "else", "fun", "bottom"]
         `S.union` reservedNames @lang
 
 typeName :: forall lang. (LanguageParser lang) => Parser String

--- a/src/Language/Pirouette/QuasiQuoter/Syntax.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Syntax.hs
@@ -306,4 +306,4 @@ typeName = label "type-identifier" $ do
 --   reservedTypeNames =
 
 restOfName :: Parser String
-restOfName = many (alphaNumChar <|> char '_' <|> char monoNameSep)
+restOfName = many (alphaNumChar <|> oneOf ('_' : monoNameSep))

--- a/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
+++ b/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
@@ -12,6 +12,7 @@ import Control.Arrow (first)
 import Control.Monad.Except
 import Data.List (elemIndex, nub, (\\))
 import qualified Data.Map as M
+import Data.Maybe
 import Data.String
 import Language.Pirouette.QuasiQuoter.Syntax
 import Pirouette.Term.Syntax.Base
@@ -44,10 +45,10 @@ trFunDecl (FunDecl rec ty expr) =
   DFunDef <$> (FunDef rec <$> trTerm [] [] expr <*> trType [] ty)
 
 trDataDecl :: String -> DataDecl lang -> TrM [((Namespace, Name), Definition lang)]
-trDataDecl sName (DataDecl vars cons) = do
+trDataDecl sName (DataDecl vars cons mDest) = do
   let ki = foldr (SystF.KTo . snd) SystF.KStar vars
   let name = fromString sName
-  let destName = fromString $ "match_" ++ sName
+  let destName = fromString $ fromMaybe ("match_" ++ sName) mDest
   constrs <- mapM (\(n, ty) -> (fromString n,) <$> trTypeWithEnv (reverse vars) ty) cons
   return $
     ((TypeNamespace, name), DTypeDef $ Datatype ki (map (first fromString) vars) destName constrs) :

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -31,7 +31,7 @@ module Pirouette.Symbolic.Eval
     SymEvalStatistics (..),
 
     -- ** Incorrectness logic
-    symevalAnyPath,
+    symevalAnyPathAccum,
     symEvalMatchesFirst,
     symEvalParallel,
     UniversalAxiom (..),
@@ -136,15 +136,17 @@ symeval opts prob = do
   where
     st0 = SymEvalSt mempty M.empty 0 mempty False S.empty
 
-symevalAnyPath ::
+symevalAnyPathAccum ::
   (SymEvalConstr lang, PirouetteDepOrder lang m) =>
+  (Path lang a -> st -> st) ->
+  st ->
   Options ->
   (Path lang a -> Bool) ->
   SymEval lang a ->
-  m (Maybe (Path lang a))
-symevalAnyPath opts p prob = do
+  m (Maybe (Path lang a), st)
+symevalAnyPathAccum f s0 opts p prob = do
   defs <- getPrtOrderedDefs
-  return $ runIdentity $ ListT.firstThat p $ runSymEvalWorker opts defs st0 prob
+  return $ runIdentity $ ListT.firstThatAccum f s0 p $ runSymEvalWorker opts defs st0 prob
   where
     st0 = SymEvalSt mempty M.empty 0 mempty False S.empty
 

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -205,10 +205,9 @@ runSymEvalWorker opts defs st f = do
       let decls = prtDecls defs
           dependencyOrder = prtDepOrder defs
           definedTypes = mapMaybe (R.argElim (lkupTypeDefOf decls) (const Nothing)) dependencyOrder
-          types = builtinTypeDefinitions definedTypes <> definedTypes
           allFns = mapMaybe (R.argElim (const Nothing) (lkupFunDefOf decls)) dependencyOrder
           fns = mapMaybe (\(n, fd) -> (n,) <$> SMT.supportedUninterpretedFunction fd) allFns
-       in SolverSharedCtx types fns
+       in SolverSharedCtx definedTypes fns
 
 instance (SymEvalConstr lang) => Alternative (SymEval lang) where
   empty = SymEval $ ReaderT $ \_ -> StateT $ const empty

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -87,7 +88,10 @@ instance Default Options where
 class (SMT.LanguageSMT lang) => LanguageSymEval lang where
   -- | Injection of different cases in the symbolic evaluator.
   -- For example, one can introduce a 'if_then_else' built-in
-  -- and implement this method to look at both possibilities.
+  -- and implement this method to look at both possibilities; or
+  -- can be used to instruct the solver to branch on functions such
+  -- as @equalsInteger :: Integer -> Integer -> Bool@, where @Bool@
+  -- might not be a builtin type.
   branchesBuiltinTerm ::
     (SMT.ToSMT meta, PirouetteReadDefs lang m) =>
     -- | Head of the application to translate
@@ -101,6 +105,15 @@ class (SMT.LanguageSMT lang) => LanguageSymEval lang where
     -- If 'Just', it provides information of what to assume in each branch and the term to
     -- symbolically evaluate further.
     m (Maybe [SMT.Branch lang meta])
+
+  -- | Casts a boolean in @lang@ to a boolean in SMT by checking whether it is true.
+  --  Its argument is the translation of a term of type "Bool" in @lang@.
+  --  If your language has booleans as a builtin and you defined their interpretation into SMTLIB as
+  --  builtin SMT booleans, this function will be just @id@, otherwise, you might
+  --  want to implement it as something such as @\x -> PureSMT.eq x (myTrue `PureSMT.as` myBool)@
+  --
+  --  This function is meant to be used with @-XTypeApplications@
+  isTrue :: PureSMT.SExpr -> PureSMT.SExpr
 
 newtype SymVar = SymVar {symVar :: Name}
   deriving (Eq, Show, Data, Typeable, IsString)

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -35,6 +35,10 @@ data Options = Options
     stoppingCondition :: StoppingCondition
   }
 
+optsSolverDebug :: Options -> Options
+optsSolverDebug opts =
+  opts {optsPureSMT = (optsPureSMT opts) {PureSMT.debug = True}}
+
 instance Default Options where
   def = Options def (\stat -> sestConstructors stat > 50)
 

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -34,7 +34,7 @@ type IncorrectnessResult lang = Maybe (Path lang (EvaluationWitness lang))
 -- | Runs an incorrectness logic check for a single term, i.e., receives no
 -- environment of definitions.
 runIncorrectnessLogicSingl ::
-  (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  (Language lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
   Options ->
   IncorrectnessParams lang ->
   IncorrectnessResult lang
@@ -42,7 +42,7 @@ runIncorrectnessLogicSingl opts =
   runIncorrectnessLogic opts (PrtUnorderedDefs M.empty)
 
 runIncorrectnessLogic ::
-  (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  (Language lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
   Options ->
   PrtUnorderedDefs lang ->
   IncorrectnessParams lang ->
@@ -104,7 +104,7 @@ assertIRResult _ = return ()
 -- | Check for counterexamples for an incorrectness logic triple and
 -- pretty-print the result
 replIncorrectnessLogic ::
-  (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  (Language lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
   Int ->
   PrtUnorderedDefs lang ->
   IncorrectnessParams lang ->
@@ -114,7 +114,7 @@ replIncorrectnessLogic maxCstrs defs params =
     runIncorrectnessLogic (def {stoppingCondition = (> maxCstrs) . sestConstructors}) defs params
 
 replIncorrectnessLogicSingl ::
-  (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  (Language lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
   Int ->
   IncorrectnessParams lang ->
   IO ()
@@ -125,7 +125,7 @@ replIncorrectnessLogicSingl maxCstrs params =
 -- | Assert a test failure (Tasty HUnit integration) when the result of the
 -- incorrectness logic execution reveals an error or a counterexample.
 assertIncorrectnessLogic ::
-  (LanguagePretty lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
+  (Language lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
   Int ->
   PrtUnorderedDefs lang ->
   IncorrectnessParams lang ->

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -1,14 +1,17 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Provides the base syntactical elements for the languages supported by Pirouette.
 --  This module /does not/ expose the underlying System F implementation. In case
@@ -20,9 +23,7 @@ module Pirouette.Term.Syntax.Base where
 import Control.Arrow ((&&&))
 import Control.Monad.Identity
 import Data.Data
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Maybe (mapMaybe)
+import qualified Data.Map as M
 import Data.Monoid (Sum (..))
 import qualified Data.Set as Set
 import Data.String
@@ -326,7 +327,7 @@ data Namespace = TermNamespace | TypeNamespace
   deriving (Eq, Ord, Show, Data, Typeable)
 
 -- | A program will be translated into a number of term and type declarations.
-type Decls lang = Map (Namespace, Name) (Definition lang)
+type Decls lang = M.Map (Namespace, Name) (Definition lang)
 
 -- * Language Builtins
 
@@ -344,31 +345,14 @@ type LanguageConstrs lang =
 --  objects of the 'BuiltinTypes' and the other builtin terms (essentially functions manipulating those obects).
 --  Constants can be thought of as the /literals/ of the language. Check "Language.Pirouette.Example" for
 --  a simple example.
+--
+-- Don't forget to also define a 'LanguagePrelude' instance for your @lang@, if you have
+-- no idea what that is, defining an empty instance will use the default
+-- implementatino of @builtinPrelude = M.empty@, which is a fine definition.
 class (LanguageConstrs lang) => LanguageBuiltins lang where
   type BuiltinTypes lang :: *
   type BuiltinTerms lang :: *
   type Constants lang :: *
-
-  -- | Definitions required for built-in types
-  builtinTypeDefinitions ::
-    -- | types which are already defined
-    [(Name, TypeDef lang)] ->
-    -- | additional definitions supporting those
-    [(Name, TypeDef lang)]
-  builtinTypeDefinitions _ = []
-
-builtinTypeDecls :: (LanguageBuiltins lang) => Decls lang -> Decls lang
-builtinTypeDecls m =
-  let defs = flip mapMaybe (Map.toList m) $ \((_, nm), def) -> case def of
-        DTypeDef td -> Just (nm, td)
-        _ -> Nothing
-      newTypeDefs = builtinTypeDefinitions defs
-   in Map.fromList $ do
-        (nm, td@Datatype {destructor, constructors}) <- newTypeDefs
-        [((TypeNamespace, nm), DTypeDef td), ((TermNamespace, destructor), DDestructor nm)]
-          ++ [ ((TermNamespace, constructorName), DConstructor i nm)
-               | (i, (constructorName, _)) <- zip [0 ..] constructors
-             ]
 
 -- | Auxiliary constraint for pretty-printing terms of a given language.
 type LanguagePretty lang =

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -141,7 +141,13 @@ data TypeDef lang = -- | Define a new datatype. For example:
     destructor :: Name,
     constructors :: [(Name, Type lang)]
   }
-  deriving (Eq, Ord, Show, Data)
+  deriving (Ord, Show, Data)
+
+instance (LanguageBuiltins lang) => Eq (TypeDef lang) where
+  -- Equality for datatype definitions should be alpha-equivalence, hence
+  -- we ignore the variables
+  (Datatype k1 _ dest1 cs1) == (Datatype k2 _ dest2 cs2) =
+    k1 == k2 && dest1 == dest2 && cs1 == cs2
 
 -- | Computes the type of the destructor from a 'TypeDef'. For example, let:
 --

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -23,6 +23,7 @@ import Data.Data
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (mapMaybe)
+import Data.Monoid (Sum (..))
 import qualified Data.Set as Set
 import Data.String
 import qualified Data.Text as Text
@@ -52,6 +53,12 @@ instance IsString Name where
 
 instance Pretty Name where
   pretty (Name str i) = pretty str <> maybe mempty pretty i
+
+instance Semigroup Name where
+  (Name n1 u1) <> (Name n2 u2) = Name (n1 <> n2) (fmap getSum $ fmap Sum u1 <> fmap Sum u2)
+
+instance Monoid Name where
+  mempty = Name mempty Nothing
 
 class ToName v where
   toName :: v -> Name

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -67,7 +67,7 @@ defunctionalize defs0 = defs' {prtUODecls = prtUODecls defs' <> typeDecls <> app
 -- The call to 'defunTypes' will pick @Mon@ as a target for defunctionalization,
 -- and will 'tell' an appropriate new declaration for @Monoid!Int@.
 defunTypes ::
-  (LanguagePretty lang, LanguageBuiltins lang) =>
+  (Language lang) =>
   PrtUnorderedDefs lang ->
   (PrtUnorderedDefs lang, M.Map Name (HofsList lang))
 defunTypes defs = runWriter $ traverseDefs defunTypeDef defs
@@ -94,7 +94,7 @@ defunTypes defs = runWriter $ traverseDefs defunTypeDef defs
 -- so we can have a few shortcuts
 defunDtors ::
   forall lang.
-  (LanguagePretty lang, LanguageBuiltins lang) =>
+  (Language lang) =>
   PrtUnorderedDefs lang ->
   PrtUnorderedDefs lang
 defunDtors defs = transformBi f defs
@@ -133,7 +133,7 @@ defunDtors defs = transformBi f defs
 -- * Defunctionalization of functions
 
 defunFuns ::
-  (LanguagePretty lang, Pretty (FunDef lang), LanguageBuiltins lang) =>
+  (Language lang) =>
   PrtUnorderedDefs lang ->
   (PrtUnorderedDefs lang, M.Map Name (HofsList lang))
 defunFuns defs = runWriter $ traverseDefs defunFunDef defs

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -12,13 +12,15 @@
 
 module Pirouette.Transformations.Defunctionalization (defunctionalize) where
 
-import Control.Arrow ((***))
+import Control.Arrow (first, (***))
 import Control.Monad.RWS.Strict
 import Control.Monad.Reader
 import Control.Monad.Writer.Strict
 import Data.Generics.Uniplate.Data
 import Data.List (nub, sortOn)
 import qualified Data.Map as M
+import Data.Maybe
+import qualified Data.Set as S
 import Data.String.Interpolate.IsString
 import qualified Data.Text as T
 import Data.Traversable
@@ -97,36 +99,46 @@ defunDtors ::
   PrtUnorderedDefs lang
 defunDtors defs = transformBi f defs
   where
+    dtorsNames = S.fromList $ mapMaybe getDtorName (M.elems $ prtUODecls defs)
+    getDtorName (DTypeDef Datatype {..}) = Just destructor
+    getDtorName _ = Nothing
+
     f :: Term lang -> Term lang
-    f term
-      | Just UnDestMeta {..} <- runReader (runMaybeT (unDest term)) defs,
-        Datatype {..} <- runReader (prtTypeDefOf undestTypeName) defs =
-        let tyArgs' = map rewriteFunType undestTypeArgs
-            _returnTy = rewriteFunType undestReturnType
-            instantiatedCtors = map ((`SystF.tyInstantiateN` tyArgs') . snd) constructors
-            branches = zipWith (handleBranches undestCasesExtra) instantiatedCtors undestCases
-         in dest $
-              UnDestMeta
-                { undestTypeArgs = tyArgs',
-                  -- , undestReturnType = returnTy
-                  undestCases = branches,
-                  undestCasesExtra = [],
-                  ..
-                }
-    --
-    -- f (SystF.Free (TermSig name) `SystF.App` args)
-    --   | name `S.member` dtorsNames = SystF.Free (TermSig name) `SystF.App` (prefix' <> branches')
-    --   where
-    --     (branches, prefix) = reverse *** reverse $ span SystF.isArg $ reverse args
-    --     tyArgErr tyArg = error $ show name <> ": unexpected TyArg " <> renderSingleLineStr (pretty tyArg)
-    --     prefix' = closurifyTyArgs prefix
-    --     branches' = SystF.argElim tyArgErr (SystF.TermArg . rewriteHofBody . rewriteNestedLamArgs) <$> branches
+    f (SystF.Free (TermSig name) `SystF.App` args)
+      | name `S.member` dtorsNames = SystF.Free (TermSig name) `SystF.App` (prefix' <> branches')
+      where
+        (branches, prefix) = reverse *** reverse $ span SystF.isArg $ reverse args
+        tyArgErr tyArg = error $ show name <> ": unexpected TyArg " <> renderSingleLineStr (pretty tyArg)
+        prefix' = closurifyTyArgs prefix
+        branches' = SystF.argElim tyArgErr (SystF.TermArg . rewriteHofBody . rewriteNestedLamArgs) <$> branches
     f x = x
 
-    handleBranches :: [Arg lang] -> Type lang -> Term lang -> Term lang
-    handleBranches exc (SystF.TyFun _ tyB) (SystF.Lam ann ty t) =
-      SystF.Lam ann (rewriteFunType ty) $ replaceApply (applyFunName ty) $ handleBranches exc tyB t
-    handleBranches exc _ t = t `SystF.appN` exc
+    -- Rewrite the branches of a destructor that have a nested higher order function
+    -- but deliberatly do not rewrite those that are already functions, that will
+    -- be handled by vanilla defunctionalization
+    rewriteNestedLamArgs :: Term lang -> Term lang
+    rewriteNestedLamArgs (SystF.Lam ann ty@SystF.TyApp {} t) =
+      SystF.Lam ann (rewriteFunType ty) (rewriteNestedLamArgs t)
+    rewriteNestedLamArgs (SystF.Lam ann ty t) =
+      SystF.Lam ann ty (rewriteNestedLamArgs t)
+    rewriteNestedLamArgs t = t
+
+    -- Replaces the functional type arguments to the type itself with the corresponding closure types.
+    --
+    -- As an example, consider maybe_Match @(Integer -> Integer) val @(Integer -> Bool) ...
+    -- The @(Integer -> Integer) is replaced by Closure[Integer -> Integer],
+    -- while the @(Integer -> Bool) stays the same.
+    --
+    -- This works under the assumption that
+    -- the datatype type arguments and the match's return type
+    -- are separated by the value argument (the value being inspected).
+    closurifyTyArgs = uncurry (<>) . first (fmap closurifyTyArg) . span SystF.isTyArg
+
+    closurifyTyArg arg@SystF.TermArg {} = arg
+    closurifyTyArg (SystF.TyArg theArg) =
+      SystF.TyArg $ case theArg of
+        SystF.TyFun {} -> closureType theArg
+        _ -> theArg
 
 -- * Defunctionalization of functions
 

--- a/src/Pirouette/Transformations/Monomorphization.hs
+++ b/src/Pirouette/Transformations/Monomorphization.hs
@@ -247,11 +247,11 @@ isSpecArg arg = null bounds
     bounds :: [TyVar lang]
     bounds = filter (isJust . isBound) $ universeBi arg
 
--- | This is the character used to separate the type arguments and the term or type name
+-- | This is the set of characters used when generating specialized names
 --  when monomorphizing. Because we need to be able to test monomorphization, this
 --  is also recognized by the "Language.Pirouette.Example" as a valid part of an identifier
-monoNameSep :: Char
-monoNameSep = '!'
+monoNameSep :: [Char]
+monoNameSep = ['<', '>', '$', '_', '!'] -- TODO: get rid of '!'
 
 -- | Generates a specialized name for a certain amount of type arguments. This
 -- function is trickier than what meets the eye since it must satisfy a homomorphism
@@ -282,7 +282,7 @@ genSpecName tys n0 = combine n0 (map specTypeNames tys)
 argsToStr :: (LanguageBuiltins lang) => [Type lang] -> T.Text
 argsToStr = T.intercalate msep . map f
   where
-    msep = T.pack [monoNameSep]
+    msep = T.pack "$"
 
     f (SystF.Free n `SystF.TyApp` args) =
       nameString (tyBaseName n) <> if null args then mempty else "<" <> argsToStr args <> ">"

--- a/src/Pirouette/Transformations/Monomorphization.hs
+++ b/src/Pirouette/Transformations/Monomorphization.hs
@@ -23,7 +23,6 @@ import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Set as S
 import qualified Data.Text as T
-import Data.Void
 import Debug.Trace
 import Pirouette.Monad
 import Pirouette.Term.Syntax
@@ -204,7 +203,7 @@ executeSpecRequest sr =
             "result:",
             show (pretty res)
           ]
-   in trace str res
+   in res -- trace str res
 
 -- | Takes a description of what needs to be specialized
 -- (a function or a type definition along with specialization args)

--- a/src/Pirouette/Transformations/Monomorphization.hs
+++ b/src/Pirouette/Transformations/Monomorphization.hs
@@ -97,7 +97,7 @@ selectMonoDefs PrtUnorderedDefs {..} =
           | (_, SystF.TyArg tydef) <- selectedDefs0,
             name <- destructor tydef : map fst (constructors tydef)
         ]
-   in M.fromList $ map (snd *** Just) selectedDefs0 ++ associatedNames
+   in M.fromList $ associatedNames <> map (snd *** Just) selectedDefs0
 
 type FunOrTypeDef lang = SystF.Arg (TypeDef lang) (FunDef lang)
 

--- a/src/Pirouette/Transformations/Monomorphization.hs
+++ b/src/Pirouette/Transformations/Monomorphization.hs
@@ -82,6 +82,10 @@ monomorphize defs0 = prune $ go mempty defs0
 --  all definitions that should be monomorphized. It also picks up associated definitions
 --  that should be monomorphized (constructors and destructors), but associates them
 --  with no particular definition.
+--
+--  Moreover, it is important to keep the 'Namespace' in the map, otherwise we might
+--  run into scenarios where a type that has a homonym constructor might not be
+--  monomorphized becase one entry overriden the other in the map.
 selectMonoDefs ::
   forall lang.
   (Language lang) =>

--- a/src/Pirouette/Transformations/Monomorphization.hs
+++ b/src/Pirouette/Transformations/Monomorphization.hs
@@ -179,12 +179,12 @@ specTyApp ::
   Type lang ->
   m (Type lang)
 specTyApp toMono (SystF.TyApp (SystF.Free (TySig name)) tyArgs)
-  | Just (Just someDef) <- name `M.lookup` toMono,
+  | Just mSomeDef <- name `M.lookup` toMono,
     not (null tyArgs),
     all isSpecArg tyArgs = do
     let (specArgs, remainingArgs) = splitAt (length tyArgs) tyArgs
         speccedName = genSpecName specArgs name
-    tell $ pure $ SpecRequest name someDef specArgs
+    tell $ maybe [] (\someDef -> pure $ SpecRequest name someDef specArgs) mSomeDef
     pure $ SystF.Free (TySig speccedName) `SystF.TyApp` remainingArgs
 specTyApp _ x = pure x
 

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -57,7 +57,9 @@ recv :: Solver -> IO SExpr
 recv solver = do
   resp <- hGetLine (getStdout $ process solver)
   case readSExpr resp of
-    Nothing -> fail $ "solver replied with: " ++ resp
+    Nothing -> do
+      rest <- hGetContents (getStdout $ process solver)
+      fail $ "solver replied with:\n" ++ resp ++ "\n" ++ rest
     Just (sexpr, _) -> do
       pid <- unsafeSolverPid solver
       when (debugMode solver && sexpr /= Atom "success") $ do

--- a/tests/unit/Pirouette/Symbolic/ProveSpec.hs
+++ b/tests/unit/Pirouette/Symbolic/ProveSpec.hs
@@ -392,5 +392,5 @@ isUnityTest =
   testGroup
     "isUnity Bug"
     [ testCase "[correct_isUnity v] validate [\\r _ -> r] counter" $
-        execFull (proveAny def isCounter) isUnity condIsUnity `satisfies` isJust
+        execFull (proveAny (optsSolverDebug def) isCounter) isUnity condIsUnity `satisfies` isJust
     ]

--- a/tests/unit/Pirouette/Symbolic/ProveSpec.hs
+++ b/tests/unit/Pirouette/Symbolic/ProveSpec.hs
@@ -392,5 +392,5 @@ isUnityTest =
   testGroup
     "isUnity Bug"
     [ testCase "[correct_isUnity v] validate [\\r _ -> r] counter" $
-        execFull (proveAny (optsSolverDebug def) isCounter) isUnity condIsUnity `satisfies` isJust
+        execFull (proveAny def isCounter) isUnity condIsUnity `satisfies` isJust
     ]

--- a/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
@@ -185,23 +185,17 @@ defuncTestsPoly =
       runTest destructors,
     testCase "Indirect types are updated and typecheck" $
       runTest indirect,
-    -- TODO: I'm marking this as expectFail because I'm aware our defunctionalization
-    -- engine can't handle this, but we really have to address it at some point!
-    expectFail $
-      testCase "Mixed types are updated and typecheck" $
-        runTest mixed
+    testCase "Mixed types are updated and typecheck" $
+      runTest mixed
   ]
   where
     monoDefunc :: PrtUnorderedDefs Ex -> PrtUnorderedDefs Ex
-    monoDefunc =
-      -- defunctionalize .
-      monomorphize
+    monoDefunc = defunctionalize . monomorphize
 
     runTest :: PrtUnorderedDefs Ex -> Assertion
     runTest decls0 =
       case monoDefunc decls0 of
         PrtUnorderedDefs decls -> do
-          print (pretty decls)
           case typeCheckDecls decls of
             Left err -> print (pretty decls) >> assertFailure (show $ pretty err)
             Right _ -> return ()

--- a/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/DefunctionalizationSpec.hs
@@ -193,12 +193,15 @@ defuncTestsPoly =
   ]
   where
     monoDefunc :: PrtUnorderedDefs Ex -> PrtUnorderedDefs Ex
-    monoDefunc = defunctionalize . monomorphize
+    monoDefunc =
+      -- defunctionalize .
+      monomorphize
 
     runTest :: PrtUnorderedDefs Ex -> Assertion
     runTest decls0 =
       case monoDefunc decls0 of
         PrtUnorderedDefs decls -> do
+          print (pretty decls)
           case typeCheckDecls decls of
             Left err -> print (pretty decls) >> assertFailure (show $ pretty err)
             Right _ -> return ()

--- a/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
@@ -96,10 +96,10 @@ tests =
       "specFunApp"
       [ testCase "specFunApp (id @Bool True) == (id@Bool True, [SpecRequest ...])" $
           runWriter (specFunApp (M.singleton "id" $ Just idDef) [term| id @Bool True |])
-            @?= ([term| id!TyBool True |], [SpecRequest "id" idDef [[ty| Bool |]]]),
-        testCase "specFunApp (const @Integer @Bool 42 False) == (const!Integer!Bool 42 False, [SpecRequest ...])" $
+            @?= ([term| id<TyBool> True |], [SpecRequest "id" idDef [[ty| Bool |]]]),
+        testCase "specFunApp (const @Integer @Bool 42 False) == (const<Integer$Bool> 42 False, [SpecRequest ...])" $
           runWriter (specFunApp (M.singleton "const" $ Just constDef) [term| const @Integer @Bool 42 True |])
-            @?= ([term| const!TyInteger!TyBool 42 True |], [SpecRequest "const" constDef [[ty| Integer |], [ty| Bool |]]])
+            @?= ([term| const<TyInteger$TyBool> 42 True |], [SpecRequest "const" constDef [[ty| Integer |], [ty| Bool |]]])
       ],
     testGroup
       "executeSpecRequest"
@@ -138,21 +138,21 @@ either3Def =
 either3Def_Bool_Integer_decls :: Decls Ex
 either3Def_Bool_Integer_decls =
   M.fromList
-    [ ( (TypeNamespace, "Either3!TyBool!TyInteger"),
+    [ ( (TypeNamespace, "Either3<TyBool$TyInteger>"),
         DTypeDef
           Datatype
             { kind = SystF.KTo SystF.KStar SystF.KStar,
               typeVariables = [("c", SystF.KStar)],
-              destructor = "match_Either3!TyBool!TyInteger",
+              destructor = "match_Either3<TyBool$TyInteger>",
               constructors =
-                [ ("Left!TyBool!TyInteger", [ty| all (c : Type) . Bool -> Either3!TyBool!TyInteger c |]),
-                  ("Mid!TyBool!TyInteger", [ty| all (c : Type) . Integer -> Either3!TyBool!TyInteger c |]),
-                  ("Right!TyBool!TyInteger", [ty| all (c : Type) . c -> Either3!TyBool!TyInteger c |])
+                [ ("Left<TyBool$TyInteger>", [ty| all (c : Type) . Bool -> Either3<TyBool$TyInteger> c |]),
+                  ("Mid<TyBool$TyInteger>", [ty| all (c : Type) . Integer -> Either3<TyBool$TyInteger> c |]),
+                  ("Right<TyBool$TyInteger>", [ty| all (c : Type) . c -> Either3<TyBool$TyInteger> c |])
                 ]
             }
       ),
-      ((TermNamespace, "match_Either3!TyBool!TyInteger"), DDestructor "Either3!TyBool!TyInteger"),
-      ((TermNamespace, "Left!TyBool!TyInteger"), DConstructor 0 "Either3!TyBool!TyInteger"),
-      ((TermNamespace, "Mid!TyBool!TyInteger"), DConstructor 1 "Either3!TyBool!TyInteger"),
-      ((TermNamespace, "Right!TyBool!TyInteger"), DConstructor 2 "Either3!TyBool!TyInteger")
+      ((TermNamespace, "match_Either3<TyBool$TyInteger>"), DDestructor "Either3<TyBool$TyInteger>"),
+      ((TermNamespace, "Left<TyBool$TyInteger>"), DConstructor 0 "Either3<TyBool$TyInteger>"),
+      ((TermNamespace, "Mid<TyBool$TyInteger>"), DConstructor 1 "Either3<TyBool$TyInteger>"),
+      ((TermNamespace, "Right<TyBool$TyInteger>"), DConstructor 2 "Either3<TyBool$TyInteger>")
     ]

--- a/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
@@ -57,9 +57,19 @@ fun myList : List Integer
 fun main : Integer = fold @Integer intMonoid myList
 |]
 
+castTy :: Type Ex -> Type Ex
+castTy = id
+
+mkTyApp :: Name -> Type Ex
+mkTyApp n = SystF.Free (TySig n) `SystF.TyApp` []
+
 tests :: [TestTree]
 tests =
-  [ testCase "selectMonoDefs picks the expected defs" $
+  [ testCase "genSpecName is homomorphic" $
+      let tyA = castTy [ty| Maybe (Bool -> Bool) |]
+          tyB = mkTyApp $ genSpecName [castTy [ty| Bool -> Bool |]] "Maybe"
+       in genSpecName [tyA] "f" @?= genSpecName [tyB] "f",
+    testCase "selectMonoDefs picks the expected defs" $
       let ds = selectMonoDefs sampleUDefs
        in sort (M.keys ds)
             @?= sort

--- a/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
+++ b/tests/unit/Pirouette/Transformations/MonomorphizationSpec.hs
@@ -93,11 +93,16 @@ tests =
                 "Monoid",
                 "Mon",
                 "match_Monoid",
-                "fold",
+                "foldMon",
                 "List",
                 "match_List",
                 "Cons",
-                "Nil"
+                "Nil",
+                "Maybe",
+                "match_Maybe",
+                "maybeMonoid",
+                "Nothing",
+                "Just"
               ],
     testCase "isSpecArg forbids type applications" $
       let cases :: [(Type Ex, Bool)]


### PR DESCRIPTION
With the more eager monomorphization, we won't need to handle difficult cases such as `Just @(Int -> Int) (\x -> x + 1)` in the defunctionalizer, anymore! This means we can revert those changes and while doing so, try to simplify that module as much as possible.