### PR TITLE
Nix-managed pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist*
 temporary.cfg
 states/
 *.vscode
+/.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -12,6 +28,42 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -31,10 +83,65 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1671271357,
+        "narHash": "sha256-xRJdLbWK4v2SewmSStYrcLa0YGJpleufl44A19XSW8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "40f79f003b6377bd2f4ed4027dde1f8f922995dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1674122161,
+        "narHash": "sha256-9QM4rvgUSEwO8DWtJN9sR/afEqrH1s3b6ACsZT5wiAM=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "53e766957b73298fa68b47478c48cbcc005cc18a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,9 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/22.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, pre-commit-hooks }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/22.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
+
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -8,6 +9,7 @@
         hpkgs = pkgs.haskell.packages.ghc902;
       in {
         formatter = pkgs.nixfmt;
+
         devShells = let
           buildInputs = (with pkgs; [
             git # Required to build in pure nix shells
@@ -17,6 +19,7 @@
             ormolu # Needed by the CI
             z3
           ]) ++ [ hpkgs.ghc ];
+
           LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [ pkgs.z3 ];
         in {
           ## A minimal development shell
@@ -24,6 +27,7 @@
             inherit buildInputs;
             inherit LD_LIBRARY_PATH;
           };
+
           ## A development shell with more features
           default = pkgs.mkShell {
             buildInputs = buildInputs ++ (with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,11 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         hpkgs = pkgs.haskell.packages.ghc902;
+
+        pre-commit = pre-commit-hooks.lib.${system}.run {
+          src = ./.;
+          hooks = { nixfmt.enable = true; };
+        };
       in {
         formatter = pkgs.nixfmt;
 
@@ -42,8 +47,11 @@
               xdot
               haskellPackages.graphmod
             ]) ++ [ hpkgs.haskell-language-server ];
+            inherit (pre-commit) shellHook;
             inherit LD_LIBRARY_PATH;
           };
         };
+
+        checks = { inherit pre-commit; };
       });
 }


### PR DESCRIPTION
This PR introduces Nix-managed pre-commit hooks using [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix). I think this dependency is not going to be a problem as it is maintained by Cachix (the company).

It brings much simpler and saner pre-commit hooks (the current one are driving me crazy). Adding pre-commit hooks is simply a matter of adding eg. `ormolu.enable = true` in the list of hooks in the `flake.nix` file. After that, one gets pre-commit hooks that do not silently change files but instead fail and change the files on the disk, allowing you to review or craft again a clean commit. I tested this PR with its own code, with purposefully badly written Nix in `flake.nix` initially:

```console
$ git commit -m 'Add pre-commit check for nixfmt'
files to format 
nixfmt...................................................................Failed
- hook id: nixfmt
- files were modified by this hook

$ git add .

$ git commit -m 'Add pre-commit check for nixfmt'
files to format 
nixfmt...................................................................Passed
[main c8013a2] Add pre-commit check for nixfmt
 2 files changed, 9 insertions(+)
 create mode 120000 .pre-commit-config.yaml
```

The pre-commit hooks are transparently added to anyone using a `nix develop`. There is also a Flake check target that can be used on one's machine or in CI to ensure that pre-commit hooks were run by everyone.

This PR is still draft as I still have to add a bunch of missing hooks.