### PR TITLE
speed up smt calls

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,12 +1,6 @@
 -- Bump this if you need newer packages
 index-state: 2022-04-07T00:00:00Z
 
--- until https://github.com/IagoAbal/haskell-z3/pull/84 is merged upstream,
--- a fork of haskell-z3 is needed
-source-repository-package
-  type: git
-  location: https://github.com/qaristote/haskell-z3.git
-
 packages:
   .
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,12 @@
 -- Bump this if you need newer packages
 index-state: 2022-04-07T00:00:00Z
 
+-- until https://github.com/IagoAbal/haskell-z3/pull/84 is merged upstream,
+-- a fork of haskell-z3 is needed
+source-repository-package
+  type: git
+  location: https://github.com/qaristote/haskell-z3.git
+
 packages:
   .
 

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -4,5 +4,6 @@
 let
   ourpkgs = import ./packages.nix {};
 in pkgs.mkShell {
+    nativeBuildInputs = ourpkgs.native-deps;
     buildInputs = ourpkgs.build-deps;
 }

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -6,4 +6,5 @@ let
 in pkgs.mkShell {
     nativeBuildInputs = ourpkgs.native-deps;
     buildInputs = ourpkgs.build-deps;
+    LD_LIBRARY_PATH = "${pkgs.z3.lib}/lib";
 }

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -6,5 +6,4 @@ let
 in pkgs.mkShell {
     nativeBuildInputs = ourpkgs.native-deps;
     buildInputs = ourpkgs.build-deps;
-    LD_LIBRARY_PATH = "${pkgs.z3.lib}/lib";
 }

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -23,7 +23,7 @@
         haskellPackages.cabal-install
         haskellPackages.happy
         haskell.compiler.ghc902
-        cvc4 # required to run pirouette once its built
+        z3 # required to run pirouette once its built
      ] ++ lib.optional (stdenv.isLinux) systemd.dev;
 
   dev-deps = with rawpkgs; [

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -23,12 +23,13 @@
         haskellPackages.cabal-install
         haskellPackages.happy
         haskell.compiler.ghc902
-        z3 # required to run pirouette once its built
      ] ++ lib.optional (stdenv.isLinux) systemd.dev;
 
   dev-deps = with rawpkgs; [
         haskellPackages.haskell-language-server
       ];
+
+  native-deps = with rawpkgs; [ z3.dev ];
 
   # Export the raw nixpkgs to be accessible to whoever imports this.
   nixPkgsProxy = rawpkgs;

--- a/package.yaml
+++ b/package.yaml
@@ -33,8 +33,7 @@ dependencies:
   - optics-core
   - optics-th
   # PureSMT deps
-  - process
-  - typed-process
+  - inline-c
   - z3
 
 library:

--- a/package.yaml
+++ b/package.yaml
@@ -34,13 +34,24 @@ dependencies:
   - optics-th
   # PureSMT deps
   - inline-c
-  - z3
+
 
 library:
   source-dirs: src
   ghc-options:
     -Wall
     -Wno-orphans
+  # Copied from https://hackage.haskell.org/package/z3-408.2/src/z3.cabal
+  #
+  # In OS X libz3 is linked statically against libgomp.
+  # In Windows Z3 is compiled using MS C++.
+  when:
+    - condition: os(darwin) || os(windows)
+      then:
+        extra-libraries: z3
+      else:
+        extra-libraries: gomp z3 gomp
+
 
 tests:
   spec:
@@ -64,4 +75,3 @@ tests:
 ##       -fprof-auto
 ##       -fexternal-interpreter
 ##       "-with-rtsopts=-N -p -s -h"
-

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   # PureSMT deps
   - process
   - typed-process
+  - z3
 
 library:
   source-dirs: src

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -59,6 +59,7 @@ library
       PureSMT
       PureSMT.Process
       PureSMT.SExpr
+      PureSMT.Z3
   other-modules:
       Paths_pirouette
   autogen-modules:
@@ -76,6 +77,7 @@ library
     , deriving-compat
     , extra
     , haskell-stack-trace-plugin
+    , inline-c
     , interpolate
     , megaparsec
     , mtl >=2.2.2
@@ -84,14 +86,12 @@ library
     , parallel
     , parser-combinators
     , prettyprinter
-    , process
     , tasty
     , tasty-expected-failure
     , tasty-hunit
     , tasty-quickcheck
     , template-haskell
     , text
-    , typed-process
     , uniplate
     , z3
   default-language: Haskell2010
@@ -127,6 +127,7 @@ test-suite spec
     , deriving-compat
     , extra
     , haskell-stack-trace-plugin
+    , inline-c
     , interpolate
     , megaparsec
     , mtl >=2.2.2
@@ -136,14 +137,12 @@ test-suite spec
     , parser-combinators
     , pirouette
     , prettyprinter
-    , process
     , tasty
     , tasty-expected-failure
     , tasty-hunit
     , tasty-quickcheck
     , template-haskell
     , text
-    , typed-process
     , uniplate
     , z3
   default-language: Haskell2010

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -93,8 +93,15 @@ library
     , template-haskell
     , text
     , uniplate
-    , z3
   default-language: Haskell2010
+  -- Copied from https://hackage.haskell.org/package/z3-408.2/src/z3.cabal
+  --
+  -- In OS X libz3 is linked statically against libgomp.
+  -- In Windows Z3 is compiled using MS C++.
+  if os(darwin) || os(windows)
+      extra-libraries:     z3
+  else
+      extra-libraries:     gomp z3 gomp
 
 test-suite spec
   type: exitcode-stdio-1.0
@@ -144,5 +151,4 @@ test-suite spec
     , template-haskell
     , text
     , uniplate
-    , z3
   default-language: Haskell2010

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -93,15 +93,13 @@ library
     , template-haskell
     , text
     , uniplate
-  default-language: Haskell2010
-  -- Copied from https://hackage.haskell.org/package/z3-408.2/src/z3.cabal
-  --
-  -- In OS X libz3 is linked statically against libgomp.
-  -- In Windows Z3 is compiled using MS C++.
   if os(darwin) || os(windows)
-      extra-libraries:     z3
+    extra-libraries:
+        z3
   else
-      extra-libraries:     gomp z3 gomp
+    extra-libraries:
+        gomp z3 gomp
+  default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -93,6 +93,7 @@ library
     , text
     , typed-process
     , uniplate
+    , z3
   default-language: Haskell2010
 
 test-suite spec
@@ -144,4 +145,5 @@ test-suite spec
     , text
     , typed-process
     , uniplate
+    , z3
   default-language: Haskell2010

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ let
 in pkgs.mkShell {
     nativeBuildInputs = ourpkgs.native-deps;
     buildInputs = ourpkgs.build-deps ++ ourpkgs.dev-deps ++ runtime-deps;
+    LD_LIBRARY_PATH = "${pkgs.z3.lib}/lib";
 
     # This shell hook was taken from: https://github.com/input-output-hk/ouroboros-network/pull/3649/files
     # and is necessary to set the right locale so tools such as ormolu and graphmod can work

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@ let
       ourpkgs.nixPkgsProxy.haskellPackages.graphmod
     ];
 in pkgs.mkShell {
+    nativeBuildInputs = ourpkgs.native-deps;
     buildInputs = ourpkgs.build-deps ++ ourpkgs.dev-deps ++ runtime-deps;
 
     # This shell hook was taken from: https://github.com/input-output-hk/ouroboros-network/pull/3649/files

--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,6 @@ let
 in pkgs.mkShell {
     nativeBuildInputs = ourpkgs.native-deps;
     buildInputs = ourpkgs.build-deps ++ ourpkgs.dev-deps ++ runtime-deps;
-    LD_LIBRARY_PATH = "${pkgs.z3.lib}/lib";
 
     # This shell hook was taken from: https://github.com/input-output-hk/ouroboros-network/pull/3649/files
     # and is necessary to set the right locale so tools such as ormolu and graphmod can work

--- a/src/Language/Pirouette/Example/IsUnity.hs
+++ b/src/Language/Pirouette/Example/IsUnity.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE QuasiQuotes #-}
+-- -l has the effect of causing the TH interpreter to try loading
+-- z3 to resolve otherwise undefined symbols
+{-# OPTIONS_GHC -lz3 #-}
 
 module Language.Pirouette.Example.IsUnity where
 

--- a/src/Pirouette/SMT/Base.hs
+++ b/src/Pirouette/SMT/Base.hs
@@ -2,7 +2,6 @@
 
 module Pirouette.SMT.Base where
 
-import Control.Monad.IO.Class
 import Data.Void
 import Pirouette.Term.Syntax
 import qualified PureSMT
@@ -33,13 +32,3 @@ instance ToSMT Name where
   translate = PureSMT.symbol . toSmtName
 
 type WithDebugMessages = Bool
-
--- | Prepare a CVC4 solver with all supported theories, which is necessary
--- to handle datatypes. The boolean parameter controls debug messages.
--- The "fmf-fun" options is much better at finding sat by constructing finite model of recursive functions,
--- whereas "full-saturate-quant" makes a much better use of the universally quantified hints to find unsat.
-cvc4_ALL_SUPPORTED :: (MonadIO m) => WithDebugMessages -> m PureSMT.Solver
-cvc4_ALL_SUPPORTED dbg = do
-  s <- liftIO $ PureSMT.launchSolverWithFinalizer "cvc4 --lang=smt2 --incremental --fmf-fun" dbg
-  liftIO $ PureSMT.setLogic s "ALL"
-  return s

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -82,7 +82,9 @@ solveOpts opts ctx = unsafePerformIO $ do
       -- TODO: what happens in an exception? For now, we just loose a solver but we shouldn't
       -- add it to the pool of workers and just retry the problem. In a future implementation
       -- we could try launching it again
-      solveProblem @domain problem solver
+      r <- solveProblem @domain problem solver
+      void $ command solver $ List [Atom "exit"]
+      return r
     pushMStack ms allProcs
     return r
 

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -94,7 +94,7 @@ initAll opts ctx = replicateM nWorkers $ do
   -- this would be especially useful if the solver options are passed
   -- when creating the configuration instead of inside the initSolver
   -- function
-  s <- X.initZ3instance (debug opts)
+  s <- X.initZ3Instance (debug opts)
   initSolver @domain ctx s
   newMVar s
   where

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -88,6 +88,10 @@ solveOpts opts ctx = unsafePerformIO $ do
 
 initAll :: forall domain. Options -> Solve domain => Ctx domain -> IO [MVar X.Solver]
 initAll opts ctx = replicateM nWorkers $ do
+  -- TODO: each init creates its own config but they could be shared
+  -- this would be especially useful if the solver options are passed
+  -- when creating the configuration instead of inside the initSolver
+  -- function
   s <- X.initZ3instance (debug opts)
   initSolver @domain ctx s
   newMVar s

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -83,7 +83,7 @@ solveOpts opts ctx = unsafePerformIO $ do
       -- add it to the pool of workers and just retry the problem. In a future implementation
       -- we could try launching it again
       r <- solveProblem @domain problem solver
-      void $ command solver $ List [Atom "exit"]
+      X.freeZ3Instance solver
       return r
     pushMStack ms allProcs
     return r

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -83,7 +83,6 @@ solveOpts opts ctx = unsafePerformIO $ do
       -- add it to the pool of workers and just retry the problem. In a future implementation
       -- we could try launching it again
       r <- solveProblem @domain problem solver
-      X.freeZ3Instance solver
       return r
     pushMStack ms allProcs
     return r

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -6,6 +6,7 @@ module PureSMT.Process where
 
 import Control.Monad
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Unsafe as BS
 import Foreign.Ptr (Ptr)
 import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Unsafe as CU
@@ -53,7 +54,7 @@ command solver cmd = do
     [CU.exp| const char* {
                   Z3_eval_smtlib2_string($(Z3_context ctx), $bs-cstr:cmdTxt)
                   } |]
-      >>= BS.packCString
+      >>= BS.unsafePackCString
   case readSExpr resp of
     Nothing -> do
       fail $ "solver replied with:\n" ++ BS.unpack resp

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -55,7 +55,7 @@ command solver cmd = do
       >>= BS.packCString
   case readSExpr resp of
     Nothing -> do
-      fail $ "solver replied with:\n" ++ BS.unpack resp -- ++ "\n" ++ rest
+      fail $ "solver replied with:\n" ++ BS.unpack resp
     Just (sexpr, _) -> do
       when (debugMode solver && sexpr /= Atom "success") $ do
         putStrLn $ "[recv] " ++ showsSExpr sexpr ""

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -7,7 +7,8 @@ module PureSMT.Process where
 import Control.Monad
 import qualified Data.ByteString.Char8 as BS
 import Foreign.Ptr (Ptr)
-import qualified Language.C.Inline as C
+import qualified Language.C.Inline as C hiding (block, exp)
+import qualified Language.C.Inline.Unsafe as C
 import PureSMT.SExpr
 import qualified PureSMT.Z3 as Z3
 import System.IO

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -24,11 +24,11 @@ data Solver = Solver
   }
 
 -- | Create a brand-new context for Z3 to work in.
-initZ3instance ::
+initZ3Instance ::
   -- | Whether or not to debug the interaction
   Bool ->
   IO Solver
-initZ3instance dbg = do
+initZ3Instance dbg = do
   solverCtx <-
     [CU.block| Z3_context {
                      Z3_config cfg = Z3_mk_config();

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -26,13 +26,11 @@ data Solver = Solver
 -- TODO: rename this function and change its type
 
 -- | Create a brand-new context for Z3 to work in.
-launchSolverWithFinalizer ::
-  -- | Unused argument existing to match the old interface
-  String ->
+initZ3instance ::
   -- | Whether or not to debug the interaction
   Bool ->
   IO Solver
-launchSolverWithFinalizer _ dbg = do
+initZ3instance dbg = do
   solverCfg <- z3_mk_config
   solverCtx <- z3_mk_context solverCfg
 

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -43,6 +43,9 @@ initZ3instance dbg = do
 
   return s
 
+freeZ3Instance :: Solver -> IO ()
+freeZ3Instance s = void $ command s $ List [Atom "exit"]
+
 -- | Have Z3 evaluate a command in SExpr format.
 command :: Solver -> SExpr -> IO SExpr
 command solver cmd = do

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -55,7 +55,7 @@ command solver cmd = do
   let ctx = context solver
   resp <-
     [CU.exp| const char* {
-                  Z3_eval_smtlib2_string($(Z3_context ctx), $bs-cstr:cmdTxt)
+                  Z3_eval_smtlib2_string($(Z3_context ctx), $bs-ptr:cmdTxt)
                   } |]
       >>= BS.unsafePackCString
   case readSExpr resp of

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -7,8 +7,8 @@ module PureSMT.Process where
 import Control.Monad
 import qualified Data.ByteString.Char8 as BS
 import Foreign.Ptr (Ptr)
-import qualified Language.C.Inline as C hiding (block, exp)
-import qualified Language.C.Inline.Unsafe as C
+import qualified Language.C.Inline as C
+import qualified Language.C.Inline.Unsafe as CU
 import PureSMT.SExpr
 import qualified PureSMT.Z3 as Z3
 import System.IO
@@ -29,7 +29,7 @@ initZ3instance ::
   IO Solver
 initZ3instance dbg = do
   solverCtx <-
-    [C.block| Z3_context {
+    [CU.block| Z3_context {
                      Z3_config cfg = Z3_mk_config();
                      Z3_context ctx = Z3_mk_context(cfg);
                      Z3_del_config(cfg);
@@ -50,7 +50,7 @@ command solver cmd = do
     BS.putStrLn $ "[send] " `BS.append` cmdTxt
   let ctx = context solver
   resp <-
-    [C.exp| const char* {
+    [CU.exp| const char* {
                   Z3_eval_smtlib2_string($(Z3_context ctx), $bs-cstr:cmdTxt)
                   } |]
       >>= BS.packCString

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -227,10 +227,10 @@ readSExpr ('(' :< more) = do
   return (List es, rest)
   where
     list :: BS.ByteString -> Maybe ([SExpr], BS.ByteString)
-    list (c :< more) | isSpace c = list more
-    list (')' :< more) = return ([], more)
-    list more = do
-      (e, rest) <- readSExpr more
+    list (c :< more') | isSpace c = list more'
+    list (')' :< more') = return ([], more')
+    list more' = do
+      (e, rest) <- readSExpr more'
       (es, rest') <- list rest
       return (e : es, rest')
 readSExpr txt =

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -15,7 +15,6 @@ import Data.ByteString.Builder
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Char (isDigit, isSpace)
-import Data.Function ((&))
 import Data.List (intersperse)
 import Data.Ratio (denominator, numerator, (%))
 import qualified Data.Text
@@ -218,7 +217,7 @@ pattern c :< rest <- (BS.uncons -> Just (c, rest))
 -- | Parse an s-expression.
 readSExpr :: BS.ByteString -> Maybe (SExpr, BS.ByteString)
 readSExpr (c :< more) | isSpace c = readSExpr more
-readSExpr (';' :< more) = BS.dropWhile (/= '\n') more & BS.drop 1 & readSExpr
+readSExpr (';' :< more) = readSExpr $ BS.drop 1 $ BS.dropWhile (/= '\n') more
 readSExpr ('|' :< more) = do
   let (sym, '|' :< rest) = BS.break (== '|') more
   Just (Atom $ BS.unpack $ BS.cons '|' $ BS.snoc sym '|', rest)

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -8,7 +8,6 @@ module PureSMT.SExpr where
 import Data.Bits (testBit)
 import Data.ByteString.Builder
   ( Builder,
-    charUtf8,
     stringUtf8,
     toLazyByteString,
   )
@@ -70,9 +69,7 @@ serializeSExpr = LBS.toStrict . toLazyByteString . (<> "\NUL") . renderSExpr
     renderSExpr :: SExpr -> Builder
     renderSExpr (Atom x) = stringUtf8 x
     renderSExpr (List es) =
-      charUtf8 '('
-        <> mconcat (intersperse (charUtf8 ' ') [renderSExpr e | e <- es])
-        <> charUtf8 ')'
+      "(" <> mconcat (intersperse " " [renderSExpr e | e <- es]) <> ")"
 
 -- | Show an s-expression.
 showsSExpr :: SExpr -> ShowS

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -63,9 +63,9 @@ overAtomS :: (String -> String) -> SExpr -> SExpr
 overAtomS f (Atom s) = Atom (f s)
 overAtomS f (List ss) = List [overAtomS f s | s <- ss]
 
--- | Convert an s-expression to a (strict) bytestring.
+-- | Convert an s-expression to a (strict) null terminated bytestring.
 serializeSExpr :: SExpr -> BS.ByteString
-serializeSExpr = LBS.toStrict . toLazyByteString . renderSExpr
+serializeSExpr = LBS.toStrict . toLazyByteString . (<> "\NUL") . renderSExpr
   where
     renderSExpr :: SExpr -> Builder
     renderSExpr (Atom x) = stringUtf8 x

--- a/src/PureSMT/Z3.hs
+++ b/src/PureSMT/Z3.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module PureSMT.Z3 where
+
+import qualified Data.Map as M
+import Foreign.Ptr (Ptr)
+import qualified Language.C.Inline.Context as C
+import qualified Language.C.Types as C
+
+data LogicalContext
+
+cContext :: C.Context
+cContext = mempty {C.ctxTypesTable = M.singleton (C.TypeName "Z3_context") [t|Ptr LogicalContext|]}


### PR DESCRIPTION
# Why ?

Currently, Pirouette uses SMT solvers by [calling them as external processes](https://github.com/tweag/pirouette/blob/3805638e0e11b5a0fc5cc6a41bd415d52674d23a/src/PureSMT/Process.hs#L26-L45) and [communicating with them using OS-level channels](https://github.com/tweag/pirouette/blob/3805638e0e11b5a0fc5cc6a41bd415d52674d23a/src/PureSMT/Process.hs#L47-L67). The language used to communicate with the solvers is SMTLib, which means the interaction goes as follows:
- Pirouette converts an s-expression (its internal representation for the solver's state) to an SMTLib command;
- it sends this command on a channel;
- the solver reads the command and parses it;
- it evaluates the result and converts it again from its internal representation to SMTLib;
- it sends this SMTLib output on a unix channel which is read by Pirouette;
- Pirouette converts the SMTLib output to an s-expression again.
This is considered slow, especially in comparison to directly linking the solvers' APIs inside Pirouette's code.

Some benchmarks verifying this intuition are available and detailed [here](/tweag/pirouette-benchmarks). Overall, here are the key takeaways:
-  on the biggest example of the test suite, Z3 is 2 times faster than the CVC instance used by default in Pirouette;
- using Z3 bindings instead of calling an external process speeds up the call to Z3 inside Pirouette by 14%;
- using bytestrings on top of bindings for the call to Z3 increases the speed-up to 14%;
- overall these two changes combined speed up Pirouette itself by 14%;
- these speed-ups could have been expected to be more important, but it is likely that Pirouette doing work in between each call to the solver hinders it from going at full speed;
- on the biggest example in the test suite, creating and parsing SMTLib commands takes up 12% of Pirouette running-time pre-speedup and 18% of its running-time post-speedup.

# What ?

This PR thus replaces the internals of the `PureSMT` module to call Z3 bindings instead of running solvers as external processes. We only use the [`z3_eval_smtlib2_string`](https://z3prover.github.io/api/html/group__capi.html#gaa623f645ba1458d1d4be9e023c05ae17) binding (which has Z3 evaluate SMTLib commands) instead of using bindings to manually build the AST because the serializing and parsing of SMTLib commands is deemed quick enough that the work needed to use these finer-grained bindings would not be worth the speedup. We thus also have these SMTLib commands be given to the solver as bytestrings instead of higher-level strings.

Commit c79d8bb4a4beb9ad448c4cf97130ebbfd9a068be replaces the internals of `PureSMT` to use bindings instead of running external processes. This introduces a dependency to the [`haskell-z3`](https://hackage.haskell.org/package/z3) library which ports Z3's C bindings to Haskell. As the library does not export the `z3_eval_smtlib2_string`, we actually rely on a [temporary fork](/qaristote/haskell-z3) that does.

This results in some of the `PureSMT` interface becoming useless as it was designed with running external processes in mind. Commit 64f18eb12229e7025596a59cb83ed07e03337fe0 cleans this interface.

As relying on a temporary fork of `haskell-z3` is not ideal, we instead use the bindings inside inlined C code in commit 33977c2e05fd32213a8c804a0eaf1329d8b3d7ef. There is still a dependency on (upstream) `haskell-z3` because I did not manage to get linking to work without it.

# What's next ?

Once the `haskell-z3` fork is [merged upstream](/IagoAbal/haskell-z3/pull/84) it shouldn't be necessary to inline C code anymore. Ideally `haskell-z3` should also be improved to allow using bytestrings in its higher-level modules `Z3.Monad` and `Z3.Base`, as currently only the lower-level `Z3.Base.C` allows it.  

This PR makes Pirouette not solver-universal anymore: the use of Z3 is forced. Other solvers could be supported again given that they provide an API with a function similar to `z3_eval_smtlib2_string`, but as of writing this is not the case of CVC4 or CVC5 for example.

Interestingly, our benchmarks also showed that even Z3's C API is not as fast as Z3 itself, most likely because `z3_eval_smtlib2_string` does not wrap Z3's internals the same way Z3's frontend does. This could be an additional direction in which to look to further improve the running-time of the interaction with Z3 inside Pirouette.

After this PR, serializing and parsing SMTLib commands will take up 18% of Pirouette's running time on the biggest example of the test suite. If this were to be deemed enough to decide that the internals of `PureSMT` should build the AST themselves (fully using Z3's API) instead of relying on SMTLib, recovering solver-universality would require a Haskell library akin to [`smt-switch`](/stanford-centaur/smt-switch) or [`metaSMT`](https://github.com/agra-uni-bremen/metaSMT) (which would likely be a lot of work).