### PR TITLE
fix warnings

### DIFF
--- a/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
+++ b/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
@@ -89,7 +89,7 @@ trTerm tyEnv termEnv (ExprIf ty c t e) = do
   e' <- trTerm tyEnv termEnv e
   return $ ifThenElse ty' c' t' e'
 -- trTerm tyEnv termEnv (ExprCase ty tyRes t cases) = trTerm tyEnv termEnv (ExprVar "undefined") -- TODO implement translation of case constructs
-trTerm tyEnv termEnv (ExprCase _tyRes _ty _t _cases) = throwError "translation of case expressions is not yet implemented"
+trTerm _ _ (ExprCase _ _ _ _) = throwError "translation of case expressions is not yet implemented"
 trTerm _ termEnv (ExprVar s) =
   case s `elemIndex` termEnv of
     Just i -> return $ SystF.termPure $ SystF.Bound (SystF.Ann $ fromString s) (fromIntegral i)

--- a/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
+++ b/src/Language/Pirouette/QuasiQuoter/ToTerm.hs
@@ -89,7 +89,7 @@ trTerm tyEnv termEnv (ExprIf ty c t e) = do
   e' <- trTerm tyEnv termEnv e
   return $ ifThenElse ty' c' t' e'
 -- trTerm tyEnv termEnv (ExprCase ty tyRes t cases) = trTerm tyEnv termEnv (ExprVar "undefined") -- TODO implement translation of case constructs
-trTerm _ _ (ExprCase _ _ _ _) = throwError "translation of case expressions is not yet implemented"
+trTerm _tyEnv _termEnv (ExprCase _tyRes _ty _t _cases) = throwError "translation of case expressions is not yet implemented"
 trTerm _ termEnv (ExprVar s) =
   case s `elemIndex` termEnv of
     Just i -> return $ SystF.termPure $ SystF.Bound (SystF.Ann $ fromString s) (fromIntegral i)

--- a/src/Pirouette/SMT/Monadic.hs
+++ b/src/Pirouette/SMT/Monadic.hs
@@ -117,10 +117,10 @@ declareDatatype typeName (Datatype _ typeVariables _ cstrs) = do
       constr'
   return $ typeName : map fst cstrs
 
--- | Returns @Right ()@ when this datatype can be declared as a SMTLIB datatype
-supportedDatatype :: (LanguageSMT lang) => TypeDef lang -> Except String ()
-supportedDatatype (Datatype _ typeVariables _ cstrs) =
-  void $ runWriterT $ mapM (constructorFromPIR typeVariables) cstrs
+-- -- | Returns @Right ()@ when this datatype can be declared as a SMTLIB datatype
+-- supportedDatatype :: (LanguageSMT lang) => TypeDef lang -> Except String ()
+-- supportedDatatype (Datatype _ typeVariables _ cstrs) =
+--   void $ runWriterT $ mapM (constructorFromPIR typeVariables) cstrs
 
 -- | Declare a set of datatypes (all at once) in the current solver session.
 declareDatatypes ::

--- a/src/Pirouette/SMT/Monadic.hs
+++ b/src/Pirouette/SMT/Monadic.hs
@@ -117,7 +117,6 @@ declareDatatype typeName (Datatype _ typeVariables _ cstrs) = do
       constr'
   return $ typeName : map fst cstrs
 
-
 -- | Declare a set of datatypes (all at once) in the current solver session.
 declareDatatypes ::
   (LanguageSMT lang, MonadIO m) => [(Name, TypeDef lang)] -> ExceptT String (SolverT m) [Name]

--- a/src/Pirouette/SMT/Monadic.hs
+++ b/src/Pirouette/SMT/Monadic.hs
@@ -117,10 +117,6 @@ declareDatatype typeName (Datatype _ typeVariables _ cstrs) = do
       constr'
   return $ typeName : map fst cstrs
 
--- -- | Returns @Right ()@ when this datatype can be declared as a SMTLIB datatype
--- supportedDatatype :: (LanguageSMT lang) => TypeDef lang -> Except String ()
--- supportedDatatype (Datatype _ typeVariables _ cstrs) =
---   void $ runWriterT $ mapM (constructorFromPIR typeVariables) cstrs
 
 -- | Declare a set of datatypes (all at once) in the current solver session.
 declareDatatypes ::

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -23,7 +23,6 @@ module Pirouette.Term.Syntax.Base where
 import Control.Arrow ((&&&))
 import Control.Monad.Identity
 import Data.Data
-import qualified Data.Kind as Kind
 import qualified Data.Map as M
 import Data.Monoid (Sum (..))
 import qualified Data.Set as Set
@@ -372,9 +371,9 @@ type LanguageConstrs lang =
 -- no idea what that is, defining an empty instance will use the default
 -- implementatino of @builtinPrelude = M.empty@, which is a fine definition.
 class (LanguageConstrs lang) => LanguageBuiltins lang where
-  type BuiltinTypes lang :: Kind.Type
-  type BuiltinTerms lang :: Kind.Type
-  type Constants lang :: Kind.Type
+  type BuiltinTypes lang
+  type BuiltinTerms lang
+  type Constants lang
 
 -- | Auxiliary constraint for pretty-printing terms of a given language.
 type LanguagePretty lang =

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -23,6 +23,7 @@ module Pirouette.Term.Syntax.Base where
 import Control.Arrow ((&&&))
 import Control.Monad.Identity
 import Data.Data
+import qualified Data.Kind as Kind
 import qualified Data.Map as M
 import Data.Monoid (Sum (..))
 import qualified Data.Set as Set
@@ -371,9 +372,9 @@ type LanguageConstrs lang =
 -- no idea what that is, defining an empty instance will use the default
 -- implementatino of @builtinPrelude = M.empty@, which is a fine definition.
 class (LanguageConstrs lang) => LanguageBuiltins lang where
-  type BuiltinTypes lang :: *
-  type BuiltinTerms lang :: *
-  type Constants lang :: *
+  type BuiltinTypes lang :: Kind.Type
+  type BuiltinTerms lang :: Kind.Type
+  type Constants lang :: Kind.Type
 
 -- | Auxiliary constraint for pretty-printing terms of a given language.
 type LanguagePretty lang =

--- a/src/Pirouette/Term/Syntax/Subst.hs
+++ b/src/Pirouette/Term/Syntax/Subst.hs
@@ -6,11 +6,12 @@
 module Pirouette.Term.Syntax.Subst where
 
 import Control.Monad.Identity
+import qualified Data.Kind as Kind
 import Data.Maybe (fromMaybe)
 import GHC.Stack (HasCallStack)
 
 class IsVar v where
-  type VarAnn v :: *
+  type VarAnn v :: Kind.Type
 
   isBound :: v -> Maybe Integer
 
@@ -53,7 +54,7 @@ singleSub t = Just t :< Inc 0
 
 -- | General class for terms that support substitution
 class (IsVar (SubstVar term)) => HasSubst term where
-  type SubstVar term :: *
+  type SubstVar term :: Kind.Type
 
   -- | How to construct an annotatd bound variable
   var :: HasCallStack => SubstVar term -> term

--- a/src/Pirouette/Term/Syntax/Subst.hs
+++ b/src/Pirouette/Term/Syntax/Subst.hs
@@ -6,12 +6,11 @@
 module Pirouette.Term.Syntax.Subst where
 
 import Control.Monad.Identity
-import qualified Data.Kind as Kind
 import Data.Maybe (fromMaybe)
 import GHC.Stack (HasCallStack)
 
 class IsVar v where
-  type VarAnn v :: Kind.Type
+  type VarAnn v
 
   isBound :: v -> Maybe Integer
 
@@ -54,7 +53,7 @@ singleSub t = Just t :< Inc 0
 
 -- | General class for terms that support substitution
 class (IsVar (SubstVar term)) => HasSubst term where
-  type SubstVar term :: Kind.Type
+  type SubstVar term
 
   -- | How to construct an annotatd bound variable
   var :: HasCallStack => SubstVar term -> term

--- a/src/Pirouette/Term/Syntax/SystemF.hs
+++ b/src/Pirouette/Term/Syntax/SystemF.hs
@@ -16,6 +16,7 @@ import Data.Data
 import Data.Foldable
 import Data.Generics.Uniplate.Data ()
 import Data.Generics.Uniplate.Operations (transform)
+import qualified Data.Kind as Kind
 import Data.Maybe (mapMaybe)
 import Data.String
 import Data.Void
@@ -427,7 +428,7 @@ mapNameScoped f = go 0
 -- ** N-ary Reducing Applications
 
 class (HasSubst term) => HasApp term where
-  type AppArg term :: *
+  type AppArg term :: Kind.Type
   appN :: (IsVar (SubstVar term), HasCallStack) => term -> [AppArg term] -> term
 
 app :: (HasApp term, HasCallStack) => term -> AppArg term -> term

--- a/src/Pirouette/Term/Syntax/SystemF.hs
+++ b/src/Pirouette/Term/Syntax/SystemF.hs
@@ -16,7 +16,6 @@ import Data.Data
 import Data.Foldable
 import Data.Generics.Uniplate.Data ()
 import Data.Generics.Uniplate.Operations (transform)
-import qualified Data.Kind as Kind
 import Data.Maybe (mapMaybe)
 import Data.String
 import Data.Void
@@ -428,7 +427,7 @@ mapNameScoped f = go 0
 -- ** N-ary Reducing Applications
 
 class (HasSubst term) => HasApp term where
-  type AppArg term :: Kind.Type
+  type AppArg term
   appN :: (IsVar (SubstVar term), HasCallStack) => term -> [AppArg term] -> term
 
 app :: (HasApp term, HasCallStack) => term -> AppArg term -> term

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -351,13 +351,6 @@ rewriteHofType = go 0
     go pos (SystF.TyAll ann k ty) = SystF.TyAll ann k *** (Nothing :) $ go (pos + 1) ty
     go _pos SystF.TyLam {} = error "unexpected arg type" -- TODO mention the type
 
--- -- | This is a little more eager than 'rewriteHofType', in this case, we rewrite ALL
--- -- function types.
--- rewriteFunType :: (Language lang) => B.Type lang -> B.Type lang
--- rewriteFunType = transform go
---   where
---     go ty@SystF.TyFun {} = closureType ty
---     go x = x
 
 -- Assumes the body is normalized enough so that all the binders are at the front.
 -- Dis-assuming this is merely about recursing on `App` ctor as well.

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -351,7 +351,6 @@ rewriteHofType = go 0
     go pos (SystF.TyAll ann k ty) = SystF.TyAll ann k *** (Nothing :) $ go (pos + 1) ty
     go _pos SystF.TyLam {} = error "unexpected arg type" -- TODO mention the type
 
-
 -- Assumes the body is normalized enough so that all the binders are at the front.
 -- Dis-assuming this is merely about recursing on `App` ctor as well.
 rewriteHofBody ::

--- a/src/Pirouette/Transformations/Defunctionalization.hs
+++ b/src/Pirouette/Transformations/Defunctionalization.hs
@@ -214,7 +214,7 @@ defunCalls ::
   M.Map Name (HofsList lang) ->
   PrtUnorderedDefs lang ->
   DefunCallsCtx lang (PrtUnorderedDefs lang)
-defunCalls toDefun decls@PrtUnorderedDefs {..} = do
+defunCalls toDefun PrtUnorderedDefs {..} = do
   decls' <- for prtUODecls $ \case
     DFunction r body ty -> (\body' -> DFunction r body' ty) <$> defunCallsInTerm [] body
     def -> pure def
@@ -351,13 +351,13 @@ rewriteHofType = go 0
     go pos (SystF.TyAll ann k ty) = SystF.TyAll ann k *** (Nothing :) $ go (pos + 1) ty
     go _pos SystF.TyLam {} = error "unexpected arg type" -- TODO mention the type
 
--- | This is a little more eager than 'rewriteHofType', in this case, we rewrite ALL
--- function types.
-rewriteFunType :: (Language lang) => B.Type lang -> B.Type lang
-rewriteFunType = transform go
-  where
-    go ty@SystF.TyFun {} = closureType ty
-    go x = x
+-- -- | This is a little more eager than 'rewriteHofType', in this case, we rewrite ALL
+-- -- function types.
+-- rewriteFunType :: (Language lang) => B.Type lang -> B.Type lang
+-- rewriteFunType = transform go
+--   where
+--     go ty@SystF.TyFun {} = closureType ty
+--     go x = x
 
 -- Assumes the body is normalized enough so that all the binders are at the front.
 -- Dis-assuming this is merely about recursing on `App` ctor as well.

--- a/src/Pirouette/Transformations/Utils.hs
+++ b/src/Pirouette/Transformations/Utils.hs
@@ -8,16 +8,11 @@
 
 module Pirouette.Transformations.Utils where
 
-import Control.Arrow (first, second)
-import Data.Data
-import qualified Data.Map as M
-import qualified Data.Text as T
+import Control.Arrow (first)
 import Debug.Trace
 import Pirouette.Monad
 import Pirouette.Term.Syntax
 import Pirouette.Term.Syntax.SystemF hiding (Arg)
-import qualified Pirouette.Term.Syntax.SystemF as SystF
-import Prettyprinter hiding (Pretty, pretty)
 
 traceDefsId :: (LanguagePretty lang) => PrtUnorderedDefs lang -> PrtUnorderedDefs lang
 traceDefsId defs = renderSingleLineStr (pretty $ prtUODecls defs) `trace` defs


### PR DESCRIPTION
Building Pirouette produces a few warnings, namely:

- `-Wstar-is-type`
- `-Wunused-imports`
- `-Wunused-top-binds`
- `-Wunused-matches`
- `-Wname-shadowing`

This PR fixes the pieces of code producing these warnings.