### PR TITLE
Add a standard library for the example language

### DIFF
--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -17,6 +17,7 @@ library
   exposed-modules:
       Language.Pirouette.Example
       Language.Pirouette.Example.IsUnity
+      Language.Pirouette.Example.StdLib
       Language.Pirouette.QuasiQuoter
       Language.Pirouette.QuasiQuoter.Internal
       Language.Pirouette.QuasiQuoter.Syntax

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -18,6 +18,7 @@ library
       Language.Pirouette.Example
       Language.Pirouette.Example.IsUnity
       Language.Pirouette.QuasiQuoter
+      Language.Pirouette.QuasiQuoter.Internal
       Language.Pirouette.QuasiQuoter.Syntax
       Language.Pirouette.QuasiQuoter.ToTerm
       ListT.Weighted

--- a/src/Language/Pirouette/Example/IsUnity.hs
+++ b/src/Language/Pirouette/Example/IsUnity.hs
@@ -59,12 +59,6 @@ pairEq @a @b eqA eqB x y =
     (\(x0 : a) (x1 : b) . match_Pair @a @b y @Bool
       (\(y0 : a) (y1 : b) . and (eqA x0 y0) (eqB x1 y1)))
 
-maybeSum : forall a . Maybe a -> Maybe a -> Maybe a
-maybeSum @a m1 m2 =
-  match_Maybe @a m1 @(Maybe a)
-    m2
-    (\(j1 : a) . Just @a j1)
-
 data KVMap k v
   = KV : List (Pair k v) -> KVMap k v
 
@@ -79,7 +73,7 @@ lkupOne @k @v predi m =
 lkup : forall k v . (k -> k -> Bool) -> KVMap k v -> k -> Maybe v
 lkup @k @v eq m tgt =
   match_KVMap @k @v m @(Maybe v)
-    (foldr @(Pair k v) @(Maybe v) (\(pk : Pair k v) . maybeSum @v (lkupOne @k @v (eq tgt) pk)) (Nothing @v))
+    (foldr @(Pair k v) @(Maybe v) (\(pk : Pair k v) . firstJust @v (lkupOne @k @v (eq tgt) pk)) (Nothing @v))
 
 -- Just like a plutus value, but se use integers for currency symbols and token names
 -- to not have to deal with bytestrings

--- a/src/Language/Pirouette/Example/StdLib.hs
+++ b/src/Language/Pirouette/Example/StdLib.hs
@@ -54,6 +54,9 @@ isJust @a m =
   match_Maybe @a m @Bool
     False
     (\(n : a) . True)
+
+firstJust : forall a . Maybe a -> Maybe a -> Maybe a
+firstJust @a m1 m2 = if @(Maybe a) isJust @a m1 then m1 else m2
 |]
 
 lists :: PrtUnorderedDefs Ex

--- a/src/Language/Pirouette/Example/StdLib.hs
+++ b/src/Language/Pirouette/Example/StdLib.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- -l has the effect of causing the TH interpreter to try loading
+-- z3 to resolve otherwise undefined symbols
+{-# OPTIONS_GHC -lz3 #-}
+
+module Language.Pirouette.Example.StdLib where
+
+import Language.Haskell.TH.Quote
+import Language.Pirouette.Example
+import Language.Pirouette.QuasiQuoter.Internal (maybeQ, parseQ, quoter, trQ)
+import Language.Pirouette.QuasiQuoter.Syntax
+import Language.Pirouette.QuasiQuoter.ToTerm
+import Pirouette.Monad
+import Pirouette.Term.TypeChecker (typeCheckDecls)
+import Text.Megaparsec
+
+booleans :: PrtUnorderedDefs Ex
+booleans =
+  [progNoTC|
+and : Bool -> Bool -> Bool
+and x y = if @Bool x then y else False
+
+or : Bool -> Bool -> Bool
+or x y = if @Bool x then True else y
+|]
+
+lists :: PrtUnorderedDefs Ex
+lists =
+  [progNoTC|
+data List a
+  = Nil : List a
+  | Cons : a -> List a -> List a
+
+foldr : forall a r . (a -> r -> r) -> r -> List a -> r
+foldr @a @r f e l =
+  match_List @a l @r
+    e
+    (\(x : a) (xs : List a) . f x (foldr @a @r f e xs))
+
+eqList :
+  forall a .
+  (a -> a -> Bool) ->
+  List a -> List a -> Bool
+eqList @a eq x0 y0 =
+  match_List @a x0 @Bool
+    (match_List @a y0 @Bool
+      True
+      (\(y : a) (ys : List a) . False))
+    (\(x : a) (xs : List a) .
+      match_List @a y0 @Bool
+        False
+        (\(y : a) (ys : List a) . and (eq x y) (eqList @a eq xs ys)))
+
+any : forall a . (a -> Bool) -> List a -> Bool
+any @a p xs =
+  match_List @a xs @Bool
+    False
+    (\(x : a) (xs2 : List a) . or (p x) (any @a p xs2))
+
+all : forall a . (a -> Bool) -> List a -> Bool
+all @a p xs =
+  match_List @a xs @Bool
+    True
+    (\(x : a) (xs2 : List a) . and (p x) (all @a p xs2))
+|]
+
+stdLib :: PrtUnorderedDefs Ex
+stdLib = unionPrtUODefs booleans lists
+
+progWithStdLib :: QuasiQuoter
+progWithStdLib = quoter $ \str -> do
+  p0 <- parseQ (spaceConsumer *> lexeme (parseProgram @Ex) <* eof) str
+  decls <- trQ (trProgram p0)
+  let fullDefs = addDecls decls stdLib
+      fullDecls = prtUODecls fullDefs
+  _ <- maybeQ (typeCheckDecls fullDecls)
+  [e|(PrtUnorderedDefs fullDecls)|]

--- a/src/Language/Pirouette/Example/StdLib.hs
+++ b/src/Language/Pirouette/Example/StdLib.hs
@@ -22,6 +22,7 @@ import Language.Pirouette.QuasiQuoter.Internal (maybeQ, parseQ, quoter, trQ)
 import Language.Pirouette.QuasiQuoter.Syntax
 import Language.Pirouette.QuasiQuoter.ToTerm
 import Pirouette.Monad
+import Pirouette.Term.Syntax.Pretty.Class (Pretty (..))
 import Pirouette.Term.TypeChecker (typeCheckDecls)
 import Text.Megaparsec
 
@@ -99,7 +100,11 @@ all @a p xs =
 |]
 
 stdLib :: PrtUnorderedDefs Ex
-stdLib = unionsPrtUODefs [booleans, maybes, lists]
+stdLib =
+  let decls = unionsPrtUODefs [booleans, maybes, lists]
+   in case typeCheckDecls $ prtUODecls decls of
+        Left typeError -> errorWithoutStackTrace $ ("Could not type-check standard library: " ++) $ show $ pretty typeError
+        Right () -> decls
 
 progWithStdLib :: QuasiQuoter
 progWithStdLib = quoter $ \str -> do

--- a/src/Language/Pirouette/Example/StdLib.hs
+++ b/src/Language/Pirouette/Example/StdLib.hs
@@ -99,7 +99,7 @@ all @a p xs =
 |]
 
 stdLib :: PrtUnorderedDefs Ex
-stdLib = unionPrtUODefs booleans $ unionPrtUODefs maybes lists
+stdLib = unionsPrtUODefs [booleans, maybes, lists]
 
 progWithStdLib :: QuasiQuoter
 progWithStdLib = quoter $ \str -> do

--- a/src/Language/Pirouette/Example/StdLib.hs
+++ b/src/Language/Pirouette/Example/StdLib.hs
@@ -10,9 +10,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
--- -l has the effect of causing the TH interpreter to try loading
--- z3 to resolve otherwise undefined symbols
-{-# OPTIONS_GHC -lz3 #-}
 
 module Language.Pirouette.Example.StdLib where
 

--- a/src/Language/Pirouette/Example/StdLib.hs
+++ b/src/Language/Pirouette/Example/StdLib.hs
@@ -33,6 +33,29 @@ and x y = if @Bool x then y else False
 
 or : Bool -> Bool -> Bool
 or x y = if @Bool x then True else y
+
+not : Bool -> Bool
+not b = if @Bool b then False else True
+|]
+
+maybes :: PrtUnorderedDefs Ex
+maybes =
+  [progNoTC|
+data Maybe a
+  = Nothing : Maybe a
+  | Just : a -> Maybe a
+
+isNothing : forall a . Maybe a -> Bool
+isNothing @a m =
+  match_Maybe @a m @Bool
+    True
+    (\(n : a) . False)
+
+isJust : forall a . Maybe a -> Bool
+isJust @a m =
+  match_Maybe @a m @Bool
+    False
+    (\(n : a) . True)
 |]
 
 lists :: PrtUnorderedDefs Ex
@@ -76,7 +99,7 @@ all @a p xs =
 |]
 
 stdLib :: PrtUnorderedDefs Ex
-stdLib = unionPrtUODefs booleans lists
+stdLib = unionPrtUODefs booleans $ unionPrtUODefs maybes lists
 
 progWithStdLib :: QuasiQuoter
 progWithStdLib = quoter $ \str -> do

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -16,17 +16,11 @@
 --  Check "Language.Pirouette.Example.QuasiQuoter" for an example instantiation.
 module Language.Pirouette.QuasiQuoter (QuasiQuoter, prog, progNoTC, term, ty, funDecl) where
 
-import Control.Monad.Except (runExcept)
-import Control.Monad.Reader
-import qualified Data.Map as M
 import Language.Haskell.TH.Quote
-import Language.Haskell.TH.Syntax hiding (Name, Type)
 import Language.Pirouette.QuasiQuoter.Internal
 import Language.Pirouette.QuasiQuoter.Syntax
 import Language.Pirouette.QuasiQuoter.ToTerm
 import Pirouette.Term.Syntax.Base
-import Pirouette.Term.Syntax.Pretty.Class (Pretty (..))
-import qualified Pirouette.Term.Syntax.SystemF as SystF
 import Pirouette.Term.TypeChecker (typeCheckDecls)
 import Text.Megaparsec
 

--- a/src/Language/Pirouette/QuasiQuoter.hs
+++ b/src/Language/Pirouette/QuasiQuoter.hs
@@ -21,6 +21,7 @@ import Control.Monad.Reader
 import qualified Data.Map as M
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax hiding (Name, Type)
+import Language.Pirouette.QuasiQuoter.Internal
 import Language.Pirouette.QuasiQuoter.Syntax
 import Language.Pirouette.QuasiQuoter.ToTerm
 import Pirouette.Term.Syntax.Base
@@ -59,67 +60,3 @@ funDecl = quoter $ \str -> do
   (_, p0) <- parseQ (spaceConsumer *> lexeme (parseFunDecl @lang) <* eof) str
   p1 <- trQ (trFunDecl p0)
   [e|p1|]
-
--- * Internals
-
-parseQ :: Parser a -> String -> Q a
-parseQ p str =
-  case runReader (runParserT p "<template-haskell>" str) Nothing of
-    Left err -> fail (errorBundlePretty err)
-    Right r -> return r
-
-trQ :: TrM a -> Q a
-trQ f = case runExcept f of
-  Left err -> fail err
-  Right r -> return r
-
-maybeQ :: (Pretty e) => Either e a -> Q a
-maybeQ (Left e) = fail $ show $ pretty e
-maybeQ (Right x) = return x
-
-instance (Ord k, Lift k, Lift v) => Lift (M.Map k v) where
-  liftTyped m = [||M.fromList $$(liftTyped (M.toList m))||]
-
-quoter :: (String -> Q Exp) -> QuasiQuoter
-quoter quote =
-  QuasiQuoter
-    { quoteExp = quote,
-      quotePat = \_ -> failure0 "patterns",
-      quoteType = \_ -> failure0 "types",
-      quoteDec = \_ -> failure0 "declarations"
-    }
-  where
-    failure0 k =
-      fail ("this quasiquoter does not support splicing " ++ k)
-
--- Orphan instances to 'Lift' the necessary types
-
-deriving instance Lift ann => Lift (SystF.Ann ann)
-
-deriving instance Lift Namespace
-
-deriving instance Lift Name
-
-deriving instance Lift SystF.Kind
-
-deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (TermBase lang)
-
-deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Var lang)
-
-deriving instance Lift (BuiltinTypes lang) => Lift (TypeBase lang)
-
-deriving instance Lift (BuiltinTypes lang) => Lift (TyVar lang)
-
-deriving instance Lift (BuiltinTypes lang) => Lift (Type lang)
-
-deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Arg lang)
-
-deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Term lang)
-
-deriving instance Lift Rec
-
-deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (FunDef lang)
-
-deriving instance Lift (BuiltinTypes lang) => Lift (TypeDef lang)
-
-deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Definition lang)

--- a/src/Language/Pirouette/QuasiQuoter/Internal.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Internal.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Pirouette.QuasiQuoter.Internal where
 

--- a/src/Language/Pirouette/QuasiQuoter/Internal.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Internal.hs
@@ -22,7 +22,6 @@ import Language.Pirouette.QuasiQuoter.ToTerm
 import Pirouette.Term.Syntax.Base
 import Pirouette.Term.Syntax.Pretty.Class (Pretty (..))
 import qualified Pirouette.Term.Syntax.SystemF as SystF
-import Pirouette.Term.TypeChecker (typeCheckDecls)
 import Text.Megaparsec
 
 parseQ :: Parser a -> String -> Q a

--- a/src/Language/Pirouette/QuasiQuoter/Internal.hs
+++ b/src/Language/Pirouette/QuasiQuoter/Internal.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Language.Pirouette.QuasiQuoter.Internal where
+
+import Control.Monad.Except (runExcept)
+import Control.Monad.Reader
+import qualified Data.Map as M
+import Language.Haskell.TH.Quote
+import Language.Haskell.TH.Syntax hiding (Name, Type)
+import Language.Pirouette.QuasiQuoter.Syntax
+import Language.Pirouette.QuasiQuoter.ToTerm
+import Pirouette.Term.Syntax.Base
+import Pirouette.Term.Syntax.Pretty.Class (Pretty (..))
+import qualified Pirouette.Term.Syntax.SystemF as SystF
+import Pirouette.Term.TypeChecker (typeCheckDecls)
+import Text.Megaparsec
+
+parseQ :: Parser a -> String -> Q a
+parseQ p str =
+  case runReader (runParserT p "<template-haskell>" str) Nothing of
+    Left err -> fail (errorBundlePretty err)
+    Right r -> return r
+
+trQ :: TrM a -> Q a
+trQ f = case runExcept f of
+  Left err -> fail err
+  Right r -> return r
+
+maybeQ :: (Pretty e) => Either e a -> Q a
+maybeQ (Left e) = fail $ show $ pretty e
+maybeQ (Right x) = return x
+
+instance (Ord k, Lift k, Lift v) => Lift (M.Map k v) where
+  liftTyped m = [||M.fromList $$(liftTyped (M.toList m))||]
+
+quoter :: (String -> Q Exp) -> QuasiQuoter
+quoter quote =
+  QuasiQuoter
+    { quoteExp = quote,
+      quotePat = \_ -> failure0 "patterns",
+      quoteType = \_ -> failure0 "types",
+      quoteDec = \_ -> failure0 "declarations"
+    }
+  where
+    failure0 k =
+      fail ("this quasiquoter does not support splicing " ++ k)
+
+-- Orphan instances to 'Lift' the necessary types
+
+deriving instance Lift ann => Lift (SystF.Ann ann)
+
+deriving instance Lift Namespace
+
+deriving instance Lift Name
+
+deriving instance Lift SystF.Kind
+
+deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (TermBase lang)
+
+deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Var lang)
+
+deriving instance Lift (BuiltinTypes lang) => Lift (TypeBase lang)
+
+deriving instance Lift (BuiltinTypes lang) => Lift (TyVar lang)
+
+deriving instance Lift (BuiltinTypes lang) => Lift (Type lang)
+
+deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Arg lang)
+
+deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Term lang)
+
+deriving instance Lift Rec
+
+deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (FunDef lang)
+
+deriving instance Lift (BuiltinTypes lang) => Lift (TypeDef lang)
+
+deriving instance (Lift (Constants lang), Lift (BuiltinTypes lang), Lift (BuiltinTerms lang)) => Lift (Definition lang)

--- a/src/Pirouette/Monad.hs
+++ b/src/Pirouette/Monad.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -198,8 +199,23 @@ termIsWHNFOrMeta tm = do
 newtype PrtUnorderedDefs lang = PrtUnorderedDefs {prtUODecls :: Decls lang}
   deriving (Eq, Data, Show)
 
-addDecls :: Decls builtins -> PrtUnorderedDefs builtins -> PrtUnorderedDefs builtins
+-- | Add declarations to a set of unordered declarations. In case of
+-- declarations going by the same name, already-existing ones are preserved and
+-- new ones are ignored. See also @addDeclsSafe@.
+addDecls :: forall lang. Decls lang -> PrtUnorderedDefs lang -> PrtUnorderedDefs lang
 addDecls decls defs = defs {prtUODecls = prtUODecls defs <> decls}
+
+-- | Add declarations to a set of unordered declarations. In case of
+-- declarations going by the same name, raises an error.
+addDeclsSafe :: forall lang. Decls lang -> PrtUnorderedDefs lang -> PrtUnorderedDefs lang
+addDeclsSafe decls defs =
+  defs {prtUODecls = Map.unionWith (\_ _ -> error "addDeclsSafe") (prtUODecls defs) decls}
+
+unionPrtUODefs :: forall lang. PrtUnorderedDefs lang -> PrtUnorderedDefs lang -> PrtUnorderedDefs lang
+unionPrtUODefs defs1 defs2 =
+  PrtUnorderedDefs
+    { prtUODecls = Map.unionWith (\_ _ -> error "unionPrtUODefs") (prtUODecls defs1) (prtUODecls defs2)
+    }
 
 -- | The definitions in this prelude are meant to support any builtins from your surface
 -- language. For instance, say you have a builtin /ifListIsEmpty/ on your surface language

--- a/src/Pirouette/Monad.hs
+++ b/src/Pirouette/Monad.hs
@@ -217,6 +217,12 @@ unionPrtUODefs defs1 defs2 =
     { prtUODecls = Map.unionWith (\_ _ -> error "unionPrtUODefs") (prtUODecls defs1) (prtUODecls defs2)
     }
 
+unionsPrtUODefs :: forall lang. [PrtUnorderedDefs lang] -> PrtUnorderedDefs lang
+unionsPrtUODefs defss =
+  PrtUnorderedDefs
+    { prtUODecls = Map.unionsWith (\_ _ -> error "unionPrtUODefs") (map prtUODecls defss)
+    }
+
 -- | The definitions in this prelude are meant to support any builtins from your surface
 -- language. For instance, say you have a builtin /ifListIsEmpty/ on your surface language
 -- but you don't necessarily want to have that as a compiled builtin. Instead, you

--- a/tests/unit/Pirouette/Symbolic/ProveSpec.hs
+++ b/tests/unit/Pirouette/Symbolic/ProveSpec.hs
@@ -12,6 +12,7 @@ import Data.Default
 import Data.Maybe (isJust)
 import Language.Pirouette.Example
 import qualified Language.Pirouette.Example.IsUnity as IsUnity
+import Language.Pirouette.Example.StdLib (stdLib)
 import Pirouette.Monad
 import Pirouette.Symbolic.Eval
 import Pirouette.Symbolic.EvalUtils
@@ -62,23 +63,6 @@ input0Output1 =
   ( [term| \(result : Integer) (x : Integer) . greaterThan1 result |],
     [term| \(result : Integer) (x : Integer) . greaterThan0 x |]
   )
-
-maybes :: PrtUnorderedDefs Ex
-maybes =
-  [prog|
-data MaybeInt
-  = JustInt : Integer -> MaybeInt
-  | NothingInt : MaybeInt
-
-isNothing : MaybeInt -> Bool
-isNothing m = match_MaybeInt m @Bool (\(n : Integer) . False) True
-
-isJust : MaybeInt -> Bool
-isJust m = match_MaybeInt m @Bool (\(n : Integer) . True) False
-
-not : Bool -> Bool
-not b = if @Bool b then False else True
-|]
 
 -- This is a small example taken from O'Hearn's paper; besides being interesting for
 -- testing conditionals, it is also interesting in and of itself. This is the example:
@@ -330,14 +314,14 @@ tests =
         testCase "[isNothing x] isJust x [not result] verified" $
           exec
             (proveUnbounded def)
-            (maybes, [ty|Bool|], [term|\(x:MaybeInt) . isJust x|])
-            ([term|\(r:Bool) (x:MaybeInt) . not r|], [term|\(r:Bool) (x:MaybeInt) . isNothing x|])
+            (stdLib, [ty|Bool|], [term|\(x:Maybe Integer) . isJust @Integer x|])
+            ([term|\(r:Bool) (x:Maybe Integer) . not r|], [term|\(r:Bool) (x:Maybe Integer) . isNothing @Integer x|])
             `pathSatisfies` (all isNoCounter .&. any isVerified),
         testCase "[isJust x] isJust x [not result] counter" $
           exec
             (proveUnbounded def)
-            (maybes, [ty|Bool|], [term|\(x:MaybeInt) . isJust x|])
-            ([term|\(r:Bool) (x:MaybeInt) . not r|], [term|\(r:Bool) (x:MaybeInt) . isJust x|])
+            (stdLib, [ty|Bool|], [term|\(x:Maybe Integer) . isJust @Integer x|])
+            ([term|\(r:Bool) (x:Maybe Integer) . not r|], [term|\(r:Bool) (x:Maybe Integer) . isJust @Integer x|])
             `pathSatisfies` any isCounter
       ],
     testGroup


### PR DESCRIPTION
This PR adds a tiny standard library for the example language. This allows shortening slightly the current tests. More importantly, it will help maximise sharing of usual functions in other tests, and I am planning to write quite a few of those in the future.

Technically, the example language does not support any notion of imports. Since the code of the tests would use those standard functions without defining them itself, the type checker would reject those pieces of code because they use undefined functions. One solution is to use the quasi-quoter `progNoTC` (read “program with no type-checking”), then to merge the resulting unchecked definitions with the ones from the standard library, and then only to call the type-checker. I attempted to make this slightly easier by providing a quasi-quoter `progWithStdLib` which basically does this under the hood. I don't know if that's the best design so I'm very open to remarks/suggestions.

Things that aren't that great yet:

- There is no notion of namespacing or modules, so all the names of the standard library are in the scope and that's it. This might become annoying if we want similar function names acting on different structures. Maybe we should consider prefixing all the functions in the standard library by the structure they act on. eg. `Maybe_map` vs. `List_map`, etc. (I'm not particularly attached to the underscore.)

- ~I don't currently type-check the standard library, meaning that the errors in it will only be found by and attributed to the quasi-quoter `progWithStdLib` when used somewhere else. This shouldn't be too hard to fix: one probably just want to run the type checker when creating the `stdLib` value.~ Edit: fixed in 1a06ec3300f7e5ca8cec025b4988e5eb7f2eeb90. Somehow, the output from Template Haskell is prettier and doesn't include the unreadable `Code:` part. But this is good enough IMHO.

- ~I don't provide a function other than `unionPrtUODefs` while only allows to combine definitions two by two, meaning we will have to call it a number of times linear in the number of “modules” (maybe a better word is “parts”) in the standard library. This is also pretty easy to fix.~ Edit: fixed in f6ffe07.

What do you guys think?