### PR TITLE
Cleanup the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,10 @@ plutus through `Language.Pirouette.PlutusIR`, but further work is necessary to
 seamlessly interact with validator scripts.
 
 To run Pirouette on Plutus Intermediate Representation scripts,
-one has to use the [pirouette-plutusir library], provided in the [cooked-validators] repository.
+one has to use the [pirouette-plutusir library].
 
 [Plutus]: https://plutus.readthedocs.io/en/latest/
-[pirouette-plutusir library]: https://github.com/tweag/cooked-validators/tree/v1.0.0/pirouette-plutusir
-[cooked-validators]: https://github.com/tweag/cooked-validators
+[pirouette-plutusir library]: https://github.com/tweag/pirouette-plutusir
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ analysis tools for [System F][systemf]-based languages. It has a number of
 transformations (monomorphization, defunctionalization, prenex, etc...) implemented,
 which can be composed in different ways to cater for different goals.
 
-# Bounded Symbolic Evaluation
+## Bounded Symbolic Evaluation
 
 There is one analysis currently built into pirouette, which symbolically evaluates terms
 while looking for counterexamples based on a mixture of [incorrectness][incorrectness] and Hoare triples.
@@ -20,9 +20,9 @@ details on these reasoning techniques.
 [incorrectness]: https://dl.acm.org/doi/pdf/10.1145/3371078
 [tweag-blogpost]: https://www.tweag.io/blog/2022-07-01-pirouette-2/
 
-## Use Cases
+### Use Cases
 
-### Example Language
+#### Example Language
 
 The `Language.Pirouette.Example` defines the `Ex` language: pirouette's example language.
 We refer the interested reader to this module for guidelines on using pirouette over
@@ -58,7 +58,7 @@ Now we can run `replIncorrectnessLogicSingl 10 params` in a repl and we should s
   x ↦ 0 }
 ```
 
-### Plutus Smart Contracts
+#### Plutus Smart Contracts
 
 [Plutus] is a subset of Haskell used to
 write smart contracts for Cardano blockchain.
@@ -71,7 +71,7 @@ one has to use the [pirouette-plutusir library](https://github.com/tweag/plutus-
 
 [Plutus]: https://plutus.readthedocs.io/en/latest/
 
-## Limitations
+### Limitations
 
 In its current form, `pirouette` itself is still a research prototype,
 hence, it has plenty of limitations. The overall approach of pirouette's
@@ -80,26 +80,26 @@ it also carries the limitations of a model checker: exploration of the state spa
 and it is not a substitute for a formal
 proof of correctness.
 
-# Building, Installing and Hacking
+## Building, Installing and Hacking
 
 The recommended way of building pirouette is through [Nix](https://nixos.org/guides/install-nix.html).
 Enter the Nix shell with `nix develop` then run `cabal update` and `cabal build` at the
 root of the repository.
 
-## Pre-commit Hooks and CI
+### Pre-commit Hooks and CI
 
 In order to help avoid CI failures due to formatting problems,
 we recommend that you install a pre-commit hook for running Ormolu.
 The Nix shell already enables such a pre-commit hook transparently.
 
-# Contributing
+## Contributing
 
 Did you find a bug while using `pirouette`?
 Please [report it](https://github.com/tweag/pirouette/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md).
 Would you like to help fix a bug or add a feature?
 We welcome pull requests! Check the [issue](https://github.com/tweag/pirouette/issues) page for inspiration.
 
-# License
+## License
 
 See [LICENSE](LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 _Pirouette is a research prototype under active development_
 
-* [Bounded Symbolic Evaluation](#bounded-symbolic-evaluation)
-  - [Use case: Example](#example-language)
-  - [Use case: Plutus Smart Contracts](#plutus-smart-contracts)
-  - [Limitations](#limitations)
-* [Building, Installing and Hacking](#building-installing-and-hacking)
-* [Contributing](#contributing)
-* [License](#license)
-
 Pirouette is a framework for constructing different static
 analysis tools for [System F][systemf]-based languages. It has a number of
 transformations (monomorphization, defunctionalization, prenex, etc...) implemented,

--- a/README.md
+++ b/README.md
@@ -3,20 +3,21 @@
 _Pirouette is a research prototype under active development_
 
 Pirouette is a framework for constructing different static
-analysis tools for [System F][systemf]-based languages. It has a number of
+analysis tools for [System F]-based languages. It has a number of
 transformations (monomorphization, defunctionalization, prenex, etc...) implemented,
 which can be composed in different ways to cater for different goals.
+
+[System F]: https://en.wikipedia.org/wiki/System_F
 
 ## Bounded Symbolic Evaluation
 
 There is one analysis currently built into pirouette, which symbolically evaluates terms
-while looking for counterexamples based on a mixture of [incorrectness][incorrectness] and Hoare triples.
+while looking for counterexamples based on a mixture of [incorrectness] and Hoare triples.
 Say we have a function `t :: Ins -> Outs`, we can check that for all `i :: Ints` up to a certain
 size, `P (t i) i` implies `Q (t i) i`, where `P` and `Q` are the user-defined predicates we
 interested in enforcing. We invite the interested reader to our [blog-post][tweag-blogpost] for more
 details on these reasoning techniques.
 
-[systemf]: https://en.wikipedia.org/wiki/System_F
 [incorrectness]: https://dl.acm.org/doi/pdf/10.1145/3371078
 [tweag-blogpost]: https://www.tweag.io/blog/2022-07-01-pirouette-2/
 
@@ -38,7 +39,7 @@ addone x = x + 1
 And we wish to check the incorrectness triple `[x > 0] addone x [result > 0]`, that
 is: if `addone x > 0`, then `x > 0`. We obviously expect a counterexample with `x = 0`.
 Because pirouette conveniently uses the `-XQuasiQuotes` extension, we can
-quickly use it find that assignment:
+quickly use it to find that assignment:
 
 ```haskell
 params :: IncorrectnessParams Ex
@@ -60,31 +61,33 @@ Now we can run `replIncorrectnessLogicSingl 10 params` in a repl and we should s
 
 #### Plutus Smart Contracts
 
-[Plutus] is a subset of Haskell used to
-write smart contracts for Cardano blockchain.
+[Plutus] is a subset of Haskell used to write smart contracts for Cardano blockchain.
 Pirouette has a prototype interface to interacting with
 plutus through `Language.Pirouette.PlutusIR`, but further work is necessary to
 seamlessly interact with validator scripts.
 
 To run Pirouette on Plutus Intermediate Representation scripts,
-one has to use the [pirouette-plutusir library](https://github.com/tweag/plutus-libs/tree/main/pirouette-plutusir), provided in the [Plutus-libs](https://github.com/tweag/plutus-libs) repository.
+one has to use the [pirouette-plutusir library], provided in the [cooked-validators] repository.
 
 [Plutus]: https://plutus.readthedocs.io/en/latest/
+[pirouette-plutusir library]: https://github.com/tweag/cooked-validators/tree/v1.0.0/pirouette-plutusir
+[cooked-validators]: https://github.com/tweag/cooked-validators
 
 ### Limitations
 
-In its current form, `pirouette` itself is still a research prototype,
+In its current form, pirouette itself is still a research prototype,
 hence, it has plenty of limitations. The overall approach of pirouette's
 symbolic engine is an intersection of bounded model checking and symbolic execution, hence,
 it also carries the limitations of a model checker: exploration of the state space can be slow
-and it is not a substitute for a formal
-proof of correctness.
+and it is not a substitute for a formal proof of correctness.
 
 ## Building, Installing and Hacking
 
-The recommended way of building pirouette is through [Nix](https://nixos.org/guides/install-nix.html).
+The recommended way of building pirouette is through [Nix].
 Enter the Nix shell with `nix develop` then run `cabal update` and `cabal build` at the
 root of the repository.
+
+[Nix]: https://nixos.org/
 
 ### Pre-commit Hooks and CI
 
@@ -94,10 +97,13 @@ The Nix shell already enables such a pre-commit hook transparently.
 
 ## Contributing
 
-Did you find a bug while using `pirouette`?
-Please [report it](https://github.com/tweag/pirouette/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md).
+Did you find a bug while using pirouette?
+Please [report it][new-issue].
 Would you like to help fix a bug or add a feature?
-We welcome pull requests! Check the [issue](https://github.com/tweag/pirouette/issues) page for inspiration.
+We welcome pull requests! Check [the issue page][issues] for inspiration.
+
+[issues]: https://github.com/tweag/pirouette/issues
+[new-issue]: https://github.com/tweag/pirouette/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md
 
 ## License
 


### PR DESCRIPTION
This PR:

- removes the table of contents; it had fallen out of sync with the document a while ago, and GitHub provides table of contents anyways,
- augments the titles by one level, leaving only one level-1 title (“Pirouette”) and having all the sections starting at level 2.
- reworks the links to make the markdown hopefully a bit more readable in text mode
- changes the bit about `pirouette-plutusir` so that it points to the standalone repository.