### PR TITLE
PureSMT: send commands with no output by batches

### DIFF
--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -98,7 +98,10 @@ command solver expr = do
   send solver cmds
 
 -- | A command with no interesting result.
--- The result is only checked for consistency in debug mode.
+-- In debug mode, the result is checked for correctness and the queue of commands
+-- to evaluate is ignored.
+-- In non-debug mode, the command must not produce any output when evaluated, and
+-- it is not checked for correctness.
 ackCommand :: Solver -> SExpr -> IO ()
 ackCommand solver expr =
   if debugMode solver
@@ -117,12 +120,14 @@ ackCommand solver expr =
     else putQueue solver expr
 
 -- | A command entirely made out of atoms, with no interesting result.
+-- See also `ackCommand`.
 simpleCommand :: Solver -> [String] -> IO ()
 simpleCommand solver = ackCommand solver . List . map Atom
 
 -- | Run a command and return True if successful, and False if unsupported.
--- This is useful for setting options that unsupported by some solvers, but used
+-- This is useful for setting options that are unsupported by some solvers, but used
 -- by others.
+-- See also `command`.
 simpleCommandMaybe :: Solver -> [String] -> IO Bool
 simpleCommandMaybe solver c =
   do

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -21,7 +21,7 @@ C.include "z3.h"
 data Solver = Solver
   { context :: ForeignPtr Z3.LogicalContext,
     debugMode :: Bool,
-    queue :: IORef Builder
+    queue :: IORef Builder   -- only used in non-debug mode
   }
 
 -- | Create a brand-new context for Z3 to work in.

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -21,7 +21,7 @@ C.include "z3.h"
 data Solver = Solver
   { context :: ForeignPtr Z3.LogicalContext,
     debugMode :: Bool,
-    queue :: IORef Builder   -- only used in non-debug mode
+    queue :: IORef Builder -- only used in non-debug mode
   }
 
 -- | Create a brand-new context for Z3 to work in.

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -71,7 +71,11 @@ serializeUntrimmed firstChunkSize newChunksSize = LBS.toStrict . toLazyByteStrin
 -- (the size of the buffer is expected to be small). The output is a null-terminated
 -- strict bytestring that is expected to be consumed immediately.
 serializeSingle :: Builder -> BS.ByteString
-serializeSingle = serializeUntrimmed 256 2048
+serializeSingle =
+  -- 256 is the first power of 2 that is bigger than the length of the longest
+  -- command with interesting output in isUnity, and 2048 is just four times this
+  -- because smallChunkSize * 4 = defaultChunkSize.
+  serializeUntrimmed 256 2048
 
 -- | Evaluate a bytestring builder corresponding to a batch of SMTLib2 commands
 -- (the size of the buffer is expected to be important). The output is a

--- a/src/PureSMT/SExpr.hs
+++ b/src/PureSMT/SExpr.hs
@@ -62,22 +62,24 @@ overAtomS :: (String -> String) -> SExpr -> SExpr
 overAtomS f (Atom s) = Atom (f s)
 overAtomS f (List ss) = List [overAtomS f s | s <- ss]
 
--- | Evaluate a bytestring builder to a strict bytestring that is expected to be
--- consumed immediately.
+-- | Evaluate a bytestring builder to a null-terminated strict bytestring
+-- that is expected to be consumed immediately.
 serializeUntrimmed :: Int -> Int -> Builder -> BS.ByteString
 serializeUntrimmed firstChunkSize newChunksSize = LBS.toStrict . toLazyByteStringWith (untrimmedStrategy firstChunkSize newChunksSize) "\NUL"
 
 -- | Evaluate a bytestring builder corresponding to a single SMTLib2 command
--- (the size of the buffer is expected to be small).
+-- (the size of the buffer is expected to be small). The output is a null-terminated
+-- strict bytestring that is expected to be consumed immediately.
 serializeSingle :: Builder -> BS.ByteString
 serializeSingle = serializeUntrimmed 256 2048
 
 -- | Evaluate a bytestring builder corresponding to a batch of SMTLib2 commands
--- (the size of the buffer is expected to be important).
+-- (the size of the buffer is expected to be important). The output is a
+-- null-terminated strict bytestring that is expected to be consumed immediately.
 serializeBatch :: Builder -> BS.ByteString
 serializeBatch = serializeUntrimmed smallChunkSize defaultChunkSize
 
--- | Convert an s-expression to a (strict) null-terminated bytestring.
+-- | Create a bytestring builder from an s-expression.
 renderSExpr :: SExpr -> Builder
 renderSExpr (Atom x) = stringUtf8 x
 renderSExpr (List es) =


### PR DESCRIPTION
This PR merges together SMTLib2 commands whose output can be ignored (typically when the output is either `(success)` or an error). In practice, these commands are effectively added to a queue given by a [ByteString Builder](https://hackage.haskell.org/package/bytestring-0.11.3.1/docs/Data-ByteString-Builder.html) and this queue is only sent to the solver as one big batched command when the output of the next command cannot be ignored. This also means that in non-debug mode the commands are not checked to be valid and may thus lead to an error that isn't caught immediately.

The expected speed-up is described in the [`qa/z3_binding_faster_eval`](https://github.com/tweag/pirouette-benchmarks/commit/e09e0a7adc3b5260b3f2dbbae5f95a9dd679fad3) branch of [`pirouette-benchmarks`](https://github.com/tweag/pirouette-benchmarks): Pirouette is now 1.16 times faster on the largest example, `isUnity`. Note that these measurements were made with [a version of Z3](https://github.com/Z3Prover/z3/pull/6422) that improves the speed of the binding used in Pirouette's code but isn't part of a release yet, so until the next release the actual speed-up may differ.

While that wasn't measured to improve the speed of Pirouette, the serialization of s-expressions to bytestring is now done using the [untrimmed strategy](https://hackage.haskell.org/package/bytestring-0.11.3.1/docs/Data-ByteString-Builder-Extra.html#v:untrimmedStrategy) which is theoretically faster for building a bytestring which will be consumed immediately afterwards. Similarly, we manually set the size of the chunks depending on whether a single command or a whole batch is being serialized.