### PR TITLE
Remove expandAllNonRec

### DIFF
--- a/src/Pirouette/Transformations/Inline.hs
+++ b/src/Pirouette/Transformations/Inline.hs
@@ -7,45 +7,10 @@
 module Pirouette.Transformations.Inline where
 
 import Data.Generics.Uniplate.Operations
-import Data.List (foldl')
 import qualified Data.Map as Map
-import qualified Data.Set as Set
-import Pirouette.Monad
 import Pirouette.Term.Syntax
 import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Transformations.Term
-
--- | Expand all non-recursive definitions in our state, keeping only the
---  recursive definitions or those satisfying the @keep@ predicate.
-expandAllNonRec :: forall lang. (LanguageBuiltins lang) => (Name -> Bool) -> PrtOrderedDefs lang -> PrtOrderedDefs lang
-expandAllNonRec keep prtDefs =
-  let ds = prtDecls prtDefs
-      ord = prtDepOrder prtDefs
-      (remainingNames, ds', _inlinables) = foldl' go ([], ds, Map.empty) ord
-   in PrtOrderedDefs ds' (reverse remainingNames)
-  where
-    -- The 'go' functions goes over the defined terms in dependency order
-    -- and inlines terms as much as possible. To do so efficiently,
-    -- we keep a map of inlinable definitions and we also maintain the order
-    -- for the names that are left in the actual definitions.
-    --
-    -- In general, say that: (rNs, ds', rest) = foldl' go ([], decls, Map.empty) ord
-    -- then, with a slight abuse of notation:
-    --
-    -- >    Map.union ds' rest == decls -- modulo beta equivalence
-    -- > && Set.fromList rNs == Set.fromList (Map.keys ds')
-    -- > && reverse rNs `isSubListOf` ord
-    --
-    go ::
-      ([SystF.Arg Name Name], Decls lang, Map.Map Name (Term lang)) ->
-      SystF.Arg Name Name ->
-      ([SystF.Arg Name Name], Decls lang, Map.Map Name (Term lang))
-    go (names, currDecls, inlinableDecls) (SystF.TyArg ty) = (SystF.TyArg ty : names, currDecls, inlinableDecls)
-    go (names, currDecls, inlinableDecls) (SystF.TermArg k) =
-      let (decls', kDef) = expandDefsIn inlinableDecls currDecls k
-       in if SystF.TermArg k `Set.member` termNames kDef || keep k
-            then (SystF.TermArg k : names, decls', inlinableDecls)
-            else (names, Map.delete (TermNamespace, k) decls', Map.insert k kDef inlinableDecls)
 
 expandDefsIn ::
   (LanguageBuiltins lang) =>


### PR DESCRIPTION
It's not used elsewhere for quite some time, and it also has no tests/spec.

I was going through the transformations updating the comments, cleaning some things up, etc, and was curious whether we want to keep things we don't use anywhere, or whether we better remove them (git remembers everything after all!).

Making this as a separate PR, so it could be rejected easily in case you don't think it's useful!