### PR TITLE
Introduce a high-level document of Pirouette's design

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,93 @@
+Pirouette's Design
+==================
+
+Languages
+---------
+
+### Pirouette's genericity
+
+### The example language
+
+The example language is the only instance of a language included in Pirouette.
+It is a simple functional language supporting higher-order types with explicit
+type annotations, basic types (booleans, integers, strings) with their
+associated operators, algebraic datatypes and pattern-matching. The definition
+of the language is done by providing the `LanguageBuiltins` instance. You will
+find all the heavy work in `Language.Pirouette.Example`.
+
+The example language also has a concrete syntax heavily inspired by Haskell.
+Thanks to quasi-quoters, it is easy to define a set of unordered value
+definitions for the `Ex`ample language:
+```haskell
+myProgram :: PrtUnorderedDefs Ex
+myProgram = [prog|
+  addone : Integer -> Integer
+  addone x = x + 1
+
+  addtwo : Integer -> Integer
+  addtwo x = x + 2
+|]
+```
+
+Now for a more involved example. Say we want to compute a sum of integers in a
+generic way. We can do that by writing a function `sum` taking a list of
+integers and returning the total. In order to do that, we first need a notion of
+lists, which we choose to do in a generic way. Here we go:
+```
+data List a
+  = Nil : List a
+  | Cons : a -> List a -> List a
+```
+
+Computing the sum of the elements of a list requires traversing it, which we can
+also decide to do in a generic way with a fold over the list.
+```
+foldr : forall a r . (a -> r -> r) -> r -> List a -> r
+foldr @a @r f e l =
+  match_List @a l @r
+    e
+    (\(x : a) (xs : List a) . f x (foldr @a @r f e xs))
+```
+Note how quantification in types has to be explicit, and the definition of the
+datatype `List` also creates the corresponding `match_List` function taking, in
+that order, the datatype type arguments, an element of that datatype, the
+returning type, and as many cases as there are constructors, in the same order.
+
+The hardest part has been done. It is now simple to define a list of integers --
+say `1`, `2`, `3` -- and sum over them.
+```
+myList : List Integer
+myList = Cons @Integer 1 (Cons @Integer 2 (Cons @Integer 3 (Nil @Integer)))
+
+myListTotal : Integer
+myListTotal =
+  foldr
+    @Integer
+    @Integer
+    (\(x : Integer) (y : Integer) . x + y)
+    0
+    myList
+```
+
+For more examples, check out the standard library for the example language in
+`Language.Pirouette.Example.StdLib`. The standard library also comes with a
+quasi-quoter of its own allowing you to leverage it in your code should you want
+it:
+```haskell
+myProgram :: PrtUnorderedDefs Ex
+myProgram = [progWithStdLib|
+  totalSum : List Integer -> Integer
+  totalSum =
+    foldr
+      @Integer
+      @Integer
+      (\(x : Integer) (y : Integer) . x + y)
+      0
+|]
+```
+
+Transformations
+---------------
+
+Evaluation
+----------

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,21 +72,23 @@ datatype `List` also creates the corresponding `match_List` function taking, in
 that order, the datatype type arguments, an element of that datatype, the
 returning type, and as many cases as there are constructors, in the same order.
 
-The hardest part has been done. It is now simple to define a list of integers --
-say `1`, `2`, `3` -- and sum over them.
+The hardest part has been done. It is now simple to define a `sum` function, a
+list of integers -- say `1`, `2`, `3` -- and apply `sum` over them.
 
 ```haskell
-myList : List Integer
-myList = Cons @Integer 1 (Cons @Integer 2 (Cons @Integer 3 (Nil @Integer)))
-
-myListTotal : Integer
-myListTotal =
+sum : List Integer -> Integer
+sum =
   foldr
     @Integer
     @Integer
     (\(x : Integer) (y : Integer) . x + y)
     0
-    myList
+
+myList : List Integer
+myList = Cons @Integer 1 (Cons @Integer 2 (Cons @Integer 3 (Nil @Integer)))
+
+myListTotal : Integer
+myListTotal = sum myList
 ```
 
 For more examples, check out the standard library for the example language in
@@ -97,8 +99,8 @@ it:
 ```haskell
 myProgram :: PrtUnorderedDefs Ex
 myProgram = [progWithStdLib|
-  totalSum : List Integer -> Integer
-  totalSum =
+  sum : List Integer -> Integer
+  sum =
     foldr
       @Integer
       @Integer

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,7 +11,9 @@ is System F-like. Anyone can then come and define their instance of
 `LanguageBuiltins`, which is Pirouette's way of defining the constants, builtin
 terms and builtin types of a language. The definition of the classes can be
 found in [`Pirouette.Term.Syntax.Base`]. For a simple, concrete instantiation of
-a language, you might want to check [the example language].
+a language, you might want to check [the example language]. For a more involved
+one, you might want to check [the support for Plutus IR][plutus intermediate
+representation].
 
 [`Pirouette.Term.Syntax.Base`]: ./src/Pirouette/Term/Syntax/Base.hs
 
@@ -102,6 +104,8 @@ myProgram = [progWithStdLib|
 [`Language.Pirouette.Example.StdLib`]: ./src/Language/Pirouette/Example/StdLib.hs
 
 ### Plutus Intermediate Representation
+
+[plutus intermediate representation]: #plutus-intermediate-representation
 
 To run Pirouette on Plutus Intermediate Representation scripts, one has to use
 the [pirouette-plutusir library].

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,7 +148,7 @@ convert assumptions/constraints to the [SMT-LIB] language. These modules live in
 
 [symbolic evaluator]: #symbolic-evaluator
 
-#### The symbolic evaluation monad -- `SymEval`
+#### The symbolic evaluation monad — `SymEval`
 
 The heart of Pirouette's symbolic engine lives in [`Pirouette.Symbolic.Eval`].
 This module defines the `SymEval` monad providing all the tooling to make
@@ -175,7 +175,7 @@ taking an environment and a state and returning a list of state, as well as
 potential return values. It returns a list because symbolic evaluation may
 branch and explore different paths.
 
-#### The key function -- `symEvalOneStep`
+#### The key function — `symEvalOneStep`
 
 The key function in this module is `symEvalOneStep`, whose type is the
 following:
@@ -232,7 +232,7 @@ above, our first term/state is now blocked because there isn't much one can do
 with an integer. The second term/state is not blocked because one can replace
 `f` by its definition and continue unfolding from there.
 
-#### The symbolic evaluation state -- `SymEvalSt`
+#### The symbolic evaluation state — `SymEvalSt`
 
 Defined in [`Pirouette.Symbolic.Eval.Types`], the symbolic state basically
 contains the following:
@@ -252,7 +252,7 @@ contains the following:
 as well as some extra fields necessary for administrative reasons. Those field
 names are prefixed by `sest` in the code.
 
-#### The symbolic evaluation environment -- `SymEvalEnv`
+#### The symbolic evaluation environment — `SymEvalEnv`
 
 Defined in [`Pirouette.Symbolic.Eval`], the symbolic environment contains the
 following:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,11 +135,15 @@ the [pirouette-plutusir library].
 Transformations
 ---------------
 
+[transformations]: #transformations
+
 _This part is empty and should be documented._ Transformations live in
 [`Pirouette.Transformations`].
 
 Symbolic Engine
 ---------------
+
+[symbolic engine]: #symbolic-engine
 
 The symbolic engine is split into three main parts: an SMT prover, as well as
 all the administrative work to communicate with it, Pirouette's _[symbolic

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -33,6 +33,7 @@ find all the heavy work in [`Language.Pirouette.Example`].
 The example language also has a concrete syntax heavily inspired by Haskell.
 Thanks to quasi-quoters, it is easy to define a set of unordered value
 definitions for the `Ex`ample language:
+
 ```haskell
 myProgram :: PrtUnorderedDefs Ex
 myProgram = [prog|
@@ -48,6 +49,7 @@ Now for a more involved example. Say we want to compute a sum of integers in a
 generic way. We can do that by writing a function `sum` taking a list of
 integers and returning the total. In order to do that, we first need a notion of
 lists, which we choose to do in a generic way. Here we go:
+
 ```haskell
 data List a
   = Nil : List a
@@ -56,6 +58,7 @@ data List a
 
 Computing the sum of the elements of a list requires traversing it, which we can
 also decide to do in a generic way with a fold over the list.
+
 ```haskell
 foldr : forall a r . (a -> r -> r) -> r -> List a -> r
 foldr @a @r f e l =
@@ -63,6 +66,7 @@ foldr @a @r f e l =
     e
     (\(x : a) (xs : List a) . f x (foldr @a @r f e xs))
 ```
+
 Note how quantification in types has to be explicit, and the definition of the
 datatype `List` also creates the corresponding `match_List` function taking, in
 that order, the datatype type arguments, an element of that datatype, the
@@ -70,6 +74,7 @@ returning type, and as many cases as there are constructors, in the same order.
 
 The hardest part has been done. It is now simple to define a list of integers --
 say `1`, `2`, `3` -- and sum over them.
+
 ```haskell
 myList : List Integer
 myList = Cons @Integer 1 (Cons @Integer 2 (Cons @Integer 3 (Nil @Integer)))
@@ -88,6 +93,7 @@ For more examples, check out the standard library for the example language in
 [`Language.Pirouette.Example.StdLib`]. The standard library also comes with a
 quasi-quoter of its own allowing you to leverage it in your code should you want
 it:
+
 ```haskell
 myProgram :: PrtUnorderedDefs Ex
 myProgram = [progWithStdLib|
@@ -115,6 +121,10 @@ the [pirouette-plutusir library].
 Transformations
 ---------------
 
+[`Pirouette.Transformations`]
+
+[`Pirouette.Transformations`]: ./src/Pirouette/Transformations.hs
+
 Symbolic Engine
 ---------------
 
@@ -124,8 +134,6 @@ evaluator]_, and Pirouette's _[symbolic prover]_. We describe these three
 aspects in the following sub-sections.
 
 ### SMT prover
-
-[smt prover]: #smt-prover
 
 As is classic in symbolic engines, Pirouette relies on SMT provers to do the
 hard work. These provers are used in two different ways. They help pruning
@@ -150,6 +158,7 @@ convert assumptions/constraints to the [SMT-LIB] language. These modules live in
 The heart of Pirouette's symbolic engine lives in [`Pirouette.Symbolic.Eval`].
 This module defines the `SymEval` monad providing all the tooling to make
 symbolic evaluation work. Here is the monad in question:
+
 ```haskell
 newtype SymEval lang a = SymEval
   { symEval ::
@@ -159,11 +168,14 @@ newtype SymEval lang a = SymEval
         a
   }
 ```
+
 Morally speaking, though, and forgetting the `lang` type parameters, this monad
 simply represent functions of type:
+
 ```haskell
 SymEvalEnv -> SymEvalSt -> [(a, SymEvalSt)]
 ```
+
 taking an environment and a state and returning a list of state, as well as
 potential return values. It returns a list because symbolic evaluation may
 branch and explore different paths.
@@ -172,6 +184,7 @@ branch and explore different paths.
 
 The key function in this module is `symEvalOneStep`, whose type is the
 following:
+
 ```haskell
 symEvalOneStep ::
   forall lang .
@@ -179,12 +192,15 @@ symEvalOneStep ::
   TermMeta lang SymVar ->
   WriterT Any (SymEval lang) (TermMeta lang SymVar)
 ```
+
 Once again, morally speaking, forgetting the `lang` type parameters and
 replacing `TermMeta lang SymVar` by just `Term`, this function has type `Term ->
 SymEval Term`. One can then think of this as a function of type:
+
 ```haskell
 SymEvalEnv -> (Term, SymEvalSt) -> [(Term, SymEvalSt)]
 ```
+
 Such a function takes a term in the input language and a symbolic evaluation
 state. It tries to apply one step of beta-reduction to the term, which may yield
 zero, one or several potential terms and updated states.
@@ -192,18 +208,22 @@ zero, one or several potential terms and updated states.
 For an example, let us assume that our input term is the body of the `foldr`
 function in [the example language], specialised for lists of `Integer`s (for
 readability, we remove the type applications).
+
 ```haskell
 match_List l
   e
   (\(x : Integer) (xs : List Integer) . f x (foldr f e xs))
 ```
+
 and that our state specifies that:
+
 - `e` is an integer, without giving its value,
 - `f` is the function `\(x : Integer) (y : Integer) . x + y`, and
 - `l` is a list of integers, without giving its value.
 
 One step of the symbolic engine would then have to explore both branches of the
 pattern matching, and therefore it would return two pairs `Term, SymEvalSt`:
+
 1. In the first pair, the `Term` would be `e` itself and the state would be
    updated to account for the fact that we now know that `l = Nil`.
 2. In the second pair, the `Term` would be `f x (foldr f e xs)` and the state
@@ -222,3 +242,5 @@ with an integer. The second term/state is not blocked because one can replace
 [symbolic prover]: #symbolic-prover
 
 [`Pirouette.Symbolic.Prover`]
+
+[`Pirouette.Symbolic.Prover`]: ./src/Pirouette/Symbolic/Prover.hs

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -115,5 +115,22 @@ the [pirouette-plutusir library].
 Transformations
 ---------------
 
-Evaluation
-----------
+Symbolic Engine
+---------------
+
+The symbolic engine is split into three main parts: an SMT prover, as well as
+all the administrative work to communicate with it, Pirouette's _[symbolic
+evaluator]_, and Pirouette's _[symbolic prover]_. We describe these three
+aspects in the following sub-sections.
+
+### SMT prover
+
+[smt prover]: #smt-prover
+
+### Symbolic Evaluator
+
+[symbolic evaluator]: #symbolic-evaluator
+
+### Symbolic Prover
+
+[symbolic prover]: #symbolic-prover

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -127,6 +127,22 @@ aspects in the following sub-sections.
 
 [smt prover]: #smt-prover
 
+As is classic in symbolic engines, Pirouette relies on SMT provers to do the
+hard work. These provers are used in two different ways. They help pruning
+branches of execution that are actually unreachable, and they help deciding
+whether the user's statement/questions actually hold.
+
+Pirouette relies on [smtlib-backend] for the communication with its SMT prover
+of choice, [Z3]. There are still a bunch of modules in Pirouette making the
+interface between the rest of the engine and [smtlib-backends], mainly to
+convert assumptions/constraints to the [SMT-LIB] language. These modules live in
+[`Pirouette.SMT`].
+
+[z3]: https://github.com/Z3Prover/z3
+[smtlib-backends]: https://github.com/tweag/smtlib-backends
+[smt-lib]: https://smtlib.cs.uiowa.edu/
+[`Pirouette.SMT`]: ./src/Pirouette/SMT.hs
+
 ### Symbolic Evaluator
 
 [symbolic evaluator]: #symbolic-evaluator

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,14 +6,27 @@ Languages
 
 ### Pirouette's genericity
 
+Pirouette attempts to be generic in the input language by only assuming that it
+is System F-like. Anyone can then come and define their instance of
+`LanguageBuiltins`, which is Pirouette's way of defining the constants, builtin
+terms and builtin types of a language. The definition of the classes can be
+found in [`Pirouette.Term.Syntax.Base`]. For a simple, concrete instantiation of
+a language, you might want to check [the example language].
+
+[`Pirouette.Term.Syntax.Base`]: ./src/Pirouette/Term/Syntax/Base.hs
+
 ### The example language
+
+[the example language]: #the-example-language
 
 The example language is the only instance of a language included in Pirouette.
 It is a simple functional language supporting higher-order types with explicit
 type annotations, basic types (booleans, integers, strings) with their
 associated operators, algebraic datatypes and pattern-matching. The definition
 of the language is done by providing the `LanguageBuiltins` instance. You will
-find all the heavy work in `Language.Pirouette.Example`.
+find all the heavy work in [`Language.Pirouette.Example`].
+
+[`Language.Pirouette.Example`]: ./src/Language/Pirouette/Example.hs
 
 The example language also has a concrete syntax heavily inspired by Haskell.
 Thanks to quasi-quoters, it is easy to define a set of unordered value
@@ -70,7 +83,7 @@ myListTotal =
 ```
 
 For more examples, check out the standard library for the example language in
-`Language.Pirouette.Example.StdLib`. The standard library also comes with a
+[`Language.Pirouette.Example.StdLib`]. The standard library also comes with a
 quasi-quoter of its own allowing you to leverage it in your code should you want
 it:
 ```haskell
@@ -85,6 +98,8 @@ myProgram = [progWithStdLib|
       0
 |]
 ```
+
+[`Language.Pirouette.Example.StdLib`]: ./src/Language/Pirouette/Example/StdLib.hs
 
 ### Plutus Intermediate Representation
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,8 +15,6 @@ a language, you might want to check [the example language]. For a more involved
 one, you might want to check [the support for Plutus IR][plutus intermediate
 representation].
 
-[`Pirouette.Term.Syntax.Base`]: ./src/Pirouette/Term/Syntax/Base.hs
-
 ### The example language
 
 [the example language]: #the-example-language
@@ -27,8 +25,6 @@ type annotations, basic types (booleans, integers, strings) with their
 associated operators, algebraic datatypes and pattern-matching. The definition
 of the language is done by providing the `LanguageBuiltins` instance. You will
 find all the heavy work in [`Language.Pirouette.Example`].
-
-[`Language.Pirouette.Example`]: ./src/Language/Pirouette/Example.hs
 
 The example language also has a concrete syntax heavily inspired by Haskell.
 Thanks to quasi-quoters, it is easy to define a set of unordered value
@@ -109,8 +105,6 @@ myProgram = [progWithStdLib|
 |]
 ```
 
-[`Language.Pirouette.Example.StdLib`]: ./src/Language/Pirouette/Example/StdLib.hs
-
 ### Plutus Intermediate Representation
 
 [plutus intermediate representation]: #plutus-intermediate-representation
@@ -124,8 +118,6 @@ Transformations
 ---------------
 
 [`Pirouette.Transformations`]
-
-[`Pirouette.Transformations`]: ./src/Pirouette/Transformations.hs
 
 Symbolic Engine
 ---------------
@@ -151,7 +143,6 @@ convert assumptions/constraints to the [SMT-LIB] language. These modules live in
 [z3]: https://github.com/Z3Prover/z3
 [smtlib-backends]: https://github.com/tweag/smtlib-backends
 [smt-lib]: https://smtlib.cs.uiowa.edu/
-[`Pirouette.SMT`]: ./src/Pirouette/SMT.hs
 
 ### Symbolic Evaluator
 
@@ -162,8 +153,6 @@ convert assumptions/constraints to the [SMT-LIB] language. These modules live in
 The heart of Pirouette's symbolic engine lives in [`Pirouette.Symbolic.Eval`].
 This module defines the `SymEval` monad providing all the tooling to make
 symbolic evaluation work. Here is the monad in question:
-
-[`Pirouette.Symbolic.Eval`]: ./src/Pirouette/Symbolic/Eval.hs
 
 ```haskell
 newtype SymEval lang a = SymEval
@@ -263,8 +252,6 @@ contains the following:
 as well as some extra fields necessary for administrative reasons. Those field
 names are prefixed by `sest` in the code.
 
-[`Pirouette.Symbolic.Eval.Types`]: ./src/Pirouette/Symbolic/Eval/Types.hs
-
 #### The symbolic evaluation environment -- `SymEvalEnv`
 
 Defined in [`Pirouette.Symbolic.Eval`], the symbolic environment contains the
@@ -301,4 +288,11 @@ Those field names are prefixed by `see` in the code.
 
 [`Pirouette.Symbolic.Prover`]
 
+[`Language.Pirouette.Example`]: ./src/Language/Pirouette/Example.hs
+[`Language.Pirouette.Example.StdLib`]: ./src/Language/Pirouette/Example/StdLib.hs
+[`Pirouette.SMT`]: ./src/Pirouette/SMT.hs
+[`Pirouette.Symbolic.Eval`]: ./src/Pirouette/Symbolic/Eval.hs
+[`Pirouette.Symbolic.Eval.Types`]: ./src/Pirouette/Symbolic/Eval/Types.hs
 [`Pirouette.Symbolic.Prover`]: ./src/Pirouette/Symbolic/Prover.hs
+[`Pirouette.Term.Syntax.Base`]: ./src/Pirouette/Term/Syntax/Base.hs
+[`Pirouette.Transformations`]: ./src/Pirouette/Transformations.hs

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -46,7 +46,7 @@ Now for a more involved example. Say we want to compute a sum of integers in a
 generic way. We can do that by writing a function `sum` taking a list of
 integers and returning the total. In order to do that, we first need a notion of
 lists, which we choose to do in a generic way. Here we go:
-```
+```haskell
 data List a
   = Nil : List a
   | Cons : a -> List a -> List a
@@ -54,7 +54,7 @@ data List a
 
 Computing the sum of the elements of a list requires traversing it, which we can
 also decide to do in a generic way with a fold over the list.
-```
+```haskell
 foldr : forall a r . (a -> r -> r) -> r -> List a -> r
 foldr @a @r f e l =
   match_List @a l @r
@@ -68,7 +68,7 @@ returning type, and as many cases as there are constructors, in the same order.
 
 The hardest part has been done. It is now simple to define a list of integers --
 say `1`, `2`, `3` -- and sum over them.
-```
+```haskell
 myList : List Integer
 myList = Cons @Integer 1 (Cons @Integer 2 (Cons @Integer 3 (Nil @Integer)))
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,6 +86,13 @@ myProgram = [progWithStdLib|
 |]
 ```
 
+### Plutus Intermediate Representation
+
+To run Pirouette on Plutus Intermediate Representation scripts, one has to use
+the [pirouette-plutusir library].
+
+[pirouette-plutusir library]: https://github.com/tweag/pirouette-plutusir
+
 Transformations
 ---------------
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -265,6 +265,36 @@ names are prefixed by `sest` in the code.
 
 [`Pirouette.Symbolic.Eval.Types`]: ./src/Pirouette/Symbolic/Eval/Types.hs
 
+#### The symbolic evaluation environment -- `SymEvalEnv`
+
+Defined in [`Pirouette.Symbolic.Eval`], the symbolic environment contains the
+following:
+
+1. A set of unordered definitions in which to evaluate the term. For instance,
+   if your term is `foldr @Integer @Integer (\(x : Integer) (y : Integer) . x +
+   y) 0 l`, then `foldr` and `l` have to come from somewhere, and it will
+   probably be the example language's standard library augmented with the
+   definition of the list of integers `l`, and that would be the set of
+   definitions in the environment.
+
+2. Two “solvers” that are functions taking a problem and trying to solve it. The
+   one of interest to us in the symbolic evaluation is `solvePathProblem ::
+   CheckPathProblem lang -> Bool` which takes a “path problem” describing the
+   logical formulas that have to hold for this path to be reachable and answers
+   whether or not it is.
+
+3. Options influencing the behaviour of the symbolic execution. Those control
+   for instance the size of the pool of SMT solvers that Pirouette uses in the
+   background. More importantly, the options contain a function `shouldStop ::
+   StoppingCondition`, where `StoppingCondition` is a type alias for
+   `SymEvalStatistics -> Bool`. This function inspects the statistics in the
+   symbolic evaluation state and decides whether the symbolic evaluation should
+   stop. This is a generalisation of the usual notion of “fuel”. Two trivial
+   instances would be `\_ -> false` that never stops and `\stat ->
+   sestConstructors stat > 50` that stops after 50 constructors unfoldings.
+
+Those field names are prefixed by `see` in the code.
+
 ### Symbolic Prover
 
 [symbolic prover]: #symbolic-prover

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,7 +135,8 @@ the [pirouette-plutusir library].
 Transformations
 ---------------
 
-[`Pirouette.Transformations`]
+_This part is empty and should be documented._ Transformations live in
+[`Pirouette.Transformations`].
 
 Symbolic Engine
 ---------------

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -155,9 +155,13 @@ convert assumptions/constraints to the [SMT-LIB] language. These modules live in
 
 [symbolic evaluator]: #symbolic-evaluator
 
+#### The symbolic evaluation monad -- `SymEval`
+
 The heart of Pirouette's symbolic engine lives in [`Pirouette.Symbolic.Eval`].
 This module defines the `SymEval` monad providing all the tooling to make
 symbolic evaluation work. Here is the monad in question:
+
+[`Pirouette.Symbolic.Eval`]: ./src/Pirouette/Symbolic/Eval.hs
 
 ```haskell
 newtype SymEval lang a = SymEval
@@ -180,7 +184,7 @@ taking an environment and a state and returning a list of state, as well as
 potential return values. It returns a list because symbolic evaluation may
 branch and explore different paths.
 
-[`Pirouette.Symbolic.Eval`]: ./src/Pirouette/Symbolic/Eval.hs
+#### The key function -- `symEvalOneStep`
 
 The key function in this module is `symEvalOneStep`, whose type is the
 following:
@@ -236,6 +240,28 @@ again until it is not possible to reduce the terms anymore. In the example
 above, our first term/state is now blocked because there isn't much one can do
 with an integer. The second term/state is not blocked because one can replace
 `f` by its definition and continue unfolding from there.
+
+#### The symbolic evaluation state -- `SymEvalSt`
+
+Defined in [`Pirouette.Symbolic.Eval.Types`], the symbolic state basically
+contains the following:
+
+1. A context of variables, that is a map from variable names to their types.
+   This context is typically called Γ in literature, and `gamma` in the code.
+
+2. A set of constraints linking variables together, for instance `l == Cons x
+   xs`, `k != Nil` or `x = 7`. It is in fact not a set, but a complex
+   union-find-based type.
+
+3. Statistics on the execution, for instance the number of unfoldings that took
+   place. Despite the name, those statistics can have an important impact on the
+   behaviour of the engine because they are observed to decide whether to stop
+   the execution or not.
+
+as well as some extra fields necessary for administrative reasons. Those field
+names are prefixed by `sest` in the code.
+
+[`Pirouette.Symbolic.Eval.Types`]: ./src/Pirouette/Symbolic/Eval/Types.hs
 
 ### Symbolic Prover
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -87,7 +87,7 @@ that order, the datatype type arguments, an element of that datatype, the
 returning type, and as many cases as there are constructors, in the same order.
 
 The hardest part has been done. It is now simple to define a `sum` function, a
-list of integers -- say `1`, `2`, `3` -- and apply `sum` over them.
+list of integers – say `1`, `2`, `3` – and apply `sum` over them.
 
 ```haskell
 sum : List Integer -> Integer

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,8 +1,26 @@
 Pirouette's Design
 ==================
 
+This document aims at giving an overview of the crucial parts of Pirouette, and
+pointers to get familiar with the code. As such, it contains three parts.
+
+1. The [first part][languages] describe how Pirouette supports several input
+   languages as well as two languages that are particularly relevant to us: [the
+   example language] and the support for Plutus IR – [Plutus intermediate
+   representation].
+
+2. The [second part][transformations] describes the transformations that
+   Pirouette performs on the input language to get it in a shape ready for
+   symbolic execution.
+
+3. The [third part][symbolic engine] digs into what constitutes the heart of
+   Pirouette: its symbolic engine, and in particular the [symbolic evaluator]
+   and the [symbolic prover].
+
 Languages
 ---------
+
+[languages]: #languages
 
 ### Pirouette's genericity
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Say we have a function `t :: Ins -> Outs`, we can check that for all `i :: Ints`
 size, `P (t i) i` implies `Q (t i) i`, where `P` and `Q` are the user-defined predicates we
 interested in enforcing. We invite the interested reader to our [blog-post][tweag-blogpost] for more
 details on these reasoning techniques.
+The design of Pirouette is discussed in more details in [DESIGN.md](./DESIGN.md).
 
 [incorrectness]: https://dl.acm.org/doi/pdf/10.1145/3371078
 [tweag-blogpost]: https://www.tweag.io/blog/2022-07-01-pirouette-2/

--- a/src/Pirouette/Term/Syntax/Base.hs
+++ b/src/Pirouette/Term/Syntax/Base.hs
@@ -15,7 +15,7 @@
 
 -- | Provides the base syntactical elements for the languages supported by Pirouette.
 --  This module /does not/ expose the underlying System F implementation. In case
---  you're interested in manipulating terms at the Systm F level make sure
+--  you're interested in manipulating terms at the System F level make sure
 --  to bring in "Pirouette.Term.Syntax.SystemF", which is meant to be
 --  imported qualified.
 module Pirouette.Term.Syntax.Base where


### PR DESCRIPTION
This PR introduces a design document for Pirouette. The goal of this document is to provide what would be needed for someone to onboard on the project, that is a helping hand to get a high-level overview of what Pirouette does and how the code is organised, as well as pointers to the parts of the code that are interesting to read first to get acquainted with the code base. The document is far from being in its final form, but I suggest the following workflow from now onwards:

1. We review this document with two goals in mind: to improve the readability of what is already in there and to note what is missing. In particular, don't hesitate to ask me questions; if I find the answer easy, I can add that as part of this PR; otherwise, we can consider it as something missing.

2. For every missing thing that is not trivial to fix, and in particular for every missing thing that involves a non-negligible amount of text to add, we add an issue.

3. We merge this pull request. The goal is to have a maybe-incomplete-but-anyways-very-readable document.

4. We tackle the issues one by one in subsequent pull requests, adding all the missing content.

If the workflow sounds good to you, let's proceed. The PR is based on #183 which we should merge in a first step.