### PR TITLE
PureSMT: update smtlib-backends to version 0.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 -- Bump this if you need newer packages
-index-state: 2022-12-16T13:45:28Z
+index-state: 2023-02-07T13:45:28Z
 
 packages:
   .

--- a/package.yaml
+++ b/package.yaml
@@ -35,8 +35,8 @@ dependencies:
   - raw-strings-qq
   - transformers
   # PureSMT deps
-  - smtlib-backends
-  - smtlib-backends-z3
+  - smtlib-backends >=0.3 && <0.4
+  - smtlib-backends-z3 >=0.3 && <0.4
 
 library:
   source-dirs: src

--- a/pirouette.cabal
+++ b/pirouette.cabal
@@ -93,8 +93,8 @@ library
     , parser-combinators
     , prettyprinter
     , raw-strings-qq
-    , smtlib-backends
-    , smtlib-backends-z3
+    , smtlib-backends ==0.3.*
+    , smtlib-backends-z3 ==0.3.*
     , tasty
     , tasty-expected-failure
     , tasty-hunit
@@ -151,8 +151,8 @@ test-suite spec
     , pirouette
     , prettyprinter
     , raw-strings-qq
-    , smtlib-backends
-    , smtlib-backends-z3
+    , smtlib-backends ==0.3.*
+    , smtlib-backends-z3 ==0.3.*
     , tasty
     , tasty-expected-failure
     , tasty-hunit


### PR DESCRIPTION
This PR updates the `PureSMT` module to use the latest version of `smtlib-backends`. The Z3 API is now calls using FFI instead of `inline-c`. Other than that, the two versions of PIrouette should be equivalent.