### PR TITLE
Use ghc 9.0.2: fixing nixpkgs HLS

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,8 +1,5 @@
 { 
   sources ? import ./sources.nix {},
-
-  # Bring in our pinned nixpkgs, but also brings in iohk's modiied nixpkgs
-  # which contains the precious ghc810420210212 needed for compiling plutus.
   rawpkgs ? import sources.nixpkgs {},
 }:
 { 
@@ -25,7 +22,7 @@
         ormolu
         haskellPackages.cabal-install
         haskellPackages.happy
-        haskell.compiler.ghc8107
+        haskell.compiler.ghc902
         cvc4 # required to run pirouette once its built
      ] ++ lib.optional (stdenv.isLinux) systemd.dev;
 

--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,6 @@ library:
   ghc-options:
     -Wall
     -Wno-orphans
-    -fplugin=StackTrace.Plugin
 
 tests:
   spec:

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -64,7 +64,7 @@ library
       Paths_pirouette
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wno-orphans -fplugin=StackTrace.Plugin
+  ghc-options: -Wall -Wno-orphans
   build-depends:
       QuickCheck
     , ansi-terminal

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -69,8 +69,8 @@ maybeQ :: (Pretty e) => Either e a -> Q a
 maybeQ (Left e) = fail $ show $ pretty e
 maybeQ (Right x) = return x
 
-instance (Lift k, Lift v) => Lift (M.Map k v) where
-  liftTyped m = unsafeTExpCoerce [e|M.fromList $(lift (M.toList m))|]
+instance (Ord k, Lift k, Lift v) => Lift (M.Map k v) where
+  liftTyped m = [||M.fromList $$(liftTyped (M.toList m))||]
 
 quoter :: (String -> Q Exp) -> QuasiQuoter
 quoter quote =

--- a/src/Pirouette/Symbolic/Eval/SMT.hs
+++ b/src/Pirouette/Symbolic/Eval/SMT.hs
@@ -21,6 +21,7 @@ import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
 import Data.Bifunctor (bimap)
+import qualified Data.Kind as K
 import qualified Data.List as List
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
@@ -55,7 +56,7 @@ data UniversalAxiom lang = UniversalAxiom
 --
 --   1. Check whether a path is plausible
 --   2. Check whether a certain property currently holds over a given path
-data SolverProblem lang :: * -> * where
+data SolverProblem lang :: K.Type -> K.Type where
   CheckProperty :: (LanguagePretty lang) => CheckPropertyProblem lang -> SolverProblem lang PruneResult
   CheckPath :: CheckPathProblem lang -> SolverProblem lang Bool
 

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -14,6 +14,7 @@ import Control.Concurrent.MVar
 import Control.Concurrent.QSem
 import Control.Monad
 import Data.Default
+import Data.Kind
 import GHC.Conc (numCapabilities)
 import PureSMT.Process as X
 import PureSMT.SExpr as X
@@ -29,10 +30,10 @@ import System.IO.Unsafe (unsafePerformIO)
 class Solve domain where
   -- | Specifies what is the common domain that is supposed to be shared amongst all calls to
   --  the SMT solver
-  type Ctx domain :: *
+  type Ctx domain :: Type
 
   -- | Specifies a GADT for the problems that we can solve for this domain.
-  type Problem domain :: * -> *
+  type Problem domain :: Type -> Type
 
   -- | How to initialize a solver with the given context;
   initSolver :: Ctx domain -> Solver -> IO ()
@@ -103,7 +104,7 @@ launchAll opts ctx = replicateM nWorkers $ do
     ensurePos :: Int -> Int
     ensurePos n = if n >= 1 then n else error "PureSMT: need a positive, non-zero, amount of workers"
 
--- * Async Stacks
+-- Type Async Stacks
 
 -- | An 'MStack a' is an 'MVar' having a list of 'a's,
 --  which can be popped off the list and pushed back onto it.

--- a/tests/unit/Pirouette/Transformations/EtaExpandSpec.hs
+++ b/tests/unit/Pirouette/Transformations/EtaExpandSpec.hs
@@ -20,7 +20,7 @@ withUnorderedDecls ::
   PrtUnorderedDefs Ex ->
   (forall m. PirouetteReadDefs Ex m => m Assertion) ->
   Assertion
-withUnorderedDecls = flip runReader
+withUnorderedDecls defs f = runReader f defs
 
 samplePrtUnorderedDefs :: PrtUnorderedDefs Ex
 samplePrtUnorderedDefs =


### PR DESCRIPTION
A few commits back we started relying on `haskell-language-server` from `nixpkgs` instead of compiling our own. That lead to issues because it was compiled with ghc 9.0.2 and we were building pirouette with ghc 8.10.7; This PR makes pirouette build with ghc 9.0.2;