### PR TITLE
Rewrite the symbolic evaluation engine denotationally

### DIFF
--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -58,6 +58,7 @@ library
       PureSMT
       PureSMT.Process
       PureSMT.SExpr
+      Supply
   other-modules:
       Paths_pirouette
   autogen-modules:

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -31,6 +31,7 @@ library
       Pirouette.SMT.FromTerm
       Pirouette.SMT.Monadic
       Pirouette.Symbolic.Eval
+      Pirouette.Symbolic.Eval.Anamorphism
       Pirouette.Symbolic.Eval.BranchingHelpers
       Pirouette.Symbolic.Eval.SMT
       Pirouette.Symbolic.Eval.Types

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -33,6 +33,7 @@ library
       Pirouette.Symbolic.Eval
       Pirouette.Symbolic.Eval.Anamorphism
       Pirouette.Symbolic.Eval.BranchingHelpers
+      Pirouette.Symbolic.Eval.Catamorphism
       Pirouette.Symbolic.Eval.SMT
       Pirouette.Symbolic.Eval.Types
       Pirouette.Symbolic.Prover

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -62,6 +62,7 @@ library
       PureSMT.Process
       PureSMT.SExpr
       Supply
+      TreeTest
   other-modules:
       Paths_pirouette
   autogen-modules:

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -34,6 +34,7 @@ library
       Pirouette.Symbolic.Eval.Anamorphism
       Pirouette.Symbolic.Eval.BranchingHelpers
       Pirouette.Symbolic.Eval.Catamorphism
+      Pirouette.Symbolic.Eval.Playground
       Pirouette.Symbolic.Eval.SMT
       Pirouette.Symbolic.Eval.Types
       Pirouette.Symbolic.Prover

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -34,6 +34,7 @@ library
       Pirouette.Symbolic.Eval.Anamorphism
       Pirouette.Symbolic.Eval.BranchingHelpers
       Pirouette.Symbolic.Eval.Catamorphism
+      Pirouette.Symbolic.Eval.Constraints
       Pirouette.Symbolic.Eval.Playground
       Pirouette.Symbolic.Eval.SMT
       Pirouette.Symbolic.Eval.Types

--- a/src/Language/Pirouette/Example/IsUnity.hs
+++ b/src/Language/Pirouette/Example/IsUnity.hs
@@ -65,14 +65,14 @@ listEq :
   forall a .
   (a -> a -> Bool) ->
   List a -> List a -> Bool
-listEq @a eq x0 y0 = 
+listEq @a eq x0 y0 =
   match_List @a x0 @Bool
     (match_List @a y0 @Bool True (\(y : a) (ys : List a) . False))
     (\(x : a) (xs : List a) .
       match_List @a y0 @Bool False (\(y : a) (ys : List a) . and (eq x y) (listEq @a eq xs ys)))
 
 contains : forall a . (a -> Bool) -> List a -> Bool
-contains @a eq x0 = 
+contains @a eq x0 =
   match_List @a x0 @Bool
     False
     (\(x : a) (xs : List a) . or (eq x) (contains @a eq xs))

--- a/src/Pirouette.hs
+++ b/src/Pirouette.hs
@@ -1,9 +1,5 @@
 module Pirouette (module X) where
 
-import Pirouette.Symbolic.Eval.Types as X
-  ( StoppingCondition,
-    SymEvalStatistics (..),
-  )
 import Pirouette.Symbolic.Prover.Runner as X
   ( AssumeProve (..),
     IncorrectnessParams (..),

--- a/src/Pirouette/Monad.hs
+++ b/src/Pirouette/Monad.hs
@@ -16,7 +16,7 @@ import qualified Control.Monad.State.Strict as Strict
 import Data.Data (Data)
 import qualified Data.Map as M
 import qualified Data.Map as Map
-import Data.Maybe (isJust)
+import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as Set
 import ListT.Weighted (WeightedListT)
 import Pirouette.Monad.Maybe
@@ -319,6 +319,10 @@ unDest (SystF.App (SystF.Free (TermSig n)) args) = do
     -- overloading the MonadFail instance, which was helpful for debugging in the past.
     _ -> fail "unDest: Destructor arguments has non-cannonical structure"
 unDest _ = fail "unDest: not an SystF.App"
+
+-- | Same as 'unDest' but crashes if the term is not the application of a destructor.
+unsafeUnDest :: (PirouetteReadDefs lang m) => TermMeta lang meta -> m (UnDestMeta lang meta)
+unsafeUnDest = fmap (fromMaybe (error "unsafeUnDest: not a destructor")) . runMaybeT . unDest
 
 data UnConsMeta lang meta = UnConsMeta
   { unconsTypeName :: TyName,

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -330,7 +330,7 @@ symEvalOneStep t@(R.App hd args) = case hd of
           case c' of
             Left _ -> pure Nothing
             Right (d, _) -> pure $ Just d
-    mayBranches <- lift $ branchesBuiltinTerm @lang builtin translator args
+    mayBranches <- lift $ undefined -- branchesBuiltinTerm @lang builtin translator args
     case mayBranches of
       -- if successful, open all the branches
       Just branches -> asum $

--- a/src/Pirouette/Symbolic/Eval.hs
+++ b/src/Pirouette/Symbolic/Eval.hs
@@ -335,7 +335,7 @@ symEvalOneStep t@(R.App hd args) = case hd of
       -- if successful, open all the branches
       Just branches -> asum $
         flip map branches $ \(SMT.Branch additionalInfo newTerm) -> do
-          lift $ learn additionalInfo
+          lift $ learn undefined --additionalInfo
           consumeFuel
           signalEvaluation
           pure newTerm
@@ -359,23 +359,23 @@ symEvalOneStep t@(R.App hd args) = case hd of
     -- if we have a meta, try to replace it
     cstr <- gets sestConstraint
     case cstr of
-      C.And atomics -> do
-        let findAssignment v (C.Assign w _) = v == w
-            findAssignment _ _ = False
-            findEq v (C.VarEq w _) = v == w
-            findEq _ _ = False
-            -- we need to jump more than one equality,
-            -- hence the involved loop here
-            findLoop v
-              | Just (C.Assign _ tm) <- find (findAssignment v) atomics =
-                Just tm
-              | Just (C.VarEq _ other) <- find (findEq v) atomics =
-                findLoop other
-              | otherwise =
-                Nothing
-        case findLoop vr of
-          Nothing -> justEvaluateArgs
-          Just lp -> signalEvaluation >> pure lp
+      -- C.And atomics -> do
+      --   let findAssignment v (C.Assign w _) = v == w
+      --       findAssignment _ _ = False
+      --       findEq v (C.VarEq w _) = v == w
+      --       findEq _ _ = False
+      --       -- we need to jump more than one equality,
+      --       -- hence the involved loop here
+      --       findLoop v
+      --         | Just (C.Assign _ tm) <- find (findAssignment v) atomics =
+      --           Just tm
+      --         | Just (C.VarEq _ other) <- find (findEq v) atomics =
+      --           findLoop other
+      --         | otherwise =
+      --           Nothing
+      --   case findLoop vr of
+      --     Nothing -> justEvaluateArgs
+      --     Just lp -> signalEvaluation >> pure lp
       _ -> justEvaluateArgs
 
   -- in any other case don't try too hard
@@ -497,8 +497,9 @@ symEvalDestructor t@(R.App hd _args) tyName = do
           -- liftIO $ print mconstr
           case mconstr of
             Nothing -> empty
-            Just constr -> do
-              let countAssigns SMT.Bot = 0
+            Just _constr -> do
+              let constr = undefined
+                  countAssigns SMT.Bot = 0
                   countAssigns (SMT.And atomics) = genericLength $ filter isAssign atomics
                   isAssign SMT.Assign {} = True
                   isAssign _ = False
@@ -535,6 +536,9 @@ moreConstructors n = undefined
 --  modify (\st -> st {sestStatistics = sestStatistics st <> mempty {sestConstructors = n}})
 
 unify :: (LanguageBuiltins lang) => TermMeta lang SymVar -> TermMeta lang SymVar -> Maybe (Constraint lang)
+unify = undefined
+
+{-
 unify (R.App (R.Meta s) []) (R.App (R.Meta r) []) = Just (symVarEq s r)
 unify (R.App (R.Meta s) []) t = Just (s =:= t)
 unify u (R.App (R.Meta s) []) = Just (s =:= u)
@@ -554,6 +558,7 @@ unifyArg :: (LanguageBuiltins lang) => ArgMeta lang SymVar -> ArgMeta lang SymVa
 unifyArg (R.TermArg x) (R.TermArg y) = unify x y
 unifyArg (R.TyArg _) (R.TyArg _) = Just (SMT.And []) -- TODO: unify types too?
 unifyArg _ _ = Nothing
+-}
 
 for2 :: [a] -> [b] -> (a -> b -> c) -> [c]
 for2 as bs f = zipWith f as bs

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -137,7 +137,7 @@ symbolically defs = runST $ do
                         let caseTerm = appExcess (length consArgs) (cases !! consIx) excess
                          in liftedTermAppN' s1 env (termMetaMapUnique (`f` env) s2 caseTerm) consArgs
                 DFunction _ body _ ->
-                  Call (liftedTermAppN s0 env (termToMeta body)) $ evalL args
+                  Call n (liftedTermAppN s0 env (termToMeta body)) $ evalL args
 
     choose :: Supply Int -> AnaEnv lang -> SymVar -> TermSet lang
     choose s env meta = Inst meta $ do

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -1,46 +1,86 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
 module Pirouette.Symbolic.Eval.Anamorphism where
 
-import Control.Applicative
-import Control.Arrow (second)
+import Control.Applicative hiding (Const)
 import Control.Monad
-import Control.Monad.Except
-import Control.Monad.Identity
 import Control.Monad.Reader
-import Control.Monad.State
-import Control.Monad.Writer
-import Control.Parallel.Strategies
-import Data.Foldable
-import Data.List (genericLength)
+import Control.Monad.ST
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
-import qualified Data.Set as S
-import ListT.Weighted (WeightedList)
-import qualified ListT.Weighted as ListT
 import Pirouette.Monad
-import Pirouette.Monad.Maybe
-import qualified Pirouette.SMT.Constraints as C
-import qualified Pirouette.SMT.FromTerm as Tr
-import qualified Pirouette.SMT.Monadic as SMT
-import Pirouette.Symbolic.Eval.SMT
 import Pirouette.Symbolic.Eval.Types as X
 import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.Subst (shift)
 import qualified Pirouette.Term.Syntax.SystemF as SystF
-import qualified PureSMT
-import Supply
+import Supply (Supply)
+import qualified Supply
+
+-- An example:
+--
+-- Let @$l@ denot that @l@ is a symbolic variable, let us explore how the
+-- symbolic evaluation of the following expression would proceed:
+--
+-- > [| map (\x -> x + 1) $l |]
+--
+-- Initially, we see a function call and because we have to work for both
+-- call-by-name and call-by-value languages, we represent that application
+-- lifted to trees:
+--
+-- > Call (\a0 a1 -> [| defOf "map" a0 a1 |]) -- (A) here's the def of map, lifted to inline trees of terms
+-- >      [ [| \x -> x + 1 |] -- (B) infinite evaluation of first argument
+-- >      , [| $l |] -- (C) infinite evaluation of second argument
+-- >      ]
+--
+-- Let's explore each different case in (A), (B) and (C) first and study their
+-- nuances. Starting with (C) as it presents an interesting situation: because the semantics
+-- of our terms, here, is grounded on infinite trees and the type of @$l@ is list of something,
+-- we can't just return @Leaf $l@, intead we should expand one layer of @$l@ and return that:
+--
+-- > [| $l |] = Inst "$l" [ Cons "Nil" []
+-- >                      , Learn (AddVars ["$l0", "$l1"]) (Cons "Cons" [ [| $l0 |], [| $l1 |] ])
+-- >                      ]
+--
+-- Naturally, the evaluation of @[| $l1 |]@ will continue ad-infinitum, but because
+-- we're in a lazy language, the thunks will remain unevaluated until we desire their result.
+-- The evaluation of @[| $l0 |]@ is more interesting. Depending on its type if will remain
+-- a symbolic variable forever: say its type is a builtin integer. There's no inductive structure
+-- the anamorphism can use to expand it any further.
+--
+-- Looking at (B) next, we see a closure. Once again, we can't just return that closure. It denotes
+-- a function that takes a term and returns that term plus one. Lited to trees, it will take a tree
+-- and return that three with all its leaves added to one.
+--
+-- Type-wise, in Pirouette, the @Lam "x" (+ "x" 1)@ closure denotes a function of type:
+--
+-- > Term m -> Term m
+--
+-- It's denotation is: @\t -> subst "x" t (+ "x" 1)@ and given a term, it returns a term.
+-- In the symbolic setting, we will have trees of terms instead, yielding a denotation in:
+--
+-- > Tree (Term m) -> Tree (Term m)
+--
+-- It gets a little bureaucratic but only relies on the monadic multiplication and
+-- distributive law between @Tree@ and @Term@:
+--
+-- > [| \x -> x + 1 |] = Closure $ \(tx :: Tree (Term Sym)) ->
+-- >    let body' = termMetaMap mkMeta "x + 1" :: Term (Tree (Term Sym))
+-- >     in termJoin <$> termMetaDistr (SystF.app body' (SystF.TermArg . pure $ tx))
+--
+-- In reality we never really handle lambdas (TODO: why not? can't we start?) because
+-- we get defunctionalized terms.
 
 -- | A 'Tree' which denotes a set of pairs of @(monoid, leaf)@
-data Tree monoid b
+data Tree lang monoid b
   = Empty
   | Leaf b
-  | Learn monoid (Tree monoid b)
-  | Union [Tree monoid b]
+  | Learn monoid (Tree lang monoid b)
+  | Union [Tree lang monoid b]
   | -- | A function call, in an untyped setting, can be seen as something
     -- that takes a list of terms and returns a term (in fact, that's the type of
     -- the partially applied 'SystF.App' constructor!).
@@ -52,30 +92,40 @@ data Tree monoid b
     -- > [Tree (Term lang)] -> Tree (Term lang)
     --
     -- Finally, because we want a monadic structure, we'll go polymorphic:
-    forall a. Call ([Tree monoid a] -> Tree monoid b) [Tree monoid a]
+    forall a. Call ([Tree lang monoid a] -> Tree lang monoid b) [Tree lang monoid a]
   | -- | Destructors are also a little tricky, because in reality, we need to
     -- consume the motive until /at least/ the first constructor is found, that
     -- is the only guaranteed way to make any progress.
-    forall a. Dest (Tree monoid a) ((ConstructorInfo, [Tree monoid a]) -> Tree monoid b)
+    forall a. Dest (Tree lang monoid a) ((ConstructorInfo, [Tree lang monoid a]) -> Tree lang monoid b)
+  | -- | Naturally, to be able to effectively build a value with potentially infinite children,
+    -- we also need torepresent constructors
+    Cons ConstructorInfo [Tree lang monoid b]
+  | -- | A Builtin is also something that we're stuck on until we decide to
+    -- consume this tree
+    Bin (BuiltinTerms lang) [Tree lang monoid b]
+  | Const (Constants lang)
 
-instance Show (Tree monoid a) where
+instance Show (Tree lang monoid a) where
   show _ = "Tree"
 
-data ConstructorInfo = ConstructorInfo TyName Int
+data ConstructorInfo = ConstructorInfo TyName Name Int
 
-instance Functor (Tree m) where
+instance Functor (Tree lang m) where
   fmap _ Empty = Empty
-  fmap f (Learn str t) = Learn str $ fmap f t
+  fmap _ (Const c) = Const c
   fmap f (Leaf x) = Leaf $ f x
+  fmap f (Union ts) = Union $ map (fmap f) ts
+  fmap f (Learn str t) = Learn str $ fmap f t
   fmap f (Call ts as) = Call (fmap f . ts) as
   fmap f (Dest motive worlds) = Dest motive (fmap f . worlds)
-  fmap f (Union ts) = Union $ map (fmap f) ts
+  fmap f (Cons c args) = Cons c (map (fmap f) args)
+  fmap f (Bin c args) = Bin c (map (fmap f) args)
 
-instance Applicative (Tree m) where
+instance Applicative (Tree lang m) where
   pure = Leaf
   (<*>) = ap
 
-instance Alternative (Tree m) where
+instance Alternative (Tree lang m) where
   empty = Empty
 
   Empty <|> u = u
@@ -85,15 +135,18 @@ instance Alternative (Tree m) where
   t <|> Union u = Union (t : u)
   t <|> u = Union [t, u]
 
-instance Monad (Tree m) where
+instance Monad (Tree lang m) where
   Empty >>= _ = Empty
+  Const c >>= _ = Const c
   Leaf x >>= f = f x
+  Union ts >>= f = Union $ map (>>= f) ts
   Learn str t >>= f = Learn str (t >>= f)
   Call body args >>= f = Call (f <=< body) args
   Dest motive worlds >>= f = Dest motive (f <=< worlds)
-  Union ts >>= f = Union $ map (>>= f) ts
+  Cons c args >>= f = Cons c $ map (>>= f) args
+  Bin c args >>= f = Bin c $ map (>>= f) args
 
-treeDistr :: (Traversable t) => t (Tree m a) -> Tree m (t a)
+treeDistr :: (Traversable t) => t (Tree lang m a) -> Tree lang m (t a)
 treeDistr = sequenceA
 
 data Env lang = Env
@@ -102,105 +155,130 @@ data Env lang = Env
   }
 
 data DeltaEnv lang
-  = DeclSymVars [(SymVar, Type lang)]
-  | Unify (TermMeta lang SymVar) (TermMeta lang SymVar)
+  = DeclSymVars (M.Map SymVar (Type lang))
+  | Assign SymVar (TermMeta lang SymVar)
 
-type SymTree lang a = Tree (DeltaEnv lang) a
+type SymTree lang a = Tree lang (DeltaEnv lang) a
 
--- | For ana to really be infinite, it should never return a term that
---  is only a metavariable; if that's ever the case, we should open that term
---  up in all of its constructors.
-ana ::
-  (LanguagePretty lang, LanguageSymEval lang) =>
-  PrtUnorderedDefs lang ->
-  Supply SymVar ->
-  TermMeta lang SymVar ->
-  SymTree lang (TermMeta lang SymVar)
-ana defs s t@(hd `SystF.App` args) =
-  case hd of
-    SystF.Free (Builtin bin) ->
-      undefined
-    SystF.Free (TermSig n) ->
-      case prtDefOf TermNamespace n `runReader` defs of
-        DTypeDef _ -> error "Can't evaluate typedefs"
-        DConstructor _ _ -> justEvaluateArgs
-        DDestructor tyName -> anaDestructor defs s (unsafeUnDest t `runReader` defs)
-        DFunction _ body _ ->
-          undefined
-    SystF.Meta vr -> do
-      undefined -- here we'll need typing info and subsequently expanding all cases!
-
-    -- in any other case, don't try too hard
-    _ -> justEvaluateArgs
-  where
-    justEvaluateArgs = undefined
-ana _ _ t@SystF.Lam {} =
-  -- Note that our AST only represents terms in normal form, hence
-  -- > App (Lam ...) ...
-  -- Never appears, so beta-reduction does not enter the game here.
-  -- We could try going into the lambda an evaluating its body
-  -- considering its variable to be symbolic, but this seems to win us
-  -- nothing. For example, if we are evaluating:
-  -- > map (\x -> x + 1) l
-  -- then going into (\x -> x + 1) would only lead to reconstructing it,
-  -- the real evaluation work happens on the definition of 'map'.
-  -- We have decided to *not* go under lambdas.
-  pure t
-ana _ _ t@SystF.Abs {} =
-  error $
-    unlines
-      [ "Can't symbolically evaluate polymorphic terms",
-        "Did you not monomorphize/defunctionalize before?",
-        "term: " ++ renderSingleLineStr (pretty t)
-      ]
-
--- | Expanding a destructor is reasonably easy, but bureaucratic. The first
-anaDestructor ::
+symbolically ::
   forall lang.
   (LanguagePretty lang, LanguageSymEval lang) =>
   PrtUnorderedDefs lang ->
-  Supply SymVar ->
-  UnDestMeta lang SymVar ->
+  TermMeta lang SymVar ->
   SymTree lang (TermMeta lang SymVar)
-anaDestructor defs s (UnDestMeta _ _tyName _tyParams motive _ cases excess) =
-  let (s0 : ss) = Supply.split s
-   in Dest (ana defs s0 motive) $ \(ConstructorInfo _ consIx, consArgs) ->
-        let caseTerm = appExcess (length consArgs) (cases !! consIx) excess
-         in liftedTermAppN defs (ss !! consIx) caseTerm consArgs
+symbolically defs = runST $ do
+  s0 <- Supply.newSupply (SymVar $ Name "s" (Just 0)) nextSymVar
+  return (ana s0 M.empty)
   where
-    -- If we're destructing a 'List Int' into a 'Unit -> Int', the term in question
-    -- can be something like:
-    -- > caseTerm = \x xs u -> x
-    -- and @excess@ above will have a list of the excess arguments. A call to
-    -- @appExcess 2 caseTerm excess@ will preserve the first 2 lambdas, then apply
-    -- the excess arguments to the term, getting rid of them.
-    -- This was mostly copied from Pirouette.Transformations.Term.removeExcessiveDestrArgs
-    appExcess :: Int -> TermMeta lang SymVar -> [ArgMeta lang SymVar] -> TermMeta lang SymVar
-    appExcess n (SystF.Lam ann ty t) = SystF.Lam ann ty . appExcess (n - 1) t . map (SystF.argMap id (shift 1))
-    appExcess 0 t = SystF.appN t
-    appExcess _ _ = error "Non-well formed destructor case"
+    nextSymVar (SymVar n) = SymVar (n {nameUnique = Just $ maybe 1 succ (nameUnique n)})
 
-mkMeta :: meta -> TermMeta lang meta
-mkMeta m = SystF.Meta m `SystF.App` []
+    -- For ana to really be infinite, it should never return a term that
+    -- is only a metavariable; if that's ever the case, we should open that term
+    -- up in all of its constructors.
+    ana ::
+      Supply SymVar ->
+      M.Map SymVar (Type lang) ->
+      TermMeta lang SymVar ->
+      SymTree lang (TermMeta lang SymVar)
+    ana s env t@(hd `SystF.App` args) =
+      let sRec : sRest = Supply.split s
+          args' = zipWith (`ana` env) sRest (mapMaybe SystF.fromArg args)
+          rec = ana sRec env
+       in case hd of
+            SystF.Bound ann _ -> error $ "Can't evaluate bound variable: " ++ show ann
+            SystF.Free Bottom -> Empty
+            SystF.Free (Constant c) -> Const c
+            SystF.Free (Builtin bin) -> Bin bin args'
+            SystF.Free (TermSig n) ->
+              case prtDefOf TermNamespace n `runReader` defs of
+                DTypeDef _ -> error "Can't evaluate typedefs"
+                DConstructor ix tyName -> Cons (ConstructorInfo tyName n ix) args'
+                DDestructor _ -> anaDestructor s env (unsafeUnDest t `runReader` defs)
+                DFunction _ body _ -> Call (liftedTermAppN (termToMeta body) >=> rec) args'
+            SystF.Meta vr -> anaMeta sRec env vr
+    ana _ _ t@SystF.Lam {} =
+      error $
+        unlines
+          [ "Can't symbolically evaluate lambdas",
+            "Did you not defunctionalize before?",
+            "term: " ++ renderSingleLineStr (pretty t)
+          ]
+    ana _ _ t@SystF.Abs {} =
+      error $
+        unlines
+          [ "Can't symbolically evaluate polymorphic terms",
+            "Did you not monomorphize before?",
+            "term: " ++ renderSingleLineStr (pretty t)
+          ]
 
--- This is where most of the heavy lifting is done
+    -- Symbolically evaluating a match/case is trivial. Let @$m@ be the symbolic
+    -- evaluation of the motive, we can lift the case semantics to being a function
+    -- that given a constructor and its arguments, yields a new tree:
+    --
+    -- > forall a. Dest (Tree monoid a) ((ConstructorInfo, [Tree monoid a]) -> Tree monoid b)
+    anaDestructor ::
+      Supply SymVar ->
+      M.Map SymVar (Type lang) ->
+      UnDestMeta lang SymVar ->
+      SymTree lang (TermMeta lang SymVar)
+    anaDestructor s env (UnDestMeta _ _tyName _tyParams motive _ cases excess) =
+      let (s0 : ss) = Supply.split s
+       in Dest (ana s0 env motive) $ \(ConstructorInfo _ _ consIx, consArgs) ->
+            let caseTerm = appExcess (length consArgs) (cases !! consIx) excess
+             in liftedTermAppN caseTerm consArgs >>= ana (ss !! consIx) env
+      where
+        -- If we're destructing a 'List Int' into a 'Unit -> Int', the term in question
+        -- can be something like:
+        -- > caseTerm = \x xs u -> x
+        -- and @excess@ above will have a list of the excess arguments. A call to
+        -- @appExcess 2 caseTerm excess@ will preserve the first 2 lambdas, then apply
+        -- the excess arguments to the term, getting rid of them.
+        -- This was mostly copied from Pirouette.Transformations.Term.removeExcessiveDestrArgs
+        appExcess :: Int -> TermMeta lang SymVar -> [ArgMeta lang SymVar] -> TermMeta lang SymVar
+        appExcess n (SystF.Lam ann ty t) = SystF.Lam ann ty . appExcess (n - 1) t . map (SystF.argMap id (shift 1))
+        appExcess 0 t = SystF.appN t
+        appExcess _ _ = error "Non-well formed destructor case"
+
+    anaMeta ::
+      Supply SymVar ->
+      M.Map SymVar (Type lang) ->
+      SymVar ->
+      SymTree lang (TermMeta lang SymVar)
+    anaMeta s env target =
+      case env M.! target of
+        -- If the symvar is of type that we have a definition for, we can "eta-expand" it!
+        -- Sat @target@ is of type @Either a b@, then:
+        -- @symeval target == symeval (Left fresh) ++ symeval (Right fresh)@
+        SystF.TyApp (SystF.Free (TySig tyName)) tyArgs ->
+          let Datatype _ _ _ consList = prtTypeDefOf tyName `runReader` defs
+           in Union $
+                for2 (Supply.split s) consList $ \s' consNameTy ->
+                  let (s'', delta, symbCons) = mkSymbolicCons s' (map typeFromMeta tyArgs) consNameTy
+                      env' = M.unionWithKey (\k _ _ -> error $ "Conflicting names for: " ++ show k) env delta
+                   in Learn (DeclSymVars delta) $
+                        Learn (Assign target symbCons) $
+                          ana s'' env' symbCons
+        -- If this symvar is of any other type, we're done. This is as far as we can go.
+        _ -> pure $ SystF.termPure $ SystF.Meta target
+
+-- | Applies a term to tree arguments, yielding a tree of results.
 liftedTermAppN ::
   forall lang.
   (LanguagePretty lang, LanguageSymEval lang) =>
-  PrtUnorderedDefs lang ->
-  Supply SymVar ->
   TermMeta lang SymVar ->
   [SymTree lang (TermMeta lang SymVar)] ->
   SymTree lang (TermMeta lang SymVar)
-liftedTermAppN defs s body args = do
+liftedTermAppN body args = do
   let body' = termMetaMap (pure . mkMeta) body
       args' = map (SystF.TermArg . mkMeta) args
       -- The resulting term is a term that has trees which
       -- contain further terms down its leaves
       res :: TermMeta lang (SymTree lang (TermMeta lang SymVar))
       res = SystF.appN body' args'
-  aux <- termJoin <$> termMetaDistr res
-  ana defs s aux
+  termJoin <$> termMetaDistr res
+  where
+    mkMeta :: meta -> TermMeta lang meta
+    mkMeta m = SystF.Meta m `SystF.App` []
 
 termMetaDistr :: (Applicative f) => TermMeta lang (f a) -> f (TermMeta lang a)
 termMetaDistr (SystF.Lam ann ty t) = SystF.Lam ann (typeUnsafeCastMeta ty) <$> termMetaDistr t
@@ -216,21 +294,6 @@ termMetaDistr (SystF.App hd args) = SystF.App <$> doVar hd <*> traverse doArgs a
     doVar (SystF.Free b) = pure $ SystF.Free b
     doVar (SystF.Bound ann i) = pure $ SystF.Bound ann i
 
-{-
-This is how we open up the term in all of its possiblities, whenever we're met with
-a single metavariable. It really shouldn't be the concern of the evaluation of
-destructors:
-
-        for3 ss consList cases $ \s' consNameTy caseTerm ->
-          let (s'', delta, symbCons) = mkSymbolicCons s' (map typeFromMeta tyParams) consNameTy
-              SystF.App _ symbArgs = symbCons
-           in do
-              t' <- stagedMotive
-              Learn delta $
-                Learn (Unify t' symbCons) $
-                  ana defs s'' $ (caseTerm `SystF.appN` symbArgs) `SystF.appN` excess
--}
-
 -- | Given a supply of names, a list of type arguments and a constructor name/type pair
 -- we construct:
 -- 1. a new supply of names, to be further used
@@ -244,7 +307,7 @@ mkSymbolicCons ::
   Supply SymVar ->
   [Type lang] ->
   (Name, Type lang) ->
-  (Supply SymVar, DeltaEnv lang, TermMeta lang SymVar)
+  (Supply SymVar, M.Map SymVar (Type lang), TermMeta lang SymVar)
 mkSymbolicCons sup tyParams (consName, consTy) =
   let instantiatedTy = SystF.tyInstantiateN consTy tyParams
       (consArgs, _) = SystF.tyFunArgs instantiatedTy
@@ -256,7 +319,7 @@ mkSymbolicCons sup tyParams (consName, consTy) =
           ( map (SystF.TyArg . typeToMeta) tyParams
               ++ symbArgs
           )
-   in (sup', DeclSymVars svars, symbCons)
+   in (sup', M.fromList svars, symbCons)
 
 freshSymVars :: Supply SymVar -> [Type lang] -> (Supply SymVar, [(SymVar, Type lang)])
 freshSymVars s [] = (s, [])
@@ -266,6 +329,9 @@ freshSymVars s tys =
     (s' : ss) ->
       let vars = zipWith (\i ty -> (Supply.supplyValue i, ty)) ss tys
        in (s', vars)
+
+for2 :: [a] -> [b] -> (a -> b -> c) -> [c]
+for2 as bs f = zipWith f as bs
 
 for3 :: [a] -> [b] -> [c] -> (a -> b -> c -> d) -> [d]
 for3 as bs cs f = zipWith3 f as bs cs

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -173,6 +173,8 @@ symbolically defs = runST $ do
                         Learn (Assign target symbCons) $
                           ana s'' env' symbCons
         -- If this symvar is of any other type, we're done. This is as far as we can go.
+        -- Maybe we need a dedicated constructor for this. We should mark that this is really stuck
+        -- and there's nothing else to do.
         _ -> pure $ SystF.termPure $ SystF.Meta target
 
 -- | Applies a term to tree arguments, yielding a tree of results.

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -11,7 +11,6 @@ import Control.Monad.Reader
 import Control.Monad.ST
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
-import Debug.Trace
 import Pirouette.Monad hiding (WHNFConstant)
 import Pirouette.Symbolic.Eval.Types
 import Pirouette.Term.Syntax
@@ -122,8 +121,8 @@ symbolically defs = runST $ do
        in case hd of
             SystF.Bound ann _ -> error $ "Bound has no spine" ++ show ann
             SystF.Meta meta -> f s env meta
-            SystF.Free (Builtin _bin) -> undefined
-            SystF.Free (Constant _x) -> undefined
+            SystF.Free (Builtin bin) -> Spine $ WHNFBuiltin bin $ evalL args
+            SystF.Free (Constant x) -> Spine $ WHNFConst x
             SystF.Free Bottom -> Spine WHNFBottom
             SystF.Free (TermSig n) ->
               case prtDefOf TermNamespace n `runReader` defs of

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 module Pirouette.Symbolic.Eval.Anamorphism where
 
 import Control.Applicative
+import Control.Arrow (second)
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Identity
@@ -27,23 +30,45 @@ import qualified Pirouette.SMT.Monadic as SMT
 import Pirouette.Symbolic.Eval.SMT
 import Pirouette.Symbolic.Eval.Types as X
 import Pirouette.Term.Syntax
+import Pirouette.Term.Syntax.Subst (shift)
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import qualified PureSMT
 import Supply
 
 -- | A 'Tree' which denotes a set of pairs of @(monoid, leaf)@
-data Tree monoid leaf
+data Tree monoid b
   = Empty
-  | Leaf leaf
-  | Learn monoid (Tree monoid leaf)
-  | Union [Tree monoid leaf]
-  | forall a. Call ([Tree monoid a] -> Tree monoid leaf) [Tree monoid a]
+  | Leaf b
+  | Learn monoid (Tree monoid b)
+  | Union [Tree monoid b]
+  | -- | A function call, in an untyped setting, can be seen as something
+    -- that takes a list of terms and returns a term (in fact, that's the type of
+    -- the partially applied 'SystF.App' constructor!).
+    --
+    -- > [Term lang] -> Term lang
+    --
+    -- The trick here consists in lifting those functions to trees:
+    --
+    -- > [Tree (Term lang)] -> Tree (Term lang)
+    --
+    -- Finally, because we want a monadic structure, we'll go polymorphic:
+    forall a. Call ([Tree monoid a] -> Tree monoid b) [Tree monoid a]
+  | -- | Destructors are also a little tricky, because in reality, we need to
+    -- consume the motive until /at least/ the first constructor is found, that
+    -- is the only guaranteed way to make any progress.
+    forall a. Dest (Tree monoid a) ((ConstructorInfo, [Tree monoid a]) -> Tree monoid b)
+
+instance Show (Tree monoid a) where
+  show _ = "Tree"
+
+data ConstructorInfo = ConstructorInfo TyName Int
 
 instance Functor (Tree m) where
   fmap _ Empty = Empty
   fmap f (Learn str t) = Learn str $ fmap f t
   fmap f (Leaf x) = Leaf $ f x
   fmap f (Call ts as) = Call (fmap f . ts) as
+  fmap f (Dest motive worlds) = Dest motive (fmap f . worlds)
   fmap f (Union ts) = Union $ map (fmap f) ts
 
 instance Applicative (Tree m) where
@@ -65,6 +90,7 @@ instance Monad (Tree m) where
   Leaf x >>= f = f x
   Learn str t >>= f = Learn str (t >>= f)
   Call body args >>= f = Call (f <=< body) args
+  Dest motive worlds >>= f = Dest motive (f <=< worlds)
   Union ts >>= f = Union $ map (>>= f) ts
 
 treeDistr :: (Traversable t) => t (Tree m a) -> Tree m (t a)
@@ -75,25 +101,34 @@ data Env lang = Env
     envConstraint :: [Constraint lang]
   }
 
+data DeltaEnv lang
+  = DeclSymVars [(SymVar, Type lang)]
+  | Unify (TermMeta lang SymVar) (TermMeta lang SymVar)
+
+type SymTree lang a = Tree (DeltaEnv lang) a
+
+-- | For ana to really be infinite, it should never return a term that
+--  is only a metavariable; if that's ever the case, we should open that term
+--  up in all of its constructors.
 ana ::
-  (Pretty meta, LanguagePretty lang, LanguageSymEval lang) =>
+  (LanguagePretty lang, LanguageSymEval lang) =>
   PrtUnorderedDefs lang ->
-  Supply Name ->
-  TermMeta lang meta ->
-  Tree (Env lang) (TermMeta lang meta)
+  Supply SymVar ->
+  TermMeta lang SymVar ->
+  SymTree lang (TermMeta lang SymVar)
 ana defs s t@(hd `SystF.App` args) =
   case hd of
     SystF.Free (Builtin bin) ->
-      _
+      undefined
     SystF.Free (TermSig n) ->
       case prtDefOf TermNamespace n `runReader` defs of
         DTypeDef _ -> error "Can't evaluate typedefs"
         DConstructor _ _ -> justEvaluateArgs
         DDestructor tyName -> anaDestructor defs s (unsafeUnDest t `runReader` defs)
         DFunction _ body _ ->
-          _
+          undefined
     SystF.Meta vr -> do
-      _
+      undefined -- here we'll need typing info and subsequently expanding all cases!
 
     -- in any other case, don't try too hard
     _ -> justEvaluateArgs
@@ -119,18 +154,116 @@ ana _ _ t@SystF.Abs {} =
         "term: " ++ renderSingleLineStr (pretty t)
       ]
 
+-- | Expanding a destructor is reasonably easy, but bureaucratic. The first
 anaDestructor ::
-  (Pretty meta, LanguagePretty lang, LanguageSymEval lang) =>
+  forall lang.
+  (LanguagePretty lang, LanguageSymEval lang) =>
   PrtUnorderedDefs lang ->
-  Supply Name ->
-  UnDestMeta lang meta ->
-  Tree (Env lang) (TermMeta lang meta)
-anaDestructor defs s (UnDestMeta _ tyName tyParams motive tyRes cases excess) =
-  let (Datatype _ _ _ consList) = prtTypeDefOf tyName `runReader` defs
-      tMotive = ana defs s motive
-   in Union $
-        for2 consList cases $ \(consName, constTy) -> do
-          _
+  Supply SymVar ->
+  UnDestMeta lang SymVar ->
+  SymTree lang (TermMeta lang SymVar)
+anaDestructor defs s (UnDestMeta _ _tyName _tyParams motive _ cases excess) =
+  let (s0 : ss) = Supply.split s
+   in Dest (ana defs s0 motive) $ \(ConstructorInfo _ consIx, consArgs) ->
+        let caseTerm = appExcess (length consArgs) (cases !! consIx) excess
+         in liftedTermAppN defs (ss !! consIx) caseTerm consArgs
+  where
+    -- If we're destructing a 'List Int' into a 'Unit -> Int', the term in question
+    -- can be something like:
+    -- > caseTerm = \x xs u -> x
+    -- and @excess@ above will have a list of the excess arguments. A call to
+    -- @appExcess 2 caseTerm excess@ will preserve the first 2 lambdas, then apply
+    -- the excess arguments to the term, getting rid of them.
+    -- This was mostly copied from Pirouette.Transformations.Term.removeExcessiveDestrArgs
+    appExcess :: Int -> TermMeta lang SymVar -> [ArgMeta lang SymVar] -> TermMeta lang SymVar
+    appExcess n (SystF.Lam ann ty t) = SystF.Lam ann ty . appExcess (n - 1) t . map (SystF.argMap id (shift 1))
+    appExcess 0 t = SystF.appN t
+    appExcess _ _ = error "Non-well formed destructor case"
 
-for2 :: [a] -> [b] -> (a -> b -> c) -> [c]
-for2 as bs f = zipWith f as bs
+mkMeta :: meta -> TermMeta lang meta
+mkMeta m = SystF.Meta m `SystF.App` []
+
+-- This is where most of the heavy lifting is done
+liftedTermAppN ::
+  forall lang.
+  (LanguagePretty lang, LanguageSymEval lang) =>
+  PrtUnorderedDefs lang ->
+  Supply SymVar ->
+  TermMeta lang SymVar ->
+  [SymTree lang (TermMeta lang SymVar)] ->
+  SymTree lang (TermMeta lang SymVar)
+liftedTermAppN defs s body args = do
+  let body' = termMetaMap (pure . mkMeta) body
+      args' = map (SystF.TermArg . mkMeta) args
+      -- The resulting term is a term that has trees which
+      -- contain further terms down its leaves
+      res :: TermMeta lang (SymTree lang (TermMeta lang SymVar))
+      res = SystF.appN body' args'
+  aux <- termJoin <$> termMetaDistr res
+  ana defs s aux
+
+--    go :: (Show m) => [Tree (Term m)] -> Tree (Term m)
+--    go targs = do
+--      let body = cast $ gamma M.! r
+--      res <- fmap termJoin $ termMetaDistr $ body `appN` (map meta targs)
+--      ana gamma res
+
+termMetaDistr :: (Applicative f) => TermMeta lang (f a) -> f (TermMeta lang a)
+termMetaDistr = undefined
+
+{-
+This is how we open up the term in all of its possiblities, whenever we're met with
+a single metavariable. It really shouldn't be the concern of the evaluation of
+destructors:
+
+        for3 ss consList cases $ \s' consNameTy caseTerm ->
+          let (s'', delta, symbCons) = mkSymbolicCons s' (map typeFromMeta tyParams) consNameTy
+              SystF.App _ symbArgs = symbCons
+           in do
+              t' <- stagedMotive
+              Learn delta $
+                Learn (Unify t' symbCons) $
+                  ana defs s'' $ (caseTerm `SystF.appN` symbArgs) `SystF.appN` excess
+-}
+
+-- | Given a supply of names, a list of type arguments and a constructor name/type pair
+-- we construct:
+-- 1. a new supply of names, to be further used
+-- 2. a delta to the environment, declaring the symbolic variables with their appropriate types
+-- 3. a term consisting of the constructor applied to these symbolic arguments.
+--
+-- For example, @mkSymbolicCons s ["Int"] ("Cons", "all a . a -> List a -> List a")@
+-- will return a new supply, a @DeclSymVar [("vx", "Int"), ("vxs", "List Int")]@
+-- and a term @Cons $vx $vxs@.
+mkSymbolicCons ::
+  Supply SymVar ->
+  [Type lang] ->
+  (Name, Type lang) ->
+  (Supply SymVar, DeltaEnv lang, TermMeta lang SymVar)
+mkSymbolicCons sup tyParams (consName, consTy) =
+  let instantiatedTy = SystF.tyInstantiateN consTy tyParams
+      (consArgs, _) = SystF.tyFunArgs instantiatedTy
+      (sup', svars) = freshSymVars sup consArgs
+      symbArgs = map (SystF.TermArg . (`SystF.App` []) . SystF.Meta . fst) svars
+      symbCons =
+        SystF.App
+          (SystF.Free $ TermSig consName)
+          ( map (SystF.TyArg . typeToMeta) tyParams
+              ++ symbArgs
+          )
+   in (sup', DeclSymVars svars, symbCons)
+
+freshSymVars :: Supply SymVar -> [Type lang] -> (Supply SymVar, [(SymVar, Type lang)])
+freshSymVars s [] = (s, [])
+freshSymVars s tys =
+  case take (length tys + 1) (Supply.split s) of
+    [] -> error "impossible: take (n+1) of infinite list is non-nil"
+    (s' : ss) ->
+      let vars = zipWith (\i ty -> (Supply.supplyValue i, ty)) ss tys
+       in (s', vars)
+
+for3 :: [a] -> [b] -> [c] -> (a -> b -> c -> d) -> [d]
+for3 as bs cs f = zipWith3 f as bs cs
+
+secondM :: (Functor m) => (b -> m c) -> (a, b) -> m (a, c)
+secondM f (x, y) = (x,) <$> f y

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -124,12 +124,12 @@ symbolically defs = runST $ do
             SystF.Meta meta -> f s env meta
             SystF.Free (Builtin _bin) -> undefined
             SystF.Free (Constant _x) -> undefined
-            SystF.Free Bottom -> Spine (SystF.App (SystF.Free Bottom) [])
+            SystF.Free Bottom -> Spine WHNFBottom
             SystF.Free (TermSig n) ->
               case prtDefOf TermNamespace n `runReader` defs of
                 DTypeDef _ -> error "TypeDef has no spine"
-                DConstructor _ix _tyName ->
-                  Spine $ SystF.App (SystF.Free $ TermSig n) $ map (SystF.TermArg . termMeta) $ evalL args
+                DConstructor ix tyName ->
+                  Spine $ WHNFCotr (ConstructorInfo tyName n ix) $ evalL args
                 DDestructor _ ->
                   let UnDestMeta _ _tyName _tyParams motive _ cases excess = unsafeUnDest t0 `runReader` defs
                       s1 : s2 : _ = ss

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Pirouette.Symbolic.Eval.Anamorphism where
+
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Except
+import Control.Monad.Identity
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Writer
+import Control.Parallel.Strategies
+import Data.Foldable
+import Data.List (genericLength)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as S
+import ListT.Weighted (WeightedList)
+import qualified ListT.Weighted as ListT
+import Pirouette.Monad
+import Pirouette.Monad.Maybe
+import qualified Pirouette.SMT.Constraints as C
+import qualified Pirouette.SMT.FromTerm as Tr
+import qualified Pirouette.SMT.Monadic as SMT
+import Pirouette.Symbolic.Eval.SMT
+import Pirouette.Symbolic.Eval.Types as X
+import Pirouette.Term.Syntax
+import qualified Pirouette.Term.Syntax.SystemF as SystF
+import qualified PureSMT
+import Supply
+
+-- | A 'Tree' which denotes a set of pairs of @(monoid, leaf)@
+data Tree monoid leaf
+  = Empty
+  | Leaf leaf
+  | Learn monoid (Tree monoid leaf)
+  | Union [Tree monoid leaf]
+  | forall a. Call ([Tree monoid a] -> Tree monoid leaf) [Tree monoid a]
+
+instance Functor (Tree m) where
+  fmap _ Empty = Empty
+  fmap f (Learn str t) = Learn str $ fmap f t
+  fmap f (Leaf x) = Leaf $ f x
+  fmap f (Call ts as) = Call (fmap f . ts) as
+  fmap f (Union ts) = Union $ map (fmap f) ts
+
+instance Applicative (Tree m) where
+  pure = Leaf
+  (<*>) = ap
+
+instance Alternative (Tree m) where
+  empty = Empty
+
+  Empty <|> u = u
+  t <|> Empty = t
+  Union t <|> Union u = Union (t ++ u)
+  Union t <|> u = Union (u : t)
+  t <|> Union u = Union (t : u)
+  t <|> u = Union [t, u]
+
+instance Monad (Tree m) where
+  Empty >>= _ = Empty
+  Leaf x >>= f = f x
+  Learn str t >>= f = Learn str (t >>= f)
+  Call body args >>= f = Call (f <=< body) args
+  Union ts >>= f = Union $ map (>>= f) ts
+
+treeDistr :: (Traversable t) => t (Tree m a) -> Tree m (t a)
+treeDistr = sequenceA
+
+data Env lang = Env
+  { envSymVars :: [(SymVar, Type lang)],
+    envConstraint :: [Constraint lang]
+  }
+
+ana ::
+  (Pretty meta, LanguagePretty lang, LanguageSymEval lang) =>
+  PrtUnorderedDefs lang ->
+  Supply Name ->
+  TermMeta lang meta ->
+  Tree (Env lang) (TermMeta lang meta)
+ana defs s t@(hd `SystF.App` args) =
+  case hd of
+    SystF.Free (Builtin bin) ->
+      _
+    SystF.Free (TermSig n) ->
+      case prtDefOf TermNamespace n `runReader` defs of
+        DTypeDef _ -> error "Can't evaluate typedefs"
+        DConstructor _ _ -> justEvaluateArgs
+        DDestructor tyName -> anaDestructor defs s (unsafeUnDest t `runReader` defs)
+        DFunction _ body _ ->
+          _
+    SystF.Meta vr -> do
+      _
+
+    -- in any other case, don't try too hard
+    _ -> justEvaluateArgs
+  where
+    justEvaluateArgs = undefined
+ana _ _ t@SystF.Lam {} =
+  -- Note that our AST only represents terms in normal form, hence
+  -- > App (Lam ...) ...
+  -- Never appears, so beta-reduction does not enter the game here.
+  -- We could try going into the lambda an evaluating its body
+  -- considering its variable to be symbolic, but this seems to win us
+  -- nothing. For example, if we are evaluating:
+  -- > map (\x -> x + 1) l
+  -- then going into (\x -> x + 1) would only lead to reconstructing it,
+  -- the real evaluation work happens on the definition of 'map'.
+  -- We have decided to *not* go under lambdas.
+  pure t
+ana _ _ t@SystF.Abs {} =
+  error $
+    unlines
+      [ "Can't symbolically evaluate polymorphic terms",
+        "Did you not monomorphize/defunctionalize before?",
+        "term: " ++ renderSingleLineStr (pretty t)
+      ]
+
+anaDestructor ::
+  (Pretty meta, LanguagePretty lang, LanguageSymEval lang) =>
+  PrtUnorderedDefs lang ->
+  Supply Name ->
+  UnDestMeta lang meta ->
+  Tree (Env lang) (TermMeta lang meta)
+anaDestructor defs s (UnDestMeta _ tyName tyParams motive tyRes cases excess) =
+  let (Datatype _ _ _ consList) = prtTypeDefOf tyName `runReader` defs
+      tMotive = ana defs s motive
+   in Union $
+        for2 consList cases $ \(consName, constTy) -> do
+          _
+
+for2 :: [a] -> [b] -> (a -> b -> c) -> [c]
+for2 as bs f = zipWith f as bs

--- a/src/Pirouette/Symbolic/Eval/Anamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Anamorphism.hs
@@ -7,7 +7,6 @@
 
 module Pirouette.Symbolic.Eval.Anamorphism where
 
-import Control.Applicative hiding (Const)
 import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.ST
@@ -77,7 +76,7 @@ import qualified Supply
 
 symbolically ::
   forall lang.
-  (LanguagePretty lang, LanguageSymEval lang) =>
+  (Language lang) =>
   PrtUnorderedDefs lang ->
   TermMeta lang SymVar ->
   SymTree lang (TermMeta lang SymVar)
@@ -179,7 +178,7 @@ symbolically defs = runST $ do
 -- | Applies a term to tree arguments, yielding a tree of results.
 liftedTermAppN ::
   forall lang.
-  (LanguagePretty lang, LanguageSymEval lang) =>
+  (Language lang) =>
   TermMeta lang SymVar ->
   [SymTree lang (TermMeta lang SymVar)] ->
   SymTree lang (TermMeta lang SymVar)
@@ -202,7 +201,7 @@ liftedTermAppN body args = do
     termMetaDistr :: (Applicative f) => TermMeta lang (f a) -> f (TermMeta lang a)
     termMetaDistr (SystF.Lam ann ty t) = SystF.Lam ann (typeUnsafeCastMeta ty) <$> termMetaDistr t
     termMetaDistr (SystF.Abs ann ki t) = SystF.Abs ann ki <$> termMetaDistr t
-    termMetaDistr (SystF.App hd args) = SystF.App <$> doVar hd <*> traverse doArgs args
+    termMetaDistr (SystF.App hd args0) = SystF.App <$> doVar hd <*> traverse doArgs args0
       where
         doArgs ::
           (Applicative f) =>

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -88,8 +88,8 @@ catamorphism defs opts = map (uncurry path) . go def
     goWHNF st (Inst m (Just ts)) = goWHNF st ts
     goWHNF st (Learn delta ts) =
       case learn delta st of
-        Nothing -> empty
-        Just st' -> goWHNF st' ts
+        Just st' | sestAssignments st' < maxAssignments opts -> goWHNF st' ts
+        _ -> empty
     goWHNF st (Call f args) = goWHNF st (f args)
     goWHNF st (Dest f x) = do
       (st', res) <- goWHNF st x

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -77,7 +77,7 @@ catamorphism defs opts = map (uncurry path) . concatMap inject . cataWHNF def
       let worlds = map (concatMap inject . cataWHNF st) args
        in flip map worlds $ \xs ->
             let (sts, args') = unzip xs
-             in (mconcat sts, buildTerm hd args')
+             in (if null sts then st else mconcat sts, buildTerm hd args')
 
     buildTerm :: WHNFTermHead lang -> [TermMeta lang SymVar] -> TermMeta lang SymVar
     buildTerm (WHNFCotr (ConstructorInfo _ n _)) args = SystF.App (SystF.Free $ TermSig n) (map SystF.TermArg args)

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -111,7 +111,9 @@ catamorphism defs opts = map (uncurry path) . concatMap inject . cataWHNF def
     cataSpine s0 (Dest worlds motive) = do
       (s1, (hd, args)) <- cataSpine s0 motive
       case hd of
-        WHNFCotr ci -> cataSpine s1 (worlds (ci, map Next args))
+        WHNFCotr ci ->
+          let info = unlines ["Destructing: " ++ show (pretty hd), "With: " ++ renderSingleLineStr (pretty args)]
+           in trace info $ cataSpine s1 (worlds (ci, map Next args))
         _ -> error "Type error: destructing something that is not a constructor!"
     -- TODO: add something to LanguageSymEval to do call by value. See
     -- issues #137 and #138 for more

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -1,1 +1,192 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
 module Pirouette.Symbolic.Eval.Catamorphism where
+
+import Control.Applicative hiding (Const)
+import Control.Monad
+import Control.Monad.Except
+import Control.Monad.Identity
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Writer
+import Control.Parallel.Strategies
+import Data.Default
+import Data.Foldable hiding (toList)
+import Data.List (genericLength)
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as S
+import ListT.Weighted (WeightedList)
+import qualified ListT.Weighted as ListT
+import Pirouette.Monad hiding (WHNFResult (..))
+import Pirouette.Monad.Maybe
+import qualified Pirouette.SMT.Constraints as C
+import qualified Pirouette.SMT.FromTerm as Tr
+import qualified Pirouette.SMT.Monadic as SMT
+import Pirouette.Symbolic.Eval.SMT
+import Pirouette.Symbolic.Eval.Types as X
+import Pirouette.Term.Syntax
+import qualified Pirouette.Term.Syntax.SystemF as R
+import qualified Pirouette.Term.Syntax.SystemF as SystF
+import qualified PureSMT
+
+data SymEvalSolvers lang = SymEvalSolvers
+  { -- | Check whether a path is plausible
+    solvePathProblem :: CheckPathProblem lang -> Bool,
+    -- | Check whether a certain property currently holds over a given path
+    solvePropProblem :: CheckPropertyProblem lang -> PruneResult
+  }
+
+data SymEvalEnv lang = SymEvalEnv
+  { seeDefs :: PrtOrderedDefs lang,
+    seeSolvers :: SymEvalSolvers lang,
+    seeOptions :: Options
+  }
+
+data WHNF lang a
+  = WHNFConstructor ConstructorInfo [SymTree lang a]
+  | WHNFConstant (Constants lang)
+  | WHNFOther a
+
+catamorphism ::
+  forall lang.
+  (LanguagePretty lang, LanguageSymEval lang) =>
+  SymEvalEnv lang ->
+  SymTree lang (TermMeta lang SymVar) ->
+  [TermMeta lang SymVar]
+catamorphism env = concatMap whnfToTerm . cataWHNF def
+  where
+    -- sharedSolve is here to hint to GHC not to create more than one pool
+    -- of SMT solvers, which could happen if sharedSolve were inlined.
+    -- TODO: Write a test to check that only one SMT pool is actually created over
+    --       multiple calls to runSymEvalWorker.
+    {-# NOINLINE sharedSolve #-}
+    sharedSolve :: SolverProblem lang res -> res
+    sharedSolve = PureSMT.solveOpts (optsPureSMT $ seeOptions env) (mkSolverCtx $ seeDefs env)
+
+    solve :: CheckPathProblem lang -> Bool
+    solve = sharedSolve . CheckPath
+
+    -- Cata WHNF will lazily search for the first WHNF of the tree
+    cataWHNF ::
+      SymEvalSt lang ->
+      SymTree lang a ->
+      [WHNF lang a]
+    cataWHNF st (Cons ci args) = return $ WHNFConstructor ci args
+    cataWHNF st (Const c) = return $ WHNFConstant c
+    cataWHNF st (Leaf t) = return $ WHNFOther t
+    -- TODO: add something to language symeval to decide whether to run this
+    -- in call-by-name/value or some mix the user might want.
+    -- for now, we're just going on call-by-name:
+    cataWHNF st (Call f xs) = cataWHNF st (f xs)
+    cataWHNF st (Union trees) = concatMap (cataWHNF st) trees
+    cataWHNF st (Dest motif cases) = do
+      motif' <- cataWHNF st motif
+      case motif' of
+        WHNFConstructor ci args -> cataWHNF st (cases (ci, args))
+        _ -> error "Type error!"
+    cataWHNF st (Learn delta t) =
+      case learn delta st of
+        Just st' | sestAssignments st' <= maxAssignments (seeOptions env) -> cataWHNF st' t
+        _ -> empty
+    cataWHNF st (Bin b args) = undefined
+
+    whnfToTerm :: WHNF lang (TermMeta lang SymVar) -> [TermMeta lang SymVar]
+    whnfToTerm (WHNFConstructor ci args) = do
+      -- TODO: seems like we have to thread state through or re-structure the whole function;
+      -- without a 'SymEvalSt' we can't recursively call cataWHNF. In fact, we might have
+      -- the need for a synchronization point here anyway; say we have the following WHNF:
+      --
+      -- > WHNFConstructor "Tuple2"
+      -- >   [ { (ca , ra) , (ca', ra') } -- here are SymTrees, written as a set of (Constraint,Res)
+      -- >   , { (cb , rb) }
+      -- >   ]
+      -- > ===>
+      -- > { (ca && cb , Tuple2 ca cb) , (ca' && cb , Tuple2 ca' cb) }
+      --
+      -- CH: Doesn't this suggest the anamorphism should be doing this branching so we
+      -- never have to come back up?
+      args' <- mapM _ args
+      return $ mkConsApp (ciCtorName ci) args'
+    whnfToTerm (WHNFConstant t) = return $ mkConstant t
+    whnfToTerm (WHNFOther t) = return t
+
+-- return $ fmap (mkConsApp (ciCtorName ci)) args'
+
+learn :: DeltaEnv lang -> SymEvalSt lang -> Maybe (SymEvalSt lang)
+learn = undefined
+
+mkConsApp :: Name -> [TermMeta lang SymVar] -> TermMeta lang SymVar
+mkConsApp n args = SystF.App (SystF.Free (TermSig n)) $ map SystF.TermArg args
+
+mkConstant :: Constants lang -> TermMeta lang SymVar
+mkConstant c = SystF.App (SystF.Free (Constant c)) []
+
+pathDistr :: [Path lang res] -> Path lang [res]
+pathDistr = foldl' combineOne emptyPath
+  where
+    emptyPath :: Path lang [res]
+    emptyPath = undefined
+
+    -- mappends things like constraint, etc...
+    combineOne :: Path lang [res] -> Path lang res -> Path lang [res]
+    combineOne = undefined
+
+-- * Auxiliar Defs
+
+mkSolverCtx :: (SMT.LanguageSMT lang) => PrtOrderedDefs lang -> SolverSharedCtx lang
+mkSolverCtx defs =
+  let decls = prtDecls defs
+      dependencyOrder = prtDepOrder defs
+      definedTypes = mapMaybe (R.argElim (lkupTypeDefOf decls) (const Nothing)) dependencyOrder
+      allFns = mapMaybe (R.argElim (const Nothing) (lkupFunDefOf decls)) dependencyOrder
+      fns = mapMaybe (\(n, fd) -> (n,) <$> SMT.supportedUninterpretedFunction fd) allFns
+   in SolverSharedCtx definedTypes fns
+  where
+    lkupTypeDefOf decls name = case M.lookup (TypeNamespace, name) decls of
+      Just (DTypeDef tdef) -> Just (name, tdef)
+      _ -> Nothing
+
+    lkupFunDefOf decls name = case M.lookup (TermNamespace, name) decls of
+      Just (DFunDef fdef) -> Just (name, fdef)
+      _ -> Nothing
+
+{-
+data L a where
+  L :: forall a b . ([b] -> [b]) -> (b -> a) -> L a
+
+toList :: L a -> [a]
+toList (L xs f) = map f (xs [])
+
+fromList :: [a] -> L a
+fromList xs = L (xs ++) id
+
+singletonL :: a -> L a
+singletonL a = L (a:) id
+
+instance Functor L where
+  fmap f (L x fs) = L x (f . fs)
+
+-- | Difference lists for efficient concats, but we also want efficient maps,
+-- so we'll coyoneda this monster in the actual type we use: 'L'
+newtype L0 a = L0 {unL0 :: [a] -> [a]}
+
+singletonL0 :: a -> L0 a
+singletonL0 = L0 . (:)
+
+emptyL0 :: L0 a
+emptyL0 = L0 id
+
+consL0 :: a -> L0 a -> L0 a
+consL0 x xs = L0 $ (x :) . unL0 xs
+
+cat2 :: L0 a -> L0 a -> L0 a
+L0 f `cat2` L0 g = L0 (f . g)
+
+concatL0 :: [L0 a] -> L0 a
+concatL0 = foldl cat2 emptyL0
+-}

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -109,11 +109,11 @@ catamorphism defs opts = map (uncurry path) . concatMap inject . cataWHNF def
     cataSpine s0 (Next x) =
       concatMap (uncurry cataSpine) (cataTree s0 $ unTermSet x)
     cataSpine s0 (Dest worlds motive) = do
-      (s1, (hd, args)) <- cataSpine s0 motive
+      (s1, (hd, args)) <- cataWHNF s0 motive
       case hd of
         WHNFCotr ci ->
           let info = unlines ["Destructing: " ++ show (pretty hd), "With: " ++ renderSingleLineStr (pretty args)]
-           in trace info $ cataSpine s1 (worlds (ci, map Next args))
+           in trace info $ cataSpine s1 (worlds (ci, args))
         _ -> error "Type error: destructing something that is not a constructor!"
     -- TODO: add something to LanguageSymEval to do call by value. See
     -- issues #137 and #138 for more

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -113,6 +113,10 @@ catamorphism env = concatMap whnfToTerm . cataWHNF def
       --
       -- CH: Doesn't this suggest the anamorphism should be doing this branching so we
       -- never have to come back up?
+      --
+      -- VM: Actually; it's not really a state monad that we need and should avoid it at all costs.
+      -- We can evaluate args, below, in parallel, we just have to wait for the return values
+      -- then compute the foldM of the path constraints before returning
       args' <- mapM _ args
       return $ mkConsApp (ciCtorName ci) args'
     whnfToTerm (WHNFConstant t) = return $ mkConstant t

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -1,0 +1,1 @@
+module Pirouette.Symbolic.Eval.Catamorphism where

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -80,7 +80,7 @@ catamorphism defs opts = map (uncurry path) . concatMap inject . cataWHNF def
              in (mconcat sts, buildTerm hd args')
 
     buildTerm :: WHNFTermHead lang -> [TermMeta lang SymVar] -> TermMeta lang SymVar
-    buildTerm (WHNFCotr (ConstructorInfo n _ _)) args = SystF.App (SystF.Free $ TermSig n) (map SystF.TermArg args)
+    buildTerm (WHNFCotr (ConstructorInfo _ n _)) args = SystF.App (SystF.Free $ TermSig n) (map SystF.TermArg args)
     buildTerm _ _ = error "not yet implemented"
 
     cataWHNF ::

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -74,13 +74,14 @@ catamorphism defs opts = map (uncurry path) . concatMap inject . cataWHNF def
 
     inject :: (SymEvalSt lang, (WHNFTermHead lang, [TermSet lang])) -> [(SymEvalSt lang, TermMeta lang SymVar)]
     inject (st, (hd, args)) =
-      let worlds = map (concatMap inject . cataWHNF st) args
+      let worlds = traverse (concatMap inject . cataWHNF st) args
        in flip map worlds $ \xs ->
             let (sts, args') = unzip xs
              in (if null sts then st else mconcat sts, buildTerm hd args')
 
     buildTerm :: WHNFTermHead lang -> [TermMeta lang SymVar] -> TermMeta lang SymVar
-    buildTerm (WHNFCotr (ConstructorInfo _ n _)) args = SystF.App (SystF.Free $ TermSig n) (map SystF.TermArg args)
+    buildTerm (WHNFCotr (ConstructorInfo _ n _)) args =
+      SystF.App (SystF.Free $ TermSig n) (map SystF.TermArg args)
     buildTerm _ _ = error "not yet implemented"
 
     cataWHNF ::

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -93,6 +93,9 @@ catamorphism env = concatMap whnfToTerm . cataWHNF def
       case learn delta st of
         Just st' | sestAssignments st' <= maxAssignments (seeOptions env) -> cataWHNF st' t
         _ -> empty
+    -- Let's not worry about builtins at all right now. With plain inductive types
+    -- we can already do so much to check whether this monster is going to work before
+    -- refining the interface to evaluating builtins in LanguageSymEval
     cataWHNF st (Bin b args) = undefined
 
     whnfToTerm :: WHNF lang (TermMeta lang SymVar) -> [TermMeta lang SymVar]

--- a/src/Pirouette/Symbolic/Eval/Catamorphism.hs
+++ b/src/Pirouette/Symbolic/Eval/Catamorphism.hs
@@ -56,7 +56,7 @@ catamorphism ::
   PrtUnorderedDefs lang ->
   Options ->
   TermSet lang ->
-  [Path lang WHNF]
+  [Path lang WHNFTerm]
 catamorphism defs opts = map (uncurry path) . go def
   where
     orderedDefs = elimEvenOddMutRec defs
@@ -72,7 +72,7 @@ catamorphism defs opts = map (uncurry path) . go def
     solve :: CheckPathProblem lang -> Bool
     solve = sharedSolve . CheckPath
 
-    go :: SymEvalSt lang -> TermSet lang -> [(SymEvalSt lang, WHNF)]
+    go :: SymEvalSt lang -> TermSet lang -> [(SymEvalSt lang, WHNFTerm)]
     go st ts = do
       (st', res) <- goWHNF st ts
       case res of
@@ -82,7 +82,7 @@ catamorphism defs opts = map (uncurry path) . go def
           (sts, args) <- combineArgs st' <$> traverse (go st') ts'
           return (sts, WHNFLayer (WHNFCotr ci args))
 
-    goWHNF :: SymEvalSt lang -> TermSet lang -> [(SymEvalSt lang, Either SymVar (WHNFTerm (TermSet lang)))]
+    goWHNF :: SymEvalSt lang -> TermSet lang -> [(SymEvalSt lang, Either SymVar (WHNFLayer (TermSet lang)))]
     goWHNF st (Union tss) = tss >>= goWHNF st
     goWHNF st (Inst m Nothing) = return (st, Left m)
     goWHNF st (Inst m (Just ts)) = goWHNF st ts
@@ -90,7 +90,7 @@ catamorphism defs opts = map (uncurry path) . go def
       case learn delta st of
         Just st' | sestAssignments st' < maxAssignments opts -> goWHNF st' ts
         _ -> empty
-    goWHNF st (Call f args) = goWHNF st (f args)
+    goWHNF st (Call _ f args) = goWHNF st (f args)
     goWHNF st (Dest f x) = do
       (st', res) <- goWHNF st x
       case res of

--- a/src/Pirouette/Symbolic/Eval/Constraints.hs
+++ b/src/Pirouette/Symbolic/Eval/Constraints.hs
@@ -1,0 +1,150 @@
+{-# HLINT ignore "Collapse lambdas" #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+module Pirouette.Symbolic.Eval.Constraints where
+
+import Control.Arrow ((&&&))
+import Control.Monad
+import Data.Default
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Data.Tuple (swap)
+import Pirouette.Monad
+import Pirouette.SMT.Base
+import Pirouette.SMT.FromTerm
+import Pirouette.Term.Syntax
+import qualified Pirouette.Term.Syntax.SystemF as SystF
+import Prettyprinter hiding (Pretty (..))
+import qualified PureSMT
+
+data Constraints lang meta = Constraints
+  { -- | Represents the set of productive symbolic variable assignments we know of.
+    -- Productive in the sense that we will always have at least one constructor
+    -- on the rhs.
+    csAssignments :: M.Map meta (TermMeta lang meta),
+    -- | Represents the symbolic variable equivalences we know of. Satisfies the invariant
+    -- that if @M.lookup v csmetaEq == Just v'@, then @v' < v@ (lexicographically)
+    csMetaEq :: M.Map meta meta,
+    -- | And any potential native constraint we might need.
+    csNative :: [PureSMT.SExpr]
+  }
+
+-- | TODO: If is often the case that we will start seeing constraints that look like:
+--
+--  > s0 := Suc $s2
+--  > s1 := Suc $s2
+--  > s2 := Zero
+--
+--  Whereas what we actually wanted is something like:
+--
+--  > s0 := Suc Zero
+--  > s1 ~~ s0
+--  > s2 ~~ s0
+--
+--  Which encodes the very same information and would give a much more meaningful
+compress :: (Ord meta, LanguageBuiltins lang) => Constraints lang meta -> Constraints lang meta
+compress Constraints {..} = undefined
+
+-- let invLkup = M.fromListWith S.union $ map (snd &&& S.singleton . fst) $ M.toList csAssignments
+--  in _
+
+instance (Ord meta) => Semigroup (Constraints lang meta) where
+  s1 <> s2 =
+    Constraints
+      (csAssignments s1 <> csAssignments s2)
+      (csMetaEq s1 <> csMetaEq s2)
+      (csNative s1 <> csNative s2)
+
+instance (Ord meta) => Monoid (Constraints lang meta) where
+  mempty = def
+
+instance Default (Constraints lang meta) where
+  def = Constraints M.empty M.empty []
+
+instance (LanguagePretty lang, Pretty meta) => Pretty (Constraints lang meta) where
+  pretty Constraints {..} =
+    vsep $
+      map (uncurry prettyAssignment) (M.toList csAssignments)
+        ++ map (uncurry prettyMetaEq) (M.toList csMetaEq)
+        ++ map prettyNative csNative
+    where
+      prettyAssignment v t = pretty v <+> pretty ":=" <+> pretty t
+      prettyMetaEq v u = pretty v <+> pretty "~~" <+> pretty u
+      prettyNative n = pretty (show n)
+
+-- | Attempts to unify two terms in an environment given by a current known set
+--  of constraints. Returns @Nothing@ when the terms can't be unified.
+unifyWith ::
+  (Pretty meta, Ord meta, Language lang) =>
+  Constraints lang meta ->
+  TermMeta lang meta ->
+  TermMeta lang meta ->
+  Maybe (Constraints lang meta)
+unifyWith cs (SystF.App (SystF.Meta v) []) u = unifyMetaWith cs v u
+unifyWith cs v (SystF.App (SystF.Meta u) []) = unifyMetaWith cs u v
+unifyWith cs (SystF.App hdT argsT) (SystF.App hdU argsU) = do
+  guard (hdT == hdU)
+  iterateM cs $ zipWith (\x y -> \cs' -> unifyArgWith cs' x y) argsT argsU
+  where
+    iterateM :: (Monad m) => a -> [a -> m a] -> m a
+    iterateM a [] = return a
+    iterateM a (f : fs) = f a >>= flip iterateM fs
+unifyWith _ t u =
+  error $
+    "unifyWith:\n"
+      ++ unlines (map (renderSingleLineStr . pretty) [t, u])
+
+-- | Attempts to unify a metavariable with a term; will perform any potential lookup
+--  that is needed. WARNING: no occurs-check is performed, if the variable occurs within
+--  the term this function will loop. For our particular use case we don't need to occurs
+--  check since we'll only ever attempt to unify terms that have generated metavariables.
+unifyMetaWith ::
+  (Pretty meta, Ord meta, Language lang) =>
+  Constraints lang meta ->
+  meta ->
+  TermMeta lang meta ->
+  Maybe (Constraints lang meta)
+unifyMetaWith cs v u
+  -- First we check whether @v@ is actually equal to anything else
+  | Just t <- M.lookup v (csAssignments cs) = unifyWith cs t u
+  -- If not, we check whether v is equivalent to some other smaller metavariable
+  | Just v' <- M.lookup v (csMetaEq cs) = unifyMetaWith cs v' u
+  | otherwise = Just $ unifyNewMetaWith cs v u
+
+-- | Like 'unifyMetaWith', but assumes that the 'meta' in question is not
+--  known by our current constraints.
+unifyNewMetaWith ::
+  (Pretty meta, Ord meta, Language lang) =>
+  Constraints lang meta ->
+  meta ->
+  TermMeta lang meta ->
+  Constraints lang meta
+unifyNewMetaWith cs@Constraints {..} v (SystF.App (SystF.Meta u) [])
+  | v == u = cs
+  | Just t <- M.lookup u csAssignments = cs {csAssignments = M.insert v t csAssignments}
+  | Just u' <- M.lookup u csMetaEq = unifyNewMetaWith cs v (SystF.App (SystF.Meta u') [])
+  | otherwise = cs {csMetaEq = M.insert (max v u) (min v u) csMetaEq}
+unifyNewMetaWith cs v u =
+  cs {csAssignments = M.insert v u (csAssignments cs)}
+
+unifyArgWith ::
+  (Pretty meta, Ord meta, Language lang) =>
+  Constraints lang meta ->
+  ArgMeta lang meta ->
+  ArgMeta lang meta ->
+  Maybe (Constraints lang meta)
+unifyArgWith cs (SystF.TermArg x) (SystF.TermArg y) = unifyWith cs x y
+unifyArgWith cs (SystF.TyArg _) (SystF.TyArg _) = Just cs -- TODO: unify types too? I don't think so
+unifyArgWith _ _ _ = Nothing
+
+-- * Translating to SMT
+
+constraintsToSExpr ::
+  (LanguageSMT lang, ToSMT meta, PirouetteReadDefs lang m) =>
+  S.Set Name ->
+  Constraints lang meta ->
+  TranslatorT m PureSMT.SExpr
+constraintsToSExpr = undefined

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -23,7 +23,7 @@ fun add : Nat -> Nat -> Nat
 |]
 
 opts :: Options
-opts = def {maxAssignments = 5}
+opts = def {maxAssignments = 1}
 
 x :: [Path Ex (TermMeta Ex SymVar)]
 x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -23,7 +23,7 @@ fun add : Nat -> Nat -> Nat
 |]
 
 opts :: Options
-opts = def {maxAssignments = 2}
+opts = def {maxAssignments = 1}
 
 x :: [Path Ex (TermMeta Ex SymVar)]
 x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -23,7 +23,7 @@ fun add : Nat -> Nat -> Nat
 |]
 
 opts :: Options
-opts = def {maxAssignments = 1}
+opts = def {maxAssignments = 2}
 
 x :: [Path Ex (TermMeta Ex SymVar)]
 x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Pirouette.Symbolic.Eval.Playground where
+
+import Data.Default
+import Language.Pirouette.Example
+import Pirouette.Monad
+import Pirouette.Symbolic.Eval.Anamorphism
+import Pirouette.Symbolic.Eval.Catamorphism
+import Pirouette.Symbolic.Eval.Types
+import Pirouette.Term.Syntax
+
+defs :: PrtUnorderedDefs Ex
+defs =
+  [prog|
+data Nat
+  = Zero : Nat
+  | Suc : Nat -> Nat
+  destructor Nat_match
+
+fun add : Nat -> Nat -> Nat
+  = \(n : Nat) (m : Nat) . Nat_match n @Nat m (\sn : Nat . Suc (add sn m))
+|]
+
+opts :: Options
+opts = def {maxAssignments = 2}
+
+x :: [Path Ex (TermMeta Ex SymVar)]
+x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n n |])
+
+xio :: IO ()
+xio = mapM_ (\p -> putStrLn "Path:" >> putStrLn (prettyIndent p)) x
+  where
+    prettyIndent =
+      unlines
+        . map ("  " ++)
+        . lines
+        . show
+        . pretty

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -23,10 +23,10 @@ fun add : Nat -> Nat -> Nat
 |]
 
 opts :: Options
-opts = def {maxAssignments = 2}
+opts = def {maxAssignments = 1}
 
 x :: [Path Ex (TermMeta Ex SymVar)]
-x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n n |])
+x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])
 
 xio :: IO ()
 xio = mapM_ (\p -> putStrLn "Path:" >> putStrLn (prettyIndent p)) x

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -18,14 +18,14 @@ data Nat
   | Suc : Nat -> Nat
   destructor Nat_match
 
-fun add : Nat -> Nat -> Nat
-  = \(n : Nat) (m : Nat) . Nat_match n @Nat m (\sn : Nat . Suc (add sn m))
+add : Nat -> Nat -> Nat
+add n m = Nat_match n @Nat m (\sn : Nat . Suc (add sn m))
 |]
 
 opts :: Options
 opts = def {maxAssignments = 1}
 
-x :: [Path Ex (TermMeta Ex SymVar)]
+x :: [Path Ex WHNF]
 x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])
 
 xio :: IO ()

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -23,7 +23,7 @@ fun add : Nat -> Nat -> Nat
 |]
 
 opts :: Options
-opts = def {maxAssignments = 2}
+opts = def {maxAssignments = 5}
 
 x :: [Path Ex (TermMeta Ex SymVar)]
 x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -23,7 +23,7 @@ add n m = Nat_match n @Nat m (\sn : Nat . Suc (add sn m))
 |]
 
 opts :: Options
-opts = def {maxAssignments = 1}
+opts = def {maxAssignments = 5}
 
 x :: [Path Ex WHNF]
 x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -20,13 +20,16 @@ data Nat
 
 add : Nat -> Nat -> Nat
 add n m = Nat_match n @Nat m (\sn : Nat . Suc (add sn m))
+
+isEven : Integer -> Bool
+isEven n = if @Bool n == 0 then True else (if @Bool n == 1 then False else isEven (n - 2))
 |]
 
 opts :: Options
 opts = def {maxAssignments = 1}
 
-x :: [Path Ex WHNFTerm]
-x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])
+x :: [Path Ex (WHNFTerm Ex)]
+x = catamorphism defs opts (symbolically defs [term| \(n : Integer) . isEven n |])
 
 xio :: IO ()
 xio = mapM_ (\p -> putStrLn "Path:" >> putStrLn (prettyIndent p)) x

--- a/src/Pirouette/Symbolic/Eval/Playground.hs
+++ b/src/Pirouette/Symbolic/Eval/Playground.hs
@@ -23,9 +23,9 @@ add n m = Nat_match n @Nat m (\sn : Nat . Suc (add sn m))
 |]
 
 opts :: Options
-opts = def {maxAssignments = 5}
+opts = def {maxAssignments = 1}
 
-x :: [Path Ex WHNF]
+x :: [Path Ex WHNFTerm]
 x = catamorphism defs opts (symbolically defs [term| \(n : Nat) . add n (Suc n) |])
 
 xio :: IO ()

--- a/src/Pirouette/Symbolic/Eval/SMT.hs
+++ b/src/Pirouette/Symbolic/Eval/SMT.hs
@@ -126,24 +126,22 @@ instance (LanguageSMT lang) => PureSMT.Solve lang where
         (LanguageSMT lang) =>
         SymEvalSt lang ->
         HackSolver lang Bool
-      pathIsPlausible env
-        | sestValidated env = return True -- We already validated this branch before; nothing new was learnt.
-        | otherwise = do
-          solverPush
-          decl <- runExceptT (declareVariables (sestGamma env))
-          case decl of
-            Right _ -> return ()
-            Left err -> error err
-          -- Here we do not care about the totality of the translation,
-          -- since we want to prune unsatisfiable path.
-          -- And if a partial translation is already unsat,
-          -- so is the translation of the whole set of constraints.
-          void $ assertConstraint (sestKnownNames env) (sestConstraint env)
-          res <- checkSat
-          solverPop
-          return $ case res of
-            Unsat -> False
-            _ -> True
+      pathIsPlausible env = do
+        solverPush
+        decl <- runExceptT (declareVariables (sestGamma env))
+        case decl of
+          Right _ -> return ()
+          Left err -> error err
+        -- Here we do not care about the totality of the translation,
+        -- since we want to prune unsatisfiable path.
+        -- And if a partial translation is already unsat,
+        -- so is the translation of the whole set of constraints.
+        void $ assertConstraint (sestKnownNames env) (sestConstraint env)
+        res <- checkSat
+        solverPop
+        return $ case res of
+          Unsat -> False
+          _ -> True
   solveProblem (CheckProperty CheckPropertyProblem {..}) s =
     hackSolverPrt s cpropDefs $ checkProperty cpropOut cpropIn cpropAxioms cpropState
     where

--- a/src/Pirouette/Symbolic/Eval/SMT.hs
+++ b/src/Pirouette/Symbolic/Eval/SMT.hs
@@ -200,6 +200,10 @@ assertConstraint,
     S.Set Name ->
     Constraint lang ->
     SolverT m (Bool, UsedAnyUFs)
+assertConstraint = undefined
+assertNotConstraint = undefined
+
+{-
 assertConstraint knownNames c@Bot = do
   (done, usedAnyUFs, expr) <- constraintToSExpr knownNames c
   assert expr
@@ -220,6 +224,7 @@ assertNotConstraint knownNames c = do
   (done, usedAnyUFs, expr) <- constraintToSExpr knownNames c
   assertNot expr
   pure (done, usedAnyUFs)
+-}
 
 -- TODO: why is this needed, what needs to be done on the TODO below?
 instantiateAxiomWithVars ::

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -69,11 +69,11 @@ data Spine lang x
     -- > [Spine lang a] -> Spine lang a
     --
     -- Finally, because we want a monadic structure, we'll go polymorphic:
-    Call Name ([Spine lang (TermSet lang)] -> Spine lang x) [Spine lang (TermSet lang)]
+    Call Name ([TermSet lang] -> Spine lang x) [TermSet lang]
   | -- | Destructors are also a little tricky, because in reality, we need to
     -- consume the motive until /at least/ the first constructor is found, that
     -- is the only guaranteed way to make any progress.
-    Dest ((ConstructorInfo, [Spine lang (TermSet lang)]) -> Spine lang x) (Spine lang (TermSet lang))
+    Dest ((ConstructorInfo, [TermSet lang]) -> Spine lang x) (TermSet lang)
   | Head (WHNFTermHead lang) [Spine lang x]
   | Next x
 
@@ -84,8 +84,8 @@ instance (LanguagePretty lang, Pretty x) => Pretty (Spine lang x) where
   pretty = prettySpine 2
 
 prettySpine :: (LanguagePretty lang, Pretty x) => Int -> Spine lang x -> Doc ann
-prettySpine d (Call n _ args) = "Call" <+> vsep [pretty n, nest 2 $ vcat (map (prettySpine (d - 1)) args)]
-prettySpine d (Dest _ mot) = vsep ["Dest", prettySpine (d - 1) mot]
+prettySpine d (Call n _ args) = "Call" <+> vsep [pretty n, nest 2 $ vcat (map pretty args)]
+prettySpine d (Dest _ mot) = vsep ["Dest", pretty mot]
 prettySpine d (Head hd args) = parens $ nest 2 $ sep $ pretty hd : map (prettySpine (d - 1)) args
 prettySpine _ (Next x) = "Next"
 

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -362,7 +362,8 @@ instance Semigroup (SymEvalSt lang) where
   SymEvalSt c1 g1 a1 n1 <> SymEvalSt c2 g2 a2 n2 =
     SymEvalSt
       (c1 <> c2)
-      (M.unionWithKey (\k _ _ -> error $ "Key already declared: " ++ show k) g1 g2)
+      -- (M.unionWithKey (\k _ _ -> error $ "Key already declared: " ++ show k) g1 g2)
+      (M.union g1 g2)
       (max a1 a2)
       (n1 <> n2)
 

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -116,7 +116,7 @@ class (SMT.LanguageSMT lang) => LanguageSymEval lang where
   isTrue :: PureSMT.SExpr -> PureSMT.SExpr
 
 newtype SymVar = SymVar {symVar :: Name}
-  deriving (Eq, Show, Data, Typeable, IsString)
+  deriving (Eq, Ord, Show, Data, Typeable, IsString)
 
 instance Pretty SymVar where
   pretty (SymVar n) = pretty n

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -297,6 +297,7 @@ class (SMT.LanguageSMT lang) => LanguageSymEval lang where
   --  This function is meant to be used with @-XTypeApplications@
   isTrue :: PureSMT.SExpr -> PureSMT.SExpr
 
+-- TODO: symvars should be flexible or rigid: rigid symvars can't be instantiated to anything.
 newtype SymVar = SymVar {symVar :: Name}
   deriving (Eq, Ord, Show, Data, Typeable, IsString)
 

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -238,10 +238,10 @@ deriving instance (Eq (Constraint lang), Eq (Type lang), Eq res) => Eq (Path lan
 deriving instance (Show (Constraint lang), Show (Type lang), Show res) => Show (Path lang res)
 
 instance (LanguagePretty lang, Pretty a) => Pretty (Path lang a) where
-  pretty (Path conds _gamma res) =
+  pretty (Path conds gamma res) =
     vsep
-      [ "", -- "Env:" <+> hsep (map pretty (M.toList gamma)),
-        "Path:" <+> indent 2 (pretty conds),
+      [ "Env:" <+> hsep (map pretty (M.toList gamma)),
+        "Conds:" <+> indent 2 (pretty conds),
         "Tip:" <+> indent 2 (pretty res)
       ]
 
@@ -258,7 +258,11 @@ data SymEvalSt lang = SymEvalSt
 
 instance Semigroup (SymEvalSt lang) where
   SymEvalSt c1 g1 a1 n1 <> SymEvalSt c2 g2 a2 n2 =
-    SymEvalSt (c1 <> c2) (g1 <> g2) (max a1 a2) (n1 <> n2)
+    SymEvalSt
+      (c1 <> c2)
+      (M.unionWithKey (\k _ _ -> error $ "Key already declared: " ++ show k) g1 g2)
+      (max a1 a2)
+      (n1 <> n2)
 
 instance Monoid (SymEvalSt lang) where
   mempty = SymEvalSt mempty M.empty 0 S.empty

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -108,7 +108,8 @@ instance Monad (Spine lang) where
 -- instance Show (SymbTerm lang x) where
 --   show _ = "<symbterm>"
 
--- THE ISSUE:
+-- THE ISSUE (WHICH IS NO LONGER RELEVANT, AND IS THE REASON FOR SPLITTING DATATYPES
+-- INTO TWO FUNCTORS):
 --
 -- When liftedTermAppN takes the following term:
 --

--- a/src/Pirouette/Symbolic/Eval/Types.hs
+++ b/src/Pirouette/Symbolic/Eval/Types.hs
@@ -33,6 +33,9 @@ import qualified PureSMT
 -- It denotes a set of pairs of @TermMeta lang SymVar@ and @Constraint lang@.
 newtype TermSet lang = TermSet {unTermSet :: Tree (DeltaEnv lang) (Spine lang (TermSet lang))}
 
+instance Show (TermSet lang) where
+  show _ = "<termset>"
+
 -- | A 'SpineTree' is a functor which represents a /set of/ 'Spine's with holes of
 -- type @a@. The trick is that once we take the fixpoint of this functor, as in 'TermSet',
 -- we now have an infinite structure that alternates between branching and some concrete spines.

--- a/src/Pirouette/Symbolic/Prover.hs
+++ b/src/Pirouette/Symbolic/Prover.hs
@@ -74,7 +74,7 @@ proveUnbounded ::
   Options ->
   Problem lang ->
   m [Path lang (EvaluationWitness lang)]
-proveUnbounded opts = prove (opts {shouldStop = const False})
+proveUnbounded opts = prove undefined
 
 -- | Executes the problem while the stopping condition is valid until
 --  the supplied predicate returns @True@. A return value of @Nothing@
@@ -190,7 +190,7 @@ worker resultVar bodyTerm assumeTerm proveTerm = do
   mayProveCond <- fmap (isTrue @lang) <$> translate proveTerm
   -- introduce the assumption about the result, if useful
   case mayBodyTerm of
-    Right _ -> learn $ And [Assign resultVar bodyTerm]
+    Right _ -> learn $ And [Pirouette.SMT.Constraints.Assign resultVar bodyTerm]
     _ -> pure ()
   -- debugPrint $ pretty (mayBodyTerm, mayAssumeCond, mayProveCond)
   -- now try to prune if we can translate the things
@@ -222,7 +222,7 @@ worker resultVar bodyTerm assumeTerm proveTerm = do
       -- debugPrint (pretty proveTerm')
       -- debugPrint somethingWasEval
       -- check the fuel
-      noMoreFuel <- asks (shouldStop . seeOptions) >>= \s -> s <$> currentStatistics
+      noMoreFuel <- asks (undefined . seeOptions) >>= \s -> s <$> currentStatistics
       -- currentFuel >>= liftIO . print
       if noMoreFuel || somethingWasEval == Any False
         then pure $ CounterExample bodyTerm' (Model [])

--- a/src/Pirouette/Symbolic/Prover/Runner.hs
+++ b/src/Pirouette/Symbolic/Prover/Runner.hs
@@ -48,11 +48,12 @@ runIncorrectnessLogic ::
   IncorrectnessParams lang ->
   IncorrectnessResult lang
 runIncorrectnessLogic opts prog parms =
-  runIdentity $ execIncorrectnessLogic (proveAny opts isCounter) prog parms
+  runIdentity $ execIncorrectnessLogic (proveAny opts undefined) prog parms
   where
-    isCounter Path {pathResult = CounterExample _ _, pathStatus = s}
-      | s /= OutOfFuel = True
-    isCounter _ = False
+
+-- isCounter Path {pathResult = CounterExample _ _, pathStatus = s}
+--   | s /= OutOfFuel = True
+-- isCounter _ = False
 
 -- | Prepares a 'IncorrectnessParams' into a 'Problem', to be passed to
 --  some worker function. Chances are that you are looking for
@@ -111,7 +112,7 @@ replIncorrectnessLogic ::
   IO ()
 replIncorrectnessLogic maxCstrs defs params =
   printIRResult maxCstrs $
-    runIncorrectnessLogic (def {shouldStop = (> maxCstrs) . sestConstructors}) defs params
+    runIncorrectnessLogic (def {- {shouldStop = (> maxCstrs) . sestConstructors} -}) defs params
 
 replIncorrectnessLogicSingl ::
   (Language lang, LanguageBuiltinTypes lang, LanguageSymEval lang) =>
@@ -120,7 +121,7 @@ replIncorrectnessLogicSingl ::
   IO ()
 replIncorrectnessLogicSingl maxCstrs params =
   printIRResult maxCstrs $
-    runIncorrectnessLogicSingl (def {shouldStop = (> maxCstrs) . sestConstructors}) params
+    runIncorrectnessLogicSingl (def {- {shouldStop = (> maxCstrs) . sestConstructors} -}) params
 
 -- | Assert a test failure (Tasty HUnit integration) when the result of the
 -- incorrectness logic execution reveals an error or a counterexample.
@@ -131,4 +132,4 @@ assertIncorrectnessLogic ::
   IncorrectnessParams lang ->
   Test.Assertion
 assertIncorrectnessLogic maxCstrs defs params =
-  assertIRResult (runIncorrectnessLogic (def {shouldStop = (> maxCstrs) . sestConstructors}) defs params)
+  assertIRResult (runIncorrectnessLogic (def {- {shouldStop = (> maxCstrs) . sestConstructors} -}) defs params)

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -276,6 +276,9 @@ termJoin (SystF.Abs ann k t) = SystF.Abs ann k (termJoin t)
 termToMeta :: Term lang -> TermMeta lang meta
 termToMeta = termMetaMap absurd
 
+termMeta :: meta -> TermMeta lang meta
+termMeta = SystF.termPure . SystF.Meta
+
 -- | Returns all the (free) names used by a term
 termNames :: TermMeta lang meta -> Set.Set (SystF.Arg Name Name)
 termNames = uncurry (<>) . (foldMap go &&& SystF.termTyFoldMap typeNames)

--- a/src/Supply.hs
+++ b/src/Supply.hs
@@ -1,0 +1,225 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module Supply
+  ( Supply,
+    newSupply,
+    newSupplyIO,
+    runSupply,
+    supplyValue,
+    split,
+    split2,
+  )
+where
+
+import Control.Monad.ST
+import Data.STRef
+import GHC.Base (MutVar#, State#, newMutVar#, noDuplicate#)
+import GHC.Exts (atomicModifyMutVar#)
+import GHC.ST (ST (..), STRep)
+
+-- This module is based on a few sources from the internet, and from conversations
+-- with Alexis King. Check the bottom of the file for a thorough explanation on State#
+-- and the following links and papers to understand the technique.
+--
+-- 1. https://stackoverflow.com/questions/6311512/creating-unique-labels-in-haskell/63406066#63406066
+-- 2. https://hackage.haskell.org/package/value-supply-0.6
+-- 3. https://www.cambridge.org/core/services/aop-cambridge-core/content/view/763DE73EB4761FDF681A613BE0E98443/S0956796800000988a.pdf/functional_pearl_on_generating_unique_names.pdf
+
+-- | A 'Supply' is a splitable suply of unique values of type @a@.
+-- new values can be obtained with 'supplyValue', which can only be
+-- called once per 'Supply'. In order to provide supplies for recursive calls,
+-- you must 'split' the 'Supply' first. Failing to do so will result
+-- in a runtime error.
+data Supply a = forall s. Supply (UseOnce# s -> a) (UseOnce# s)
+
+instance Functor Supply where
+  fmap f (Supply g u) = Supply (f . g) u
+
+-- | This is the recomended wrapper to run a supply if all you care about is
+-- the uniqueness of supplied values, provided by the 'Eq' class. More general
+-- supplies can be created with 'newSupply' and 'newSupplyIO'.
+runSupply :: (forall a. (Eq a, Show a) => Supply a -> b) -> b
+runSupply f = f (runST (newSupply (0 :: Int) succ))
+
+-- | Creates a new supply with a given seed and /next/ function.
+-- Being on the 'ST' monad is crucial, since it stops GHC from
+-- transforming a call @f (newSupply z s) (newSupply z s)@ into
+-- @let x = newSupply z s in f x x@, since that cause the same
+-- supply to be reused. The /next/ function must be cycle-free
+-- for everything to work as expected.
+newSupply :: forall s a. a -> (a -> a) -> ST s (Supply a)
+newSupply start next = do
+  -- A supply, internally, will be a STRef that is updated
+  -- every time the function @g@ is called.
+  r <- newSTRef start
+  ST $ use# (Supply $ asUseOnce# (unST $ nextValue r))
+  where
+    nextValue :: STRef s a -> ST s a
+    nextValue r =
+      let upd a = let b = next a in seq b (b, a)
+       in atomicModifySTRef r upd
+
+-- | Just like 'newSupply', but returns the supply in the @IO@ monad instead.
+newSupplyIO :: a -> (a -> a) -> IO (Supply a)
+newSupplyIO start next = stToIO (newSupply start next)
+
+-- | Consumes a supply, retrieving a new value. It is guaranteed that
+-- if @s@ is a supply obtained from transitively splitting some
+-- other supply @s0@, that is, @s \in transitiveReflexiveClosure split s0@,
+-- then @supplyValue s@ is different from @supplyValue s'@ where
+-- @s' \in transitiveReflexiveClosure split s0 - { s }@.
+supplyValue :: Supply a -> a
+supplyValue (Supply g u) = g u
+
+-- | Splits a supply into an infinite list of supplies, this function needs to
+-- be used in conjunction with @take n@ or explicitely pattern matched with
+-- an underscore in the tail:
+--
+-- > case split s of
+-- >   s1 : s2 : _ -> ...
+split :: Supply a -> [Supply a]
+split s0 =
+  let !(s1, s2) = split2 s0
+   in s1 : split s2
+
+-- | Splits a supply in two further supplies.
+split2 :: Supply a -> (Supply a, Supply a)
+split2 (Supply g u) =
+  let !(# u1, u2 #) = split2# u
+   in (Supply g u1, Supply g u2)
+
+-- Local Definitions
+
+atomicModifySTRef :: STRef s a -> (a -> (a, b)) -> ST s b
+atomicModifySTRef r f = do
+  x <- readSTRef r
+  let !(x', y) = f x
+  writeSTRef r x'
+  return y
+
+unST :: ST s a -> STRep s a
+unST (ST act) = act
+
+-- * Single-use values
+
+-- | 'UseOnce#' values can be thought of as unique values.
+-- They can be used to make sure that we call 'use#' only once per
+-- allocated 'UseOnce#', but we can also 'split#' a unused value into
+-- two. For more information on what this is and why it works, check the commentary
+-- at the end of this file.
+type UseOnce# s = String -> State# s
+
+-- | Splits an unused value into two unused values.
+split2# :: UseOnce# s -> (# UseOnce# s, UseOnce# s #)
+split2# h =
+  let !s = h "split2"
+      !(# s', h1 #) = dispense# s
+      (# _, h2 #) = dispense# s'
+   in (# h1, h2 #)
+
+-- | Uses a /use-once/ resource in this current state thread; that
+--  resource will not be able to be used again.
+use# :: (UseOnce# s -> a) -> State# s -> (# State# s, a #)
+use# g s =
+  let !(# s', h #) = dispense# s
+      -- this is where the "use" really happens: dispense# returns a UseOnce#
+      -- and h will be @expire# s' r@, which when given an argument will modify
+      -- the underlying MutVar placing a call to error inside, which
+      -- stop anyone from ever "using" it again during runtime.
+      !r = g h
+   in (# s', r #)
+
+-- | Create a new /use-once/ resource in this state thread. The trick
+--  is in returning a closure that when given an argument, will update
+--  an internal 'MutVar#' setting it to error whenever it is /used/.
+dispense# :: State# s -> (# State# s, UseOnce# s #)
+dispense# s0 =
+  let !(# s1, r #) = newMutVar# () s0
+   in (# s1, expire# s1 r #)
+
+-- | Expires a resource, by pushing @error@ into the 'MutVar#'. If that
+-- particular mutvar is ever used again, that error will be evaluated.
+expire# :: State# s -> MutVar# s () -> String -> State# s
+expire# s0 r name =
+  let !(# s1, () #) = atomicModifyMutVar# r (error (name ++ " expired"),) s0
+   in s1
+
+-- | Given an action that produces an @a@ from a given @State# s@, run
+--  it on the @State# s@ given by the 'UseOnce#', once applied to a constant
+--  string. The 'noDuplicate#' is important: it ensures that two threads will never
+--  attempt to evaluate that thunk at the same time, which could end up calling 'dispence#' twice.
+asUseOnce# :: (State# s -> (# State# s, a #)) -> UseOnce# s -> a
+asUseOnce# act h = let (# _, t #) = act (noDuplicate# (h "asUseOnce#")) in t
+
+-- I finally understood how this module worked after a great explanation from
+-- Alexis King on what is @State#@. I will just quote her explanation verbatim here.
+-- Alongside the commentary on the different functions in here, it should
+-- give you enough to start playing around with the implementation of this module.
+--
+-- Open quotes:
+--
+-- Haskell-the-language is semantically completely pure, which is to say @f x@ always reduces to the
+-- same value given the same argument @x@. This is true even for functions that return @IO@:
+-- a function @f :: Int -> IO Int@ always returns the same @IO Int@ value. It just so happens
+-- that when the runtime executes the resulting IO action, it may do impure things.
+--
+-- GHC exploits this property during optimization. If you have an expression
+-- @foo (bar 1) (bar 1)@, GHC will rewrite it to @let x = bar 1 in foo x x@. Similarly, if you have an expression:
+--
+-- > \x -> foo x (bar 1)
+--
+-- Then GHC will rewrite it to
+--
+-- > let y = bar y
+-- > in \x -> foo x y
+--
+-- To avoid re-evaluating @bar 1@ every time the function is applied.
+--
+-- But @IO@ has to actually be implemented somehow, and this raises the question of what representation
+-- can allow GHC to compile @IO@ code efficiently without it ever accidentally rearranging code in a
+-- way that changes semantics. For example, suppose we have a primitive for generating a random
+-- integer called @randInt :: IO Int@. We certainly can’t use @newtype IO a = IO a@ because then GHC could rewrite
+--
+-- > randInt >>= \x -> randInt >>= \y -> pure (x + y)
+--
+-- to @let { x = randInt; y = randInt } in x + y@ and then to @let x = randInt in x + x@, which is not what we want.
+--
+-- @IO@ needs to be implemented internally /as a function/ in order to have any hope of success,
+-- because a function can at least produce different results when given different inputs.
+-- We could therefore imagine IO being implemented this way:
+--
+-- > newtype IO a = IO (Unique -> (a, Unique))
+--
+-- The @Monad@ instance here is literally just the usual one for @State Unique@. Now we can have
+-- a @randInt# :: Unique -> (Int, Unique)@ primop that generates a random @Int@, and there’s no problem
+-- as long as GHC doesn’t know anything about the implementation of @randInt#@! For all it knows,
+-- every use of @randInt#@ could return a different @Unique@, and therefore if we have
+--
+-- > \u1 -> let (x, u2) = readInt# u1
+-- >            (y, u3) = readInt# u2
+-- >        in (x + y, u3)
+--
+-- then GHC can’t assume @randInt# u1@ and @randInt# u2@ return the same value because they’re applied
+-- to different arguments! So everything works out as we want. The only problem with this is
+-- that now we have all these dummy @Unique@ values floating around, even though in reality, primops
+-- like @randInt#@ don’t care about the @Unique@ values at all (they could always just return their
+-- argument and the strategy would still work fine). So GHC’s trick is to represent @IO@ this way:
+--
+-- > newtype State# s = State# (# #) -- the unboxed unit
+-- > newtype IO a = IO (State# RealWorld -> (# a, State# RealWorld #))
+--
+-- This isn’t literally the way it’s defined, because in order for the trick to work, the GHC optimizer
+-- has to be clueless to the fact that @State#@ doesn’t actually hold any information (and therefore
+-- all @State#@ values are equivalent), but it’s pretty close. The idea is just that @State#@ looks just
+-- like threading around a @Unique@ everywhere to the typechecker and optimizer, but to the code
+-- generator and runtime, it actually has no representation at all—it’s totally free.
+--
+-- So @State#@ is really just a performance trick to implement @IO@ without having to pass around
+-- dummy pointers. If you want, you can pretend there’s a definition somewhere @type State# s = Unique@,
+-- and everything will pretty much work the same way.

--- a/src/TreeTest.hs
+++ b/src/TreeTest.hs
@@ -1,0 +1,350 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use foldr" #-}
+module TreeTest where
+
+import Control.Arrow (first, second)
+import Control.Monad
+import Data.Foldable
+import Data.IORef
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Data.Void
+import System.IO.Unsafe
+
+----------------------------------------
+-- Term type to symbolically execute: --
+----------------------------------------
+
+data Term m
+  = Lam String (Term m)
+  | App (Var m) [Term m]
+  | NatCase (Term m) (Term m) (Term m)
+  | ConsZero
+  | ConsSucc (Term m)
+  deriving (Show, Functor)
+
+data Var m
+  = Bound String
+  | Free String
+  | Meta m
+  | Bottom
+  deriving (Show, Functor)
+
+type Defs = M.Map String (Term Void)
+
+type Meta = String
+
+------------------------------------------------
+-- Infinite trees, giving semantics to terms: --
+------------------------------------------------
+
+data TermSet
+  = Simple {unTermSet :: Tree (Spines TermSet)}
+  | Inst {unMeta :: Meta, unTermSet :: Tree (Spines TermSet)}
+
+data CotrInfo = CIZero | CISucc
+
+-- Spine Layer
+data S r
+  = forall a. Call ([Spines a] -> r) [Spines a]
+  | forall a. Dest ((CotrInfo, [Term a]) -> r) (Spines a)
+  | Cotr CotrInfo [r]
+  | Bot
+
+instance Functor S where
+  fmap f Bot = Bot
+  fmap f (Cotr ci rs) = Cotr ci $ fmap f rs
+  fmap f (Dest cs mot) = Dest (f . cs) mot
+  fmap f (Call func args) = Call (f . func) args
+
+data Spines r
+  = One (S (Spines r))
+  | None r
+  deriving (Functor)
+
+spinesJoin :: Spines (Spines r) -> Spines r
+spinesJoin (None r) = r
+spinesJoin (One s) = One $ fmap spinesJoin s
+
+data Tree a
+  = Leaf a
+  | Learn String (Tree a)
+  | Branch [Tree a]
+  deriving (Show, Functor)
+
+------
+
+type ScopedTerm = (S.Set Meta, Term Meta)
+
+type ScopedMeta = (S.Set Meta, Meta)
+
+-- The anamorphism!
+symbolically :: Defs -> Term Void -> TermSet
+symbolically defs = withSymVars []
+  where
+    withSymVars :: [Meta] -> Term Void -> TermSet
+    withSymVars s (Lam n t) = withSymVars (n : s) t
+    withSymVars s body =
+      Simple $
+        Learn (show s) $
+          Leaf $ evalChooseLoop (S.fromList s, appN (termCast body) (map meta s))
+
+    evalChooseLoop :: ScopedTerm -> Spines TermSet
+    evalChooseLoop = fmap termSet . eval
+
+    termSet :: ScopedMeta -> TermSet
+    termSet = uncurry Inst . choose
+
+    eval :: ScopedTerm -> Spines ScopedMeta
+    eval (s, t) = (\m -> (S.insert m s, m)) <$> eval1 t
+
+    eval1 :: Term m -> Spines m
+    eval1 Lam {} = error "Lam has no eval"
+    eval1 ConsZero = One $ Cotr CIZero []
+    eval1 (ConsSucc t) = One $ Cotr CISucc [eval1 t]
+    eval1 (NatCase mot cZ cS) = One $
+      flip Dest (eval1 mot) $ \case
+        (CIZero, []) -> eval1 cZ
+        (CISucc, [x]) -> eval1 $ cS `appN` [x]
+        _ -> error "type error"
+    eval1 t@(App hd args) =
+      case hd of
+        Bound _ -> error "Bound head"
+        Meta n -> None n
+        Bottom -> One Bot
+        Free n ->
+          let bodyN = termCast $ defs M.! n
+           in magic bodyN $ map eval1 args
+
+    choose :: ScopedMeta -> (Meta, Tree (Spines TermSet))
+    choose (s, n) = (n,) $
+      Branch $
+        flip map [CIZero, CISucc] $ \cons ->
+          let (vs, cotr) = mkSymbolicCotr cons
+              res = "$s" ++ show (unsafePerformIO fresh)
+           in Learn ("(++ " ++ show vs ++ ")") $
+                Learn (res ++ " == " ++ show vs) $ Leaf $ evalChooseLoop (S.union s vs, cotr)
+
+    magic :: forall m. Term m -> [Spines m] -> Spines m
+    magic body args =
+      let body' = fmap None body
+          args' = map meta args
+          res :: Term (Spines m)
+          res = body' `appN` args'
+       in spinesJoin $ eval1 res
+
+mkSymbolicCotr :: CotrInfo -> (S.Set Meta, Term Meta)
+mkSymbolicCotr CIZero = (S.empty, ConsZero)
+mkSymbolicCotr CISucc =
+  let v = "$s" ++ show (unsafePerformIO fresh)
+   in (S.singleton v, ConsSucc (meta v))
+
+------
+
+data CallConvention
+  = CallByName
+  | CallByValue
+
+type State = [String]
+
+cata :: CallConvention -> Integer -> TermSet -> [(State, Term Meta)]
+cata cc depth = go depth []
+  where
+    go :: Integer -> State -> TermSet -> [(State, Term Meta)]
+    go n st (Inst m ts)
+      | n <= 0 = return (st, meta m)
+      | otherwise = goAux n st ts
+    go n st (Simple ts) = goAux n st ts
+
+    goAux :: Integer -> State -> Tree (Spines TermSet) -> [(State, Term Meta)]
+    goAux n st = concatMap (uncurry goAgain) . goWHNF n st
+      where
+        goAgain :: State -> Term TermSet -> [(State, Term Meta)]
+        goAgain st' t = do
+          t' <- termDistr $ fmap (go (n - 1) st') t
+          let (sts, t'') = termStr t'
+          let sts' = if null sts then st' else mconcat sts
+          return (sts', termJoin t'')
+
+    goWHNF :: Integer -> State -> Tree (Spines a) -> [(State, Term a)]
+    goWHNF n st ts = concatMap (uncurry (goSpines n)) $ goTree st ts
+
+    goTree :: State -> Tree a -> [(State, a)]
+    goTree st (Learn s t) = goTree (s : st) t
+    goTree st (Branch ts) = asum $ map (goTree st) ts
+    goTree st (Leaf x) = return (st, x)
+
+    goSpines :: Integer -> State -> Spines a -> [(State, Term a)]
+    goSpines n st (None a) = return (st, meta a)
+    goSpines n st (One s) =
+      case s of
+        Bot -> return (st, bottom)
+        Cotr ci rs ->
+          case ci of
+            CIZero -> return (st, ConsZero)
+            CISucc -> do
+              -- because this is succ, we know it has one argument
+              (st', [rs']) <- combineArgs st <$> traverse (goSpines (n - 1) st) rs
+              return (st', ConsSucc rs')
+        Call f args -> case cc of
+          CallByName -> goSpines n st (f args)
+          CallByValue -> undefined
+        Dest f x -> do
+          (st', x') <- goSpines n st x
+          case x' of
+            ConsZero -> goSpines n st' $ f (CIZero, [])
+            ConsSucc as -> goSpines n st' $ f (CISucc, [as])
+            _ -> error "Type Error"
+
+    combineArgs :: State -> [(State, a)] -> (State, [a])
+    combineArgs s0 [] = (s0, [])
+    combineArgs s0 xs = first concat . unzip $ xs
+
+cataIO :: CallConvention -> Integer -> TermSet -> IO ()
+cataIO cc n t = mapM_ (uncurry pretty) $ cata cc n t
+  where
+    pretty strs res =
+      putStrLn $ "- " ++ show res -- ++ "\n" ++ unlines (map ("    " ++) strs)
+
+-----------------
+
+add :: (String, Term m)
+add =
+  ( "add",
+    Lam "n" $
+      Lam "m" $
+        NatCase
+          (bound "n")
+          (bound "m")
+          (Lam "sn" $ ConsSucc $ appN (free "add") [bound "sn", bound "m"])
+  )
+
+constF :: (String, Term m)
+constF = ("const", Lam "n" $ Lam "m" $ bound "n")
+
+defs :: Defs
+defs = M.fromList [add, constF]
+
+res :: CallConvention -> Integer -> IO ()
+res cc n =
+  cataIO cc n $
+    symbolically defs $ Lam "k" (appN (free "add") [bound "k", ConsSucc (bound "k")])
+
+-- Boilerplate:
+
+------
+
+bottom :: Term m
+bottom = App Bottom []
+
+bound :: String -> Term m
+bound s = App (Bound s) []
+
+free :: String -> Term m
+free s = App (Free s) []
+
+meta :: m -> Term m
+meta s = App (Meta s) []
+
+termDistr :: (Applicative f) => Term (f a) -> f (Term a)
+termDistr (App fa args) = App <$> varDistr fa <*> traverse termDistr args
+termDistr (Lam s t) = Lam s <$> termDistr t
+termDistr (NatCase m z s) = NatCase <$> termDistr m <*> termDistr z <*> termDistr s
+termDistr ConsZero = pure ConsZero
+termDistr (ConsSucc n) = ConsSucc <$> termDistr n
+
+varDistr :: (Applicative f) => Var (f a) -> f (Var a)
+varDistr (Bound s) = pure (Bound s)
+varDistr (Free s) = pure (Free s)
+varDistr Bottom = pure Bottom
+varDistr (Meta s) = Meta <$> s
+
+termStr :: Term (a, b) -> ([a], Term b)
+termStr (App fa args) =
+  let (a1, fa') = varStr fa
+      (as, args') = unzip $ map termStr args
+   in (a1 ++ concat as, App fa' args')
+termStr (Lam s t) = second (Lam s) (termStr t)
+termStr (NatCase m z s) =
+  let (a1, m') = termStr m
+      (a2, z') = termStr z
+      (a3, s') = termStr s
+   in (a1 ++ a2 ++ a3, NatCase m' z' s')
+termStr ConsZero = pure ConsZero
+termStr (ConsSucc n) = second ConsSucc $ termStr n
+
+varStr :: Var (a, b) -> ([a], Var b)
+varStr (Bound s) = ([], Bound s)
+varStr (Free s) = ([], Free s)
+varStr Bottom = ([], Bottom)
+varStr (Meta (a, b)) = ([a], Meta b)
+
+termJoin :: Term (Term a) -> Term a
+termJoin (App (Meta m) args) = appN m (map termJoin args)
+termJoin (App (Bound s) args) = App (Bound s) (map termJoin args)
+termJoin (App (Free s) args) = App (Free s) (map termJoin args)
+termJoin (App Bottom args) = App Bottom (map termJoin args)
+termJoin (Lam s t) = Lam s (termJoin t)
+termJoin (NatCase m z s) = NatCase (termJoin m) (termJoin z) (termJoin s)
+termJoin (ConsSucc s) = ConsSucc (termJoin s)
+termJoin ConsZero = ConsZero
+
+termCast :: Term Void -> Term m
+termCast = fmap absurd
+
+app :: Term m -> Term m -> Term m
+app (App hd args) u = App hd (args ++ [u])
+app (Lam s t) u = subst s u t
+app t u =
+  error $
+    unlines
+      [ "Cant app: ",
+        "t " ++ show (fmap (const ()) t),
+        "u " ++ show (fmap (const ()) u)
+      ]
+
+appN :: Term m -> [Term m] -> Term m
+appN = foldl app
+
+subst :: String -> Term m -> Term m -> Term m
+subst s t (Lam s' t')
+  | s /= s' = Lam s' (subst s t t')
+subst s t (App hd args) = appN (substVar s t hd) (map (subst s t) args)
+subst _ _ m = m
+
+substVar :: String -> Term m -> Var m -> Term m
+substVar s t (Bound s')
+  | s == s' = t
+substVar _ _ t = App t []
+
+--
+
+instance Applicative Tree where
+  pure = Leaf
+  (<*>) = ap
+
+instance Monad Tree where
+  Leaf x >>= f = f x
+  Learn str t >>= f = Learn str (t >>= f)
+  Branch ts >>= f = Branch $ map (>>= f) ts
+
+distr :: [Tree a] -> Tree [a]
+distr [] = Leaf []
+distr (tx : txs) = (:) <$> tx <*> distr txs
+
+-- Fresh names:
+
+{-# NOINLINE fresh #-}
+fresh :: IO Integer
+fresh = do
+  atomicModifyIORef ctr (\i -> (i + 1, i))
+  where
+    ctr :: IORef Integer
+    ctr = unsafePerformIO $ newIORef 0


### PR DESCRIPTION
This PR aims to split the symbolic evaluation engine in its core parts:
1. One anamorphism that gives semantics to `Term lang` as an infinite tree of possibilities
2. Multiple catamorphisms that consume these trees according to some language parameters that will be provided by the user, things like:
    1. Do we run in call-by-name or call-by-value fashion?
    2. When to stop
    3. How to evaluate builtins
    4. etc...

This is in a very drafty state still, but for those interested, the discussion in #137 and #138 is what is driving the design.