### PR TITLE
Add an `hlint` pre-commit hook and cleanup files accordingly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
           hooks = {
             nixfmt.enable = true;
             ormolu.enable = true;
+            hlint.enable = true;
           };
         };
       in {

--- a/src/Pirouette/Term/Syntax.hs
+++ b/src/Pirouette/Term/Syntax.hs
@@ -41,7 +41,7 @@ separateBoundFrom u t =
 
     -- `structuredInter` transforms the set of name clashes into a map
     -- from nameString to the list of nameUnique associated.
-    structuredInter inter = Set.fold (\n m -> Map.insertWith (++) (nameString n) [nameUnique n] m) Map.empty inter
+    structuredInter = Set.fold (\n m -> Map.insertWith (++) (nameString n) [nameUnique n] m) Map.empty
 
     -- `nextFresh s txt i n` takes a set `s` of names and a `nameString` `txt` and outputs
     -- the first index which does not create clash.

--- a/src/Pirouette/Term/Syntax/SystemF.hs
+++ b/src/Pirouette/Term/Syntax/SystemF.hs
@@ -405,7 +405,7 @@ instance (Show v, Show ty, Show ann, IsVar v, HasSubst ty) => HasApp (AnnTerm ty
             -- Now we know we'll be applying n arguments at once.
             (_, body) = getNHead n t
             (args, excess) = splitAt n vs
-            sigma xs = foldl' (\x y -> Just y :< x) (Inc 0) xs
+            sigma = foldl' (\x y -> Just y :< x) (Inc 0)
          in case mapM from args of
               Just as -> appN (sub (sigma as) body) excess
               Nothing -> error "Mismatched Term/Type application"

--- a/src/Pirouette/Transformations/Tagged.hs
+++ b/src/Pirouette/Transformations/Tagged.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/PureSMT.hs
+++ b/src/PureSMT.hs
@@ -82,8 +82,7 @@ solveOpts opts ctx = unsafePerformIO $ do
       -- TODO: what happens in an exception? For now, we just loose a solver but we shouldn't
       -- add it to the pool of workers and just retry the problem. In a future implementation
       -- we could try launching it again
-      r <- solveProblem @domain problem solver
-      return r
+      solveProblem @domain problem solver
     pushMStack ms allProcs
     return r
 

--- a/src/PureSMT/Process.hs
+++ b/src/PureSMT/Process.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module PureSMT.Process where
 

--- a/src/UnionFind/Monadic.hs
+++ b/src/UnionFind/Monadic.hs
@@ -105,8 +105,9 @@ find ::
   (Ord key, Monad m) =>
   key ->
   WithUnionFindT key value m (key, Int, Maybe value)
-find key =
-  Map.lookup key <$> getBindings >>= \case
+find key = do
+  bindings <- getBindings
+  case Map.lookup key bindings of
     Nothing -> return (key, 1, Nothing)
     Just (ChildOf key') -> do
       -- We use @findExn@ because invariant (ii) guarantees that it will
@@ -122,8 +123,9 @@ findExn ::
   (Ord key, Monad m) =>
   key ->
   WithUnionFindT key value m (key, Int, Maybe value)
-findExn key =
-  Map.lookup key <$> getBindings >>= \case
+findExn key = do
+  bindings <- getBindings
+  case Map.lookup key bindings of
     Nothing -> error "findExn: no value associated with key"
     Just (ChildOf key') -> do
       (ancestor, size, maybeValue) <- findExn key'

--- a/tests/unit/Pirouette/Symbolic/EvalSpec.hs
+++ b/tests/unit/Pirouette/Symbolic/EvalSpec.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Pirouette.Symbolic.EvalSpec (tests) where

--- a/tests/unit/UnionFind/Spec.hs
+++ b/tests/unit/UnionFind/Spec.hs
@@ -24,7 +24,7 @@ instance (Arbitrary key, Arbitrary value) => Arbitrary (Action key value) where
       False -> Union <$> arbitrary <*> arbitrary
 
 unionFindToNormalisedList :: (Ord key, Ord value) => UF.UnionFind key value -> [([key], Maybe value)]
-unionFindToNormalisedList = sort . map (first (sort . NE.toList)) . (\uf -> fst $ UF.runWithUnionFind uf $ UF.toList)
+unionFindToNormalisedList = sort . map (first (sort . NE.toList)) . (\uf -> fst $ UF.runWithUnionFind uf UF.toList)
 
 dummyUnionFindToNormalisedList :: (Ord key, Ord value) => DUF.DummyUnionFind key value -> [([key], Maybe value)]
 dummyUnionFindToNormalisedList = sort . map (first sort)


### PR DESCRIPTION
closes #173 

builds on top of #172 

Now that I look at this, I am not convinced that we really want or need `hlint`. Maybe only for the unused pragmas?