### PR TITLE
Pretty-print programs to a text representation that is parsable back

### DIFF
--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -104,6 +104,7 @@ test-suite spec
       Pirouette.Symbolic.EvalUtils
       Pirouette.Symbolic.ProveSpec
       Pirouette.Term.Syntax.BaseSpec
+      Pirouette.Term.Syntax.PrettySpec
       Pirouette.Term.Syntax.SystemFSpec
       Pirouette.Transformations.DefunctionalizationSpec
       Pirouette.Transformations.EtaExpandSpec

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -31,14 +31,14 @@ import Text.Megaparsec
 
 prog :: forall lang. (LanguageParser lang, LanguageBuiltinTypes lang, LanguagePretty lang) => QuasiQuoter
 prog = quoter $ \str -> do
-  p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
+  p0 <- parseQ (parseProgram @lang) str
   decls <- trQ (trProgram p0)
   _ <- maybeQ (typeCheckDecls decls)
   [e|(PrtUnorderedDefs decls)|]
 
 progNoTC :: forall lang. (LanguageParser lang, LanguagePretty lang) => QuasiQuoter
 progNoTC = quoter $ \str -> do
-  p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @lang) <* eof) str
+  p0 <- parseQ (parseProgram @lang) str
   decls <- trQ (trProgram p0)
   [e|(PrtUnorderedDefs decls)|]
 

--- a/src/Language/Pirouette/QuasiQuoter/Syntax.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Syntax.hs
@@ -153,7 +153,7 @@ deriving instance
 parseProgram ::
   (LanguageParser lang) =>
   Parser (Map String (Either (DataDecl lang) (FunDecl lang)))
-parseProgram = Map.fromList <$> P.many parseDecl
+parseProgram = spaceConsumer *> lexeme (Map.fromList <$> P.many parseDecl) <* P.eof
 
 -- | A declaration is either a datatype or a function
 parseDecl ::

--- a/tests/unit/Pirouette/Term/Syntax/PrettySpec.hs
+++ b/tests/unit/Pirouette/Term/Syntax/PrettySpec.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Pirouette.Term.Syntax.PrettySpec where
+
+import Control.Monad.Reader (runReader)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Language.Pirouette.Example (Ex, prog)
+import Language.Pirouette.QuasiQuoter.Syntax (DataDecl, FunDecl, parseProgram)
+import Pirouette.Monad (PrtUnorderedDefs (..))
+import Pirouette.Term.Syntax.Pretty
+import qualified Test.Tasty as Test
+import qualified Test.Tasty.HUnit as Test
+import Text.Megaparsec (runParserT)
+import qualified Text.Megaparsec as P
+import qualified Text.Megaparsec.Char as P
+import qualified Text.Megaparsec.Char.Lexer as L
+
+example1 :: PrtUnorderedDefs Ex
+example1 =
+  [prog|
+    data Either a b = Left : a -> Either a b | Right : b -> Either a b
+    data Maybe a = Nothing : Maybe a | Just : a -> Maybe a
+  |]
+
+showProgram :: PrtUnorderedDefs Ex -> String
+showProgram = renderSingleLineStr . pretty . Map.assocs . prtUODecls
+
+readProgram :: String -> Either String (Map String (Either (DataDecl Ex) (FunDecl Ex)))
+readProgram str =
+  case runReader (P.runParserT (parseProgram @Ex) "program" str) Nothing of
+    Left err -> Left (P.errorBundlePretty err)
+    Right r -> Right r
+
+assertRight :: Either String (Map String (Either (DataDecl Ex) (FunDecl Ex))) -> Test.Assertion
+assertRight (Left err) = Test.assertFailure err
+assertRight (Right _) = return ()
+
+tests :: [Test.TestTree]
+tests =
+  [ Test.testCase
+      "Pretty-printed program is parsable"
+      (assertRight (readProgram . showProgram $ example1))
+  ]

--- a/tests/unit/Pirouette/Term/Syntax/PrettySpec.hs
+++ b/tests/unit/Pirouette/Term/Syntax/PrettySpec.hs
@@ -27,8 +27,15 @@ example1 =
     data Maybe a = Nothing : Maybe a | Just : a -> Maybe a
   |]
 
+example2 :: PrtUnorderedDefs Ex
+example2 =
+  [prog|
+    toMaybe : Integer -> Integer
+    toMaybe n = n + 1
+  |]
+
 showProgram :: PrtUnorderedDefs Ex -> String
-showProgram = renderSingleLineStr . pretty . Map.assocs . prtUODecls
+showProgram = Text.unpack . renderSmart . pretty . Map.assocs . prtUODecls
 
 readProgram :: String -> Either String (Map String (Either (DataDecl Ex) (FunDecl Ex)))
 readProgram str =
@@ -43,6 +50,6 @@ assertRight (Right _) = return ()
 tests :: [Test.TestTree]
 tests =
   [ Test.testCase
-      "Pretty-printed program is parsable"
+      "Pretty-printed datatype declaration is parsable"
       (assertRight (readProgram . showProgram $ example1))
   ]

--- a/tests/unit/Spec.hs
+++ b/tests/unit/Spec.hs
@@ -2,6 +2,7 @@ import qualified Language.Pirouette.ExampleSpec as Ex
 import qualified Pirouette.Symbolic.EvalSpec as SymbolicEval
 import qualified Pirouette.Symbolic.ProveSpec as SymbolicProve
 import qualified Pirouette.Term.Syntax.BaseSpec as Base
+import qualified Pirouette.Term.Syntax.PrettySpec as PrettySpec
 import qualified Pirouette.Term.Syntax.SystemFSpec as SF
 import qualified Pirouette.Transformations.DefunctionalizationSpec as Defunc
 import qualified Pirouette.Transformations.EtaExpandSpec as Eta
@@ -36,5 +37,6 @@ tests =
         ],
       testGroup
         "Language"
-        [testGroup "Example" Ex.tests]
+        [testGroup "Example" Ex.tests],
+      testGroup "Pretty printing" PrettySpec.tests
     ]


### PR DESCRIPTION
This addresses #126. Right now, declarations (types and terms) are pretty-printed to a format that is not the Pirouette surface language. This PR provides a pretty-printer that produces declarations following the concrete syntax of the surface language.

For now, datatype declarations are handled. Printing of function declarations remains to be implemented.

- Pretty-print function declarations
  - [x] Function declarations not involving infix operators
  - [ ] Handle infix operators: the info about whether a function being applied corresponds to a binary infix operator (e.g `==`) in the concrete example language is not available at the level of the very generic printer for systemf application `App`
- [ ] Implement as an alternative printer instead of replacing the existing one?

Eventually, maybe this should be provided as an additionnal pretty-printer besides the existing one (instead of replacing it) because there is additional info (e.g. De Bruijn indexes, destructors) that do not appear in the concrete syntax of the surface language which may come in handy when debugging.