### PR TITLE
Add an `hpack` pre-commit hook

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674122161,
-        "narHash": "sha256-9QM4rvgUSEwO8DWtJN9sR/afEqrH1s3b6ACsZT5wiAM=",
+        "lastModified": 1675688762,
+        "narHash": "sha256-oit/SxMk0B380ASuztBGQLe8TttO1GJiXF8aZY9AYEc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "53e766957b73298fa68b47478c48cbcc005cc18a",
+        "rev": "ab608394886fb04b8a5df3cb0bab2598400e3634",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,11 @@
           hooks = {
             nixfmt.enable = true;
             ormolu.enable = true;
+            hpack-sync = {
+              enable = true;
+              entry = "${pkgs.hpack}/bin/hpack";
+              files = "^package\\.yaml$";
+            };
           };
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -14,30 +14,7 @@
           hooks = {
             nixfmt.enable = true;
             ormolu.enable = true;
-
-            ## FIXME: The upstream `hpack` hook is completely broken, so we
-            ## write our own, heavily inspired by theirs but introducing some
-            ## fixes. The bugs have been reported at
-            ##
-            ## https://github.com/cachix/pre-commit-hooks.nix/issues/235
-            ##
-            ## and we should simply update pre-commit-hooks, remove all this and
-            ## replace it by `hpack.enable = true` once they are fixed.
-            hpack-fixed = {
-              enable = true;
-              entry = let
-                hpack-dir = pkgs.writeShellApplication {
-                  name = "hpack-dir";
-                  text = ''
-                    find . -type f -name package.yaml | while read -r file; do
-                        ${pkgs.hpack}/bin/hpack --force "$file"
-                    done
-                  '';
-                };
-              in "${hpack-dir}/bin/hpack-dir";
-              files = "(\\.l?hs(-boot)?$)|(\\.cabal$)|((^|/)package\\.yaml$)";
-              pass_filenames = false;
-            };
+            hpack.enable = true;
           };
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -35,8 +35,7 @@
                   '';
                 };
               in "${hpack-dir}/bin/hpack-dir";
-              files =
-                "(\\.l?hs(-boot)?$)|(\\.cabal$)|(^package\\.yaml$)|(/package\\.yaml$)";
+              files = "(\\.l?hs(-boot)?$)|(\\.cabal$)|((^|/)package\\.yaml$)";
               pass_filenames = false;
             };
           };

--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,6 @@ dependencies:
   - mtl >= 2.2.2
   - interpolate
   - bytestring
-  - containers
   - extra
   - text
   - prettyprinter
@@ -24,14 +23,12 @@ dependencies:
   - deriving-compat
   - template-haskell
   - tasty
-  - tasty-hunit
   - tasty-quickcheck
   - tasty-expected-failure
   - QuickCheck
   - haskell-stack-trace-plugin
   - parallel
   - optics-core
-  - optics-th
   - raw-strings-qq
   - transformers
   # PureSMT deps
@@ -49,20 +46,5 @@ tests:
     main: Spec.hs
     source-dirs:
       - tests/unit
-    dependencies:
-      - pirouette
     ghc-options:
       -threaded
-
-## executables:
-##   spec-prof:
-##     main: Spec.hs
-##     source-dirs:
-##       - tests/unit
-##     dependencies:
-##       - pirouette
-##     ghc-options:
-##       -threaded
-##       -fprof-auto
-##       -fexternal-interpreter
-##       "-with-rtsopts=-N -p -s -h"

--- a/package.yaml
+++ b/package.yaml
@@ -14,6 +14,7 @@ dependencies:
   - mtl >= 2.2.2
   - interpolate
   - bytestring
+  - containers
   - extra
   - text
   - prettyprinter
@@ -23,12 +24,14 @@ dependencies:
   - deriving-compat
   - template-haskell
   - tasty
+  - tasty-hunit
   - tasty-quickcheck
   - tasty-expected-failure
   - QuickCheck
   - haskell-stack-trace-plugin
   - parallel
   - optics-core
+  - optics-th
   - raw-strings-qq
   - transformers
   # PureSMT deps
@@ -46,5 +49,20 @@ tests:
     main: Spec.hs
     source-dirs:
       - tests/unit
+    dependencies:
+      - pirouette
     ghc-options:
       -threaded
+
+## executables:
+##   spec-prof:
+##     main: Spec.hs
+##     source-dirs:
+##       - tests/unit
+##     dependencies:
+##       - pirouette
+##     ghc-options:
+##       -threaded
+##       -fprof-auto
+##       -fexternal-interpreter
+##       "-with-rtsopts=-N -p -s -h"

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,6 @@ dependencies:
   - bytestring
   - containers
   - extra
-  - text
   - prettyprinter
   - megaparsec
   - parser-combinators
@@ -49,20 +48,5 @@ tests:
     main: Spec.hs
     source-dirs:
       - tests/unit
-    dependencies:
-      - pirouette
     ghc-options:
       -threaded
-
-## executables:
-##   spec-prof:
-##     main: Spec.hs
-##     source-dirs:
-##       - tests/unit
-##     dependencies:
-##       - pirouette
-##     ghc-options:
-##       -threaded
-##       -fprof-auto
-##       -fexternal-interpreter
-##       "-with-rtsopts=-N -p -s -h"

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,14 @@ dependencies:
   - text
   - prettyprinter
   - megaparsec
+  - parser-combinators
+  - uniplate
+  - deriving-compat
+  - template-haskell
+  - tasty
+  - tasty-hunit
+  - tasty-quickcheck
+  - tasty-expected-failure
   - QuickCheck
   - haskell-stack-trace-plugin
   - parallel
@@ -41,5 +49,20 @@ tests:
     main: Spec.hs
     source-dirs:
       - tests/unit
+    dependencies:
+      - pirouette
     ghc-options:
       -threaded
+
+## executables:
+##   spec-prof:
+##     main: Spec.hs
+##     source-dirs:
+##       - tests/unit
+##     dependencies:
+##       - pirouette
+##     ghc-options:
+##       -threaded
+##       -fprof-auto
+##       -fexternal-interpreter
+##       "-with-rtsopts=-N -p -s -h"

--- a/package.yaml
+++ b/package.yaml
@@ -16,6 +16,7 @@ dependencies:
   - bytestring
   - containers
   - extra
+  - text
   - prettyprinter
   - megaparsec
   - parser-combinators
@@ -48,5 +49,20 @@ tests:
     main: Spec.hs
     source-dirs:
       - tests/unit
+    dependencies:
+      - pirouette
     ghc-options:
       -threaded
+
+## executables:
+##   spec-prof:
+##     main: Spec.hs
+##     source-dirs:
+##       - tests/unit
+##     dependencies:
+##       - pirouette
+##     ghc-options:
+##       -threaded
+##       -fprof-auto
+##       -fexternal-interpreter
+##       "-with-rtsopts=-N -p -s -h"

--- a/package.yaml
+++ b/package.yaml
@@ -19,14 +19,6 @@ dependencies:
   - text
   - prettyprinter
   - megaparsec
-  - parser-combinators
-  - uniplate
-  - deriving-compat
-  - template-haskell
-  - tasty
-  - tasty-hunit
-  - tasty-quickcheck
-  - tasty-expected-failure
   - QuickCheck
   - haskell-stack-trace-plugin
   - parallel
@@ -49,20 +41,5 @@ tests:
     main: Spec.hs
     source-dirs:
       - tests/unit
-    dependencies:
-      - pirouette
     ghc-options:
       -threaded
-
-## executables:
-##   spec-prof:
-##     main: Spec.hs
-##     source-dirs:
-##       - tests/unit
-##     dependencies:
-##       - pirouette
-##     ghc-options:
-##       -threaded
-##       -fprof-auto
-##       -fexternal-interpreter
-##       "-with-rtsopts=-N -p -s -h"

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -35,13 +35,12 @@ library
       Pirouette.SMT.Monadic
       Pirouette.Symbolic.Eval
       Pirouette.Symbolic.Eval.BranchingHelpers
-      Pirouette.Symbolic.Eval.SMT
       Pirouette.Symbolic.Eval.Types
       Pirouette.Symbolic.Prover
       Pirouette.Symbolic.Prover.Runner
-      Pirouette.Term.Syntax
       Pirouette.Term.Syntax.Base
       Pirouette.Term.Syntax.Pretty
+      Pirouette.Term.Syntax
       Pirouette.Term.Syntax.Pretty.Class
       Pirouette.Term.Syntax.Subst
       Pirouette.Term.Syntax.SystemF
@@ -49,17 +48,16 @@ library
       Pirouette.Term.TypeChecker
       Pirouette.Transformations
       Pirouette.Transformations.Contextualize
-      Pirouette.Transformations.Defunctionalization
       Pirouette.Transformations.ElimEvenOddMutRec
       Pirouette.Transformations.EtaExpand
       Pirouette.Transformations.Inline
       Pirouette.Transformations.Monomorphization
       Pirouette.Transformations.Prenex
+      Pirouette.Transformations.Defunctionalization
       Pirouette.Transformations.Tagged
       Pirouette.Transformations.Term
       Pirouette.Transformations.Utils
       Pirouette.Utils
-      PureSMT
       PureSMT.Process
       PureSMT.SExpr
       UnionFind
@@ -80,7 +78,6 @@ library
     , base >=4.9 && <5
     , bytestring
     , containers
-    , data-default
     , deriving-compat
     , extra
     , haskell-stack-trace-plugin
@@ -92,7 +89,6 @@ library
     , parallel
     , parser-combinators
     , prettyprinter
-    , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
     , tasty
@@ -144,14 +140,14 @@ test-suite spec
     , interpolate
     , megaparsec
     , mtl >=2.2.2
+    , parallel
     , optics-core
     , optics-th
-    , parallel
     , parser-combinators
     , pirouette
+    , smtlib-backends
     , prettyprinter
     , raw-strings-qq
-    , smtlib-backends
     , smtlib-backends-z3
     , tasty
     , tasty-expected-failure

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -113,8 +113,8 @@ test-suite spec
       Pirouette.Symbolic.EvalSpec
       Pirouette.Symbolic.EvalUtils
       Pirouette.Symbolic.ProveSpec
-      Pirouette.Symbolic.ProveSpec.NastyLists
       Pirouette.Symbolic.ProveSpec.Internal
+      Pirouette.Symbolic.ProveSpec.NastyLists
       Pirouette.Term.Syntax.BaseSpec
       Pirouette.Term.Syntax.SystemFSpec
       Pirouette.Transformations.DefunctionalizationSpec

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -81,7 +81,6 @@ library
     , bytestring
     , containers
     , data-default
-    , deriving-compat
     , extra
     , haskell-stack-trace-plugin
     , interpolate
@@ -90,19 +89,12 @@ library
     , optics-core
     , optics-th
     , parallel
-    , parser-combinators
     , prettyprinter
     , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
-    , tasty
-    , tasty-expected-failure
-    , tasty-hunit
-    , tasty-quickcheck
-    , template-haskell
     , text
     , transformers
-    , uniplate
   default-language: Haskell2010
 
 test-suite spec
@@ -138,7 +130,6 @@ test-suite spec
     , bytestring
     , containers
     , data-default
-    , deriving-compat
     , extra
     , haskell-stack-trace-plugin
     , interpolate
@@ -147,18 +138,10 @@ test-suite spec
     , optics-core
     , optics-th
     , parallel
-    , parser-combinators
-    , pirouette
     , prettyprinter
     , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
-    , tasty
-    , tasty-expected-failure
-    , tasty-hunit
-    , tasty-quickcheck
-    , template-haskell
     , text
     , transformers
-    , uniplate
   default-language: Haskell2010

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -81,6 +81,7 @@ library
     , bytestring
     , containers
     , data-default
+    , deriving-compat
     , extra
     , haskell-stack-trace-plugin
     , interpolate
@@ -89,12 +90,19 @@ library
     , optics-core
     , optics-th
     , parallel
+    , parser-combinators
     , prettyprinter
     , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
+    , tasty
+    , tasty-expected-failure
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell
     , text
     , transformers
+    , uniplate
   default-language: Haskell2010
 
 test-suite spec
@@ -130,6 +138,7 @@ test-suite spec
     , bytestring
     , containers
     , data-default
+    , deriving-compat
     , extra
     , haskell-stack-trace-plugin
     , interpolate
@@ -138,10 +147,18 @@ test-suite spec
     , optics-core
     , optics-th
     , parallel
+    , parser-combinators
+    , pirouette
     , prettyprinter
     , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
+    , tasty
+    , tasty-expected-failure
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell
     , text
     , transformers
+    , uniplate
   default-language: Haskell2010

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -79,6 +79,7 @@ library
     , ansi-terminal
     , base >=4.9 && <5
     , bytestring
+    , containers
     , data-default
     , deriving-compat
     , extra
@@ -87,6 +88,7 @@ library
     , megaparsec
     , mtl >=2.2.2
     , optics-core
+    , optics-th
     , parallel
     , parser-combinators
     , prettyprinter
@@ -95,6 +97,7 @@ library
     , smtlib-backends-z3
     , tasty
     , tasty-expected-failure
+    , tasty-hunit
     , tasty-quickcheck
     , template-haskell
     , text
@@ -133,6 +136,7 @@ test-suite spec
     , ansi-terminal
     , base >=4.9 && <5
     , bytestring
+    , containers
     , data-default
     , deriving-compat
     , extra
@@ -141,14 +145,17 @@ test-suite spec
     , megaparsec
     , mtl >=2.2.2
     , optics-core
+    , optics-th
     , parallel
     , parser-combinators
+    , pirouette
     , prettyprinter
     , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
     , tasty
     , tasty-expected-failure
+    , tasty-hunit
     , tasty-quickcheck
     , template-haskell
     , text

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -35,12 +35,13 @@ library
       Pirouette.SMT.Monadic
       Pirouette.Symbolic.Eval
       Pirouette.Symbolic.Eval.BranchingHelpers
+      Pirouette.Symbolic.Eval.SMT
       Pirouette.Symbolic.Eval.Types
       Pirouette.Symbolic.Prover
       Pirouette.Symbolic.Prover.Runner
+      Pirouette.Term.Syntax
       Pirouette.Term.Syntax.Base
       Pirouette.Term.Syntax.Pretty
-      Pirouette.Term.Syntax
       Pirouette.Term.Syntax.Pretty.Class
       Pirouette.Term.Syntax.Subst
       Pirouette.Term.Syntax.SystemF
@@ -48,16 +49,17 @@ library
       Pirouette.Term.TypeChecker
       Pirouette.Transformations
       Pirouette.Transformations.Contextualize
+      Pirouette.Transformations.Defunctionalization
       Pirouette.Transformations.ElimEvenOddMutRec
       Pirouette.Transformations.EtaExpand
       Pirouette.Transformations.Inline
       Pirouette.Transformations.Monomorphization
       Pirouette.Transformations.Prenex
-      Pirouette.Transformations.Defunctionalization
       Pirouette.Transformations.Tagged
       Pirouette.Transformations.Term
       Pirouette.Transformations.Utils
       Pirouette.Utils
+      PureSMT
       PureSMT.Process
       PureSMT.SExpr
       UnionFind
@@ -78,6 +80,7 @@ library
     , base >=4.9 && <5
     , bytestring
     , containers
+    , data-default
     , deriving-compat
     , extra
     , haskell-stack-trace-plugin
@@ -89,6 +92,7 @@ library
     , parallel
     , parser-combinators
     , prettyprinter
+    , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
     , tasty
@@ -140,14 +144,14 @@ test-suite spec
     , interpolate
     , megaparsec
     , mtl >=2.2.2
-    , parallel
     , optics-core
     , optics-th
+    , parallel
     , parser-combinators
     , pirouette
-    , smtlib-backends
     , prettyprinter
     , raw-strings-qq
+    , smtlib-backends
     , smtlib-backends-z3
     , tasty
     , tasty-expected-failure

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -79,7 +79,6 @@ library
     , ansi-terminal
     , base >=4.9 && <5
     , bytestring
-    , containers
     , data-default
     , deriving-compat
     , extra
@@ -88,7 +87,6 @@ library
     , megaparsec
     , mtl >=2.2.2
     , optics-core
-    , optics-th
     , parallel
     , parser-combinators
     , prettyprinter
@@ -97,7 +95,6 @@ library
     , smtlib-backends-z3
     , tasty
     , tasty-expected-failure
-    , tasty-hunit
     , tasty-quickcheck
     , template-haskell
     , text
@@ -136,7 +133,6 @@ test-suite spec
     , ansi-terminal
     , base >=4.9 && <5
     , bytestring
-    , containers
     , data-default
     , deriving-compat
     , extra
@@ -145,17 +141,14 @@ test-suite spec
     , megaparsec
     , mtl >=2.2.2
     , optics-core
-    , optics-th
     , parallel
     , parser-combinators
-    , pirouette
     , prettyprinter
     , raw-strings-qq
     , smtlib-backends
     , smtlib-backends-z3
     , tasty
     , tasty-expected-failure
-    , tasty-hunit
     , tasty-quickcheck
     , template-haskell
     , text


### PR DESCRIPTION
Somehow, [the default `hpack` hook](https://github.com/cachix/pre-commit-hooks.nix/blob/7bdf85f6bbef581eb687838d19f2b35a4c9d77f0/modules/hooks.nix#L419-L435) does not work for us, so we write our own, which we call `hpack-sync` so as not to clash with the default. Only the first commit matters. The others will be there for testing purposes.